### PR TITLE
Only show featured collections

### DIFF
--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -39,7 +39,7 @@ export class HomeComponent implements OnInit {
     });
     this.collectionService.getCollections()
       .then(collections => {
-        this.collections = collections.filter(c => c.abvName !== 'secinj' && c.abvName !== 'gencyber');
+        this.collections = collections.filter(c => c.abvName === 'nccp' || c.abvName === 'c5');
       })
       .catch(e => {
         console.error(e.message);


### PR DESCRIPTION
By having a filter to exclude specific collections from the home page, any new collections by default are featured. This logic has been inverted. 