### PR TITLE
Remove download button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.6.12",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.6.12",
+  "version": "1.7.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/learning-object/learning-object.component.html
+++ b/src/app/shared/learning-object/learning-object.component.html
@@ -5,7 +5,7 @@
   <div class="learning-object-content">
     <div class="title">
       {{ truncateText(learningObject.name, 45) }}
-      <button *ngIf="(auth.isLoggedIn | async) && canDownload" class="download-btn" (click)="download($event)"><i class="fas fa-download"></i></button>      
+      <button *ngIf="!loading && (auth.isLoggedIn | async) && canDownload" class="download-btn" (click)="download($event)"><i class="fas fa-download"></i></button>      
     </div>
     <div class="details">
       <div class="author">


### PR DESCRIPTION
Learning Object Components no longer show the download indicator while the object is still loading. This cleans up the placeholder animation and prevents non-responsive UI interactions.