### PR TITLE
Fix bug where entering a new search query while on the browse page doesn't route back to the first page before displaying results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -138,7 +138,7 @@ export class SearchComponent implements OnInit, AfterViewChecked, OnDestroy {
     if (text.length) {
       searchbar.blur();
       this.didBlur.emit();
-      this.router.navigate(['/browse'], { queryParams: { text }});
+      this.router.navigate(['/browse'], { queryParams: { text, currPage: 1 }});
     }
 
     this.close.emit();


### PR DESCRIPTION
When browsing results on a page number > 1, entering a search query that returns a result set of ```length < ceiling(results / 20)``` shows a no results screen and a result counter > 0.

**This PR forces the search component to navigate back to the first page every time a search is executed.**