### PR TITLE
Add Autofocus Directive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cube",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cube",
   "displayName": "CyberCuBE: Curriculum Bank Enumeration",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/forgot-password/forgot-password.component.html
+++ b/src/app/auth/forgot-password/forgot-password.component.html
@@ -9,7 +9,7 @@
           Please enter the email address associated with your account and we'll send you instructions for resetting your password.
         </div>
         <div class="input email" [ngClass]="{'active': email !== ''}">
-          <input name="email" type="text" placeholder="Email address" [(ngModel)]="email" />
+          <input name="email" type="text" placeholder="Email address" [(ngModel)]="email" [autofocus]/>
           <i class="far fa-at"></i>
         </div>
         <button type="type" class="auth-button">

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -8,7 +8,7 @@
       </div>
       <form (ngSubmit)="submit()">
         <div class="input username" [ngClass]="{'active': authInfo.username !== ''}">
-          <input name="username" type="text" placeholder="Username" [(ngModel)]="authInfo.username" />
+          <input name="username" type="text" placeholder="Username" [(ngModel)]="authInfo.username" [autofocus]/>
           <i class="far fa-user"></i>
         </div>
         <div class="input password" [ngClass]="{'active': authInfo.password !== ''}">

--- a/src/app/auth/reset-password/reset-password.component.html
+++ b/src/app/auth/reset-password/reset-password.component.html
@@ -6,7 +6,7 @@
         <div class="auth-title light">Cybersecurity Labs and Resource Knowledge-base</div>
         <form *ngIf="!done" (ngSubmit)="submit()">
           <div class="input password" [ngClass]="{'active': password !== ''}">
-            <input name="password" type="password" placeholder="New password" [(ngModel)]="password" />
+            <input name="password" type="password" placeholder="New password" [(ngModel)]="password" [autofocus]/>
             <i class="far fa-key"></i>
           </div>
           <div class="input password" [ngClass]="{'active': password_conf !== ''}">

--- a/src/app/shared/directives/autofocus.directive.ts
+++ b/src/app/shared/directives/autofocus.directive.ts
@@ -5,17 +5,16 @@ import { Directive, ElementRef, Input } from '@angular/core';
  * This is needed because the autofocus attribute only works on page load, but Angular is a SPA.
  *
  * Usage: <input ... [autofocus] />
- * 
+ *
  * Additionally, the directive can be given a value (e.g. <input ... [autofocus]="MY_CONDITION" />)
  * so that the developer can have more control in the way focusing is coordinated.
- * 
+ *
  * @class AutofocusDirective
  */
 @Directive({
-    selector: "[autofocus]"
+    selector: '[autofocus]'
 })
-export class AutofocusDirective
-{
+export class AutofocusDirective {
     private focus = true;
 
     constructor(private el: ElementRef) { }
@@ -28,7 +27,8 @@ export class AutofocusDirective
         if (this.focus) {
             // Prevents expression has changed after it was checked error
             window.setTimeout(() => {
-                this.el.nativeElement.focus(); // For SSR (server side rendering) this is not safe. Use: https://github.com/angular/angular/issues/15008#issuecomment-285141070)
+                // For SSR (server side rendering) this is not safe. Use: https://github.com/angular/angular/issues/15008#issuecomment-285141070)
+                this.el.nativeElement.focus();
             });
         }
     }

--- a/src/app/shared/directives/autofocus.directive.ts
+++ b/src/app/shared/directives/autofocus.directive.ts
@@ -1,0 +1,35 @@
+import { Directive, ElementRef, Input } from '@angular/core';
+
+/**
+ * A directive to simulate the functionality of the autofocus attribute on inputs in Angular.
+ * This is needed because the autofocus attribute only works on page load, but Angular is a SPA.
+ *
+ * Usage: <input ... [autofocus] />
+ * 
+ * Additionally, the directive can be given a value (e.g. <input ... [autofocus]="MY_CONDITION" />)
+ * so that the developer can have more control in the way focusing is coordinated.
+ * 
+ * @class AutofocusDirective
+ */
+@Directive({
+    selector: "[autofocus]"
+})
+export class AutofocusDirective
+{
+    private focus = true;
+
+    constructor(private el: ElementRef) { }
+
+    @Input() set autofocus(condition: boolean) {
+        this.focus = condition !== false;
+    }
+
+    ngOnInit() {
+        if (this.focus) {
+            // Prevents expression has changed after it was checked error
+            window.setTimeout(() => {
+                this.el.nativeElement.focus(); // For SSR (server side rendering) this is not safe. Use: https://github.com/angular/angular/issues/15008#issuecomment-285141070)
+            });
+        }
+    }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -27,6 +27,7 @@ import { LearningObjectCardDirective } from './directives/learning-object-card.d
 import { FilterComponent } from './filter/filter.component';
 import { MappingsFilterComponent } from './mappings-filter/mappings-filter.component';
 import { SearchComponent } from './search/search.component';
+import { AutofocusDirective } from './directives/autofocus.directive';
 
 /**
  * Contains all stateless UI modules (directives, components, pipes) that are used across the app.
@@ -62,7 +63,8 @@ import { SearchComponent } from './search/search.component';
     LearningObjectCardDirective,
     FilterComponent,
     MappingsFilterComponent,
-    SearchComponent
+    SearchComponent,
+    AutofocusDirective
   ],
   exports: [
     BrowseByMappingsComponent,
@@ -77,7 +79,8 @@ import { SearchComponent } from './search/search.component';
     UserCardComponent,
     LearningObjectCardDirective,
     FilterComponent,
-    MappingsFilterComponent
+    MappingsFilterComponent,
+    AutofocusDirective
   ]
 })
 export class SharedModule {}


### PR DESCRIPTION
Adds a directive to simulate the functionality of the autofocus attribute on inputs in Angular. This is needed because the autofocus attribute only works on page load, but Angular is a SPA.
