### PR TITLE
Fix no standard outcome sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/outcome.service.ts
+++ b/src/app/core/outcome.service.ts
@@ -28,11 +28,7 @@ export class OutcomeService {
   getSources(): Promise<string[]> {
     return this.http.get(environment.suggestionUrl + '/outcomes/sources', { headers: this.headers })
       .toPromise()
-      .then((res: any) => {
-        if (res.ok) {
-          return res;
-        }
-      });
+      .then((res: any) => res);
   }
 
   private formatFilter(filter) {


### PR DESCRIPTION
Since `HTTPClient` parses the response object, only the parsed body is passed into the promise chains. This means the response is just an array of sources, and all network info like the `ok` property is stripped off. 