### PR TITLE
Fix collection filter doesn't select from URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -38,6 +38,7 @@ export class BrowseComponent implements OnInit, OnDestroy {
     standardOutcomes: [],
     orderBy: undefined,
     sortType: undefined,
+    collection: ''
   };
 
   tooltipText = {

--- a/src/app/shared/interfaces/query.ts
+++ b/src/app/shared/interfaces/query.ts
@@ -20,6 +20,7 @@ export interface Query {
     | string[]
     | { id: string; name: string; date: string; outcome: string }[];
   released?: boolean;
+  collection?: string;
 }
 
 export interface MappingQuery extends Query {


### PR DESCRIPTION
The collection filter was not applied to learning objects when loading the app with the filter applied via query param in the URL.