### PR TITLE
Outcome search bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/outcome.service.ts
+++ b/src/app/core/outcome.service.ts
@@ -19,9 +19,7 @@ export class OutcomeService {
     return this.http.get(environment.suggestionUrl + '/outcomes?' + query, { headers: this.headers })
       .toPromise()
       .then((res: any) => {
-        if (res.ok) {
-          return res;
-        }
+        return res;
       });
   }
 

--- a/src/app/shared/browse-by-mappings/browse-by-mappings.component.ts
+++ b/src/app/shared/browse-by-mappings/browse-by-mappings.component.ts
@@ -12,6 +12,7 @@ import {
 import { OutcomeSuggestion } from '@cyber4all/clark-entity';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/debounceTime';
+import { fromEvent } from 'rxjs';
 import { OutcomeService } from '../../core/outcome.service';
 import {
   SuggestionService
@@ -97,6 +98,7 @@ export class BrowseByMappingsComponent implements OnInit, AfterViewChecked, OnCh
         // (EG inside the learning outcome component in object builder)
         this.bindFilterInput();
       } catch (error) {
+        console.log(error);
         // if this is true, we know to try again when a source is selected
         this.mappingsFilterInputError = true;
       }
@@ -104,8 +106,7 @@ export class BrowseByMappingsComponent implements OnInit, AfterViewChecked, OnCh
   }
 
   bindFilterInput() {
-    this.mappingsFilterInput = Observable
-      .fromEvent(this.mappingsSearchInput.nativeElement, 'input')
+    this.mappingsFilterInput = fromEvent(this.mappingsSearchInput.nativeElement, 'input')
       .map(x => x['currentTarget'].value).debounceTime(650);
 
       // listen for user to stop typing in the text input and perform query


### PR DESCRIPTION
This PR fixes two bugs

1. The switch to HTTPClient left a residual `res.ok` check that was preventing the outcome service from returning it's results
2. RxJS deprecated Observable.fromEvent a little while ago, yet the outcome-search component was still attempting to use it when capturing input from the search box.