### PR TITLE
Add Academic Levels to Details Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -6,6 +6,12 @@
         <div class="title">Description</div>
         <p [innerHtml]="learningObject.goals[0].text"></p>
       </div>
+
+      <section class="academic-levels">
+        <div class="title">Academic Levels</div>
+        <a class="level" *ngFor="let l of learningObject?.levels" routerLink="/browse" [queryParams]="{ 'level': l }">{{ l | titlecase}}</a>
+      </section>
+
       <cube-outcomes-detail-view [outcomes]="learningObject.outcomes"></cube-outcomes-detail-view>
       <cube-children-detail-view *ngIf="learningObject.children?.length > 0" [length]="learningObject.length" [children]="learningObject.children"></cube-children-detail-view>
       <div class="materials">

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -65,6 +65,38 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
         box-shadow: 1px 1px 10px 0 rgba(0, 0, 0, 0.05);
       }
 
+      .academic-levels {
+          display: flex;
+          flex-wrap: wrap;
+          flex-direction: row;
+          justify-content: flex-start;
+          align-items: center;
+          margin-bottom: 5px;
+          .title {
+            width: 100%;
+            color: black;
+            font-size: 22px;
+            padding-left: 10px;
+          }
+          .level {
+            text-transform: none;
+            cursor: pointer;
+            margin-right: 10px;
+            background: $blue-accent;
+            color: #fff;
+            box-shadow: none;
+            padding: 5px 10px;
+            border-radius: 2px;
+            border: 3px solid transparent;
+            margin-top: 10px;
+            user-select: none;
+            &:hover, &:focus {
+              text-decoration: none;
+              outline: none;
+            }
+          }
+      }
+
       .outcomes {
         background: desaturate(lighten($blue-accent, 55), 20);
       }


### PR DESCRIPTION
Adds academic levels to the details page, listed out in the same fashion that they appear in the builder. However, instead of being selectable, they act as links to the browse page with the level applied as a filter.

Resolves #445 