### PR TITLE
Allow user's to edit learning objects while under review or waiting for review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/dashboard/dashboard-item/dashboard-item.component.html
+++ b/src/app/onion/dashboard/dashboard-item/dashboard-item.component.html
@@ -17,7 +17,7 @@
       <span *ngIf="learningObject.parents?.length" tip="{{ learningObject.parents.join(', ') }}" tipLocation="above" class="hierarchy-parents">{{ learningObject.parents.length }} parent{{ learningObject.parents.length !== 1 ? 's' : '' }}</span>
       <span *ngIf="learningObject.children?.length" tip="{{ objectChildrenNames(learningObject).join(', ') }}" tipLocation="above" class="hierarchy-children">{{ learningObject.children.length }} {{ learningObject.children.length !== 1 ? 'children' : 'child' }}</span>
     </div>
-    <div>{{ learningObject.length }}</div>
+    <div>{{ learningObject.length | titlecase }}</div>
     <div>{{ learningObject.date | date:'medium' }}</div>
     <div>
       <div *ngIf="!disabled && meatball" class="meatball" [ngClass]="{'open': meatballOpen}" (click)="this.toggleContextMenu($event)">

--- a/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
@@ -143,7 +143,7 @@ export class DashboardItemComponent implements OnChanges {
    */
   actionPermissions(action: string) {
     const permissions = {
-      edit: ['unpublished', 'published', 'denied'],
+      edit: ['unpublished', 'published', 'denied', 'waiting', 'review'],
       editChildren: ['unpublished', 'published', 'denied', this.learningObject.length !== 'nanomodule'],
       manageMaterials: ['unpublished', 'published', 'denied', this.verifiedEmail],
       submit: ['unpublished', 'denied', this.verifiedEmail],

--- a/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
@@ -144,8 +144,8 @@ export class DashboardItemComponent implements OnChanges {
   actionPermissions(action: string) {
     const permissions = {
       edit: ['unpublished', 'published', 'denied', 'waiting', 'review'],
-      editChildren: ['unpublished', 'published', 'denied', this.learningObject.length !== 'nanomodule'],
-      manageMaterials: ['unpublished', 'published', 'denied', this.verifiedEmail],
+      editChildren: ['unpublished', 'published', 'denied', 'waiting', 'review', this.learningObject.length !== 'nanomodule'],
+      manageMaterials: ['unpublished', 'published', 'denied', 'waiting', 'review', this.verifiedEmail],
       submit: ['unpublished', 'denied', this.verifiedEmail],
       view: ['published', this.verifiedEmail],
       delete: ['unpublished', 'denied'],

--- a/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/dashboard-item/dashboard-item.component.ts
@@ -147,7 +147,7 @@ export class DashboardItemComponent implements OnChanges {
       editChildren: ['unpublished', 'published', 'denied', 'waiting', 'review', this.learningObject.length !== 'nanomodule'],
       manageMaterials: ['unpublished', 'published', 'denied', 'waiting', 'review', this.verifiedEmail],
       submit: ['unpublished', 'denied', this.verifiedEmail],
-      view: ['published', this.verifiedEmail],
+      view: ['published'],
       delete: ['unpublished', 'denied'],
       cancelSubmission: ['waiting', this.verifiedEmail]
     };

--- a/src/app/onion/dashboard/dashboard.component.scss
+++ b/src/app/onion/dashboard/dashboard.component.scss
@@ -78,7 +78,6 @@ $light-blue-gradient: linear-gradient(45deg, darken($bright-blue, 10), lighten($
             & > div {
                 padding-top: 20px;
                 padding-bottom: 20px;
-                text-transform: capitalize;
             }
         }
 


### PR DESCRIPTION
This PR addresses the inability of a curator to control the status of a learning object, thus rendering it impossible for a contributor to make changes to an 'under review' learning object.

**This PR adds the 'edit' context menu item for all status. It also removes the title casing from the dashboard table and reimplements it for only the length field. Learning Object names should not be displayed in a manner other than as they were entered.**