### PR TITLE
Remove Zero Counter from Folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.15.4",
+  "version": "1.15.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.html
@@ -12,7 +12,7 @@
       [contextMenuSubject]="folder">
       <div class="text-contained inline-flex">
         <i class="fas fa-folder icon"></i>
-        {{ folder.name }} {{ getItemCount(folder) }}
+        {{ folder.name }}
       </div>
       <div class="text-contained description">
         <span>{{ folder.description || 'No description here!' }}</span>

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.html
@@ -12,7 +12,7 @@
       [contextMenuSubject]="folder">
       <div class="text-contained inline-flex">
         <i class="fas fa-folder icon"></i>
-        {{ folder.name }} ({{ folder.files.length }} item{{ folder.files.length !== 1 ? 's' : '' }})
+        {{ folder.name }} {{ getItemCount(folder) }}
       </div>
       <div class="text-contained description">
         <span>{{ folder.description || 'No description here!' }}</span>

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
@@ -157,4 +157,10 @@ export class FileListViewComponent implements OnInit, OnDestroy {
       sub.unsubscribe();
     }
   }
+
+  getItemCount(folder) {
+    return folder.files.length === 0
+      ? ''
+      : `(${folder.files.length} item${folder.files.length !== 1 ? 's' : ''})`;
+  }
 }

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
@@ -157,10 +157,4 @@ export class FileListViewComponent implements OnInit, OnDestroy {
       sub.unsubscribe();
     }
   }
-
-  getItemCount(folder) {
-    return folder.files.length === 0
-      ? ''
-      : `(${folder.files.length} item${folder.files.length !== 1 ? 's' : ''})`;
-  }
 }


### PR DESCRIPTION
Folders that contain only other folders had previously read "0 Items" due to not directly containing a file. These folders now make no mention of the items contained inside.