### PR TITLE
Fix organization suggestions blocking next button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.15.7",
+  "version": "1.15.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.15.7",
+  "version": "1.15.9",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.15.6",
+  "version": "1.15.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/register/personal-info/personal-info.component.html
+++ b/src/app/auth/register/personal-info/personal-info.component.html
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="input organization">
-    <input #organization name="organization" id="organization" type="text" placeholder="Organization" aria-label="Organization" formControlName="organization"/>
+    <input #organization name="organization" id="organization" type="text" placeholder="Organization" aria-label="Organization" formControlName="organization" (blur)="closeOrganizationList()"/>
     <i class="far fa-building"></i>
   </div>
   <div id="container">

--- a/src/app/auth/register/personal-info/personal-info.component.ts
+++ b/src/app/auth/register/personal-info/personal-info.component.ts
@@ -103,6 +103,13 @@ export class PersonalInfoComponent implements AfterViewInit, OnDestroy {
     }
   }
 
+  /**
+   * Clears the organization results, which removes the list items from the DOM.
+   */
+  closeOrganizationList() {
+    this.organizationsList = [];
+  }
+
   private checkOrganization() {
     if (this.organizationsList.length > 0) {
       // Check if current query matches any org within the results


### PR DESCRIPTION
When a full list of organizations is returned, it covers the next button. If a user does not select an organization from the list, but instead types it out, they are unable to click the next button. This PR adds a function that clears the list when the user is no longer focused on the input.