### PR TITLE
Fix bug where the browse component would fire search query twice on init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -115,10 +115,6 @@ export class BrowseComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.auth.group.subscribe(group => {
-      this.query.released = group !== AUTH_GROUP.ADMIN ? true : undefined;
-      this.fetchLearningObjects(this.query);
-    });
     // used by the performSearch function (when delay is true) to add a debounce effect
     this.searchDelaySubject = new Subject<void>().debounceTime(650);
     this.searchDelaySubject.takeUntil(this.unsubscribe).subscribe(() => {
@@ -127,6 +123,7 @@ export class BrowseComponent implements OnInit, OnDestroy {
 
     // whenever the queryParams change, map them to the query object and perform the search
     this.route.queryParams.takeUntil(this.unsubscribe).subscribe(params => {
+      this.query.released = this.auth.group.getValue() !== AUTH_GROUP.ADMIN ? true : undefined;
       this.makeQuery(params);
       this.fetchLearningObjects(this.query);
     });


### PR DESCRIPTION
On load, the browse component currently subscribes to both the auth group BehaviorSubject and the ActivatedRoutes queryParams. Since both of these observables fire immediately (the BehaviorSubject always fires on subscription, and the queryParams fires immediately after the route resolves) this situation results in two queries for learning objects, one without the proper query parameters and one with. 

**This PR removes the subscription to auth.group since we can simply retrieve current value of the BehaviorSubject and use it in the queryParams subscription.**