### PR TITLE
Update versioning in dependencies for clark-tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -230,9 +230,9 @@
       "integrity": "sha512-aTZTtKH9U2tqT+jhskpu0Ptx/2y+2/0/4GYhdET58hEiwgRlfVN/RhqfCnb10hrNKdXdydbkKgt1PfQeRAEfuQ=="
     },
     "@cyber4all/clark-tooltip": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@cyber4all/clark-tooltip/-/clark-tooltip-0.2.7.tgz",
-      "integrity": "sha512-geDSPULQczi1Ou37BInHEN2f9/frd1bGBQ8bf/lc2TAu+oLgGnshS7Hj/YK+/z/fSo+n2R4Jl52AURzrmBseFg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@cyber4all/clark-tooltip/-/clark-tooltip-0.4.0.tgz",
+      "integrity": "sha512-D/BCtWNc3xhbVweQwD8V+PrWwWBDrdsx8tuKHZdo9mqW2PyexVk7ON0N5rwxXMFOpaB8ixHmJl/0EAezgY4ijg=="
     },
     "@ngrx/core": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "1.0.0-beta.9.11",
+  "version": "1.0.0-beta.9.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cube",
   "displayName": "CyberCuBE: Curriculum Bank Enumeration",
-  "version": "1.0.0-beta.9.11",
+  "version": "1.0.0-beta.9.12",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "^5.0.0",
     "@cyber4all/clark-entity": "^2.1.0-beta.0.3",
     "@cyber4all/clark-taxonomy": "^2.0.1",
-    "@cyber4all/clark-tooltip": "^0.2.7",
+    "@cyber4all/clark-tooltip": "^0.4.0",
     "@ngrx/core": "^1.2.0",
     "@ngrx/store": "^4.1.1",
     "angular-particle": "^1.0.4",


### PR DESCRIPTION
No clue why this should be necessary with the '^' flag, but oh well. This will fix the tooltips in production