### PR TITLE
Only show released to non-admins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -16,6 +16,7 @@ import {
  } from '../../onion/learning-object-builder/components/outcome-page/outcome/standard-outcomes/suggestion/services/suggestion.service';
  import { FilterSection } from '../../shared/filter/filter.component';
  import { COPY } from './browse.copy';
+import { AuthService, AUTH_GROUP } from '../../core/auth.service';
 
 
 @Component({
@@ -38,7 +39,8 @@ export class BrowseComponent implements OnInit, OnDestroy {
     standardOutcomes: [],
     orderBy: undefined,
     sortType: undefined,
-    collection: ''
+    collection: '',
+    released: this.auth.group.value !== AUTH_GROUP.ADMIN ? true : undefined
   };
 
   tooltipText = {
@@ -106,12 +108,17 @@ export class BrowseComponent implements OnInit, OnDestroy {
   }
 
   constructor(public learningObjectService: LearningObjectService, private route: ActivatedRoute,
-    private router: Router, private modalService: ModalService, public mappingService: SuggestionService) {
+    private router: Router, private modalService: ModalService, public mappingService: SuggestionService,
+    private auth: AuthService) {
       this.windowWidth = window.innerWidth;
       this.learningObjects = Array(20).fill(new LearningObject);
   }
 
   ngOnInit() {
+    this.auth.group.subscribe(group => {
+      this.query.released = group !== AUTH_GROUP.ADMIN ? true : undefined;
+      this.fetchLearningObjects(this.query);
+    });
     // used by the performSearch function (when delay is true) to add a debounce effect
     this.searchDelaySubject = new Subject<void>().debounceTime(650);
     this.searchDelaySubject.takeUntil(this.unsubscribe).subscribe(() => {

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Query } from '../../shared/interfaces/query';
 import { COPY } from './home.copy';
+import { AuthService, AUTH_GROUP } from '../../core/auth.service';
 
 
 @Component({
@@ -15,18 +16,28 @@ export class HomeComponent implements OnInit {
   query: Query = {
     text: '',
     currPage: 1,
-    limit: 30
+    limit: 0,
+    released: this.auth.group.value !== AUTH_GROUP.ADMIN ? true : undefined
   };
   placeholderText = 'Searching across ... learning objects';
 
-  constructor(public learningObjectService: LearningObjectService, private router: Router) { }
+  constructor(
+    public learningObjectService: LearningObjectService,
+    private router: Router,
+    private auth: AuthService) { }
 
   ngOnInit() {
-    this.learningObjectService.getLearningObjects({text: '', currPage: 1, limit: 0}).then((res) => {
+    this.auth.group.subscribe(group => {
+      this.query.released = group !== AUTH_GROUP.ADMIN ? true : undefined;
+      this.fetchLearningObjects(this.query);
+    });
+    this.fetchLearningObjects(this.query);
+  }
+  fetchLearningObjects(query: Query) {
+    this.learningObjectService.getLearningObjects(query).then((res) => {
       this.placeholderText = 'Searching across ' + res.total + ' learning objects';
     });
   }
-
   keyDownSearch(event) {
     if (event.keyCode === 13) {
       this.search();


### PR DESCRIPTION
The browse page has been updated to only show objects that have been released to users that are not on the whitelist. Since users now can only browse non-released objects, the counter in the searchbar has also been updated.