### PR TITLE
Microsoft Word file preview hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.15.13",
+  "version": "1.15.14",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -10,6 +10,7 @@ import { RatingService } from '../../core/rating.service';
 import { ToasterService } from '../../shared/toaster/toaster.service';
 import { ModalService, ModalListElement } from '../../shared/modals';
 import { PUBLIC_LEARNING_OBJECT_ROUTES } from '@env/route';
+import { canViewInBrowser } from 'app/shared/filesystem/file-functions';
 
 // TODO move this to clark entity?
 export interface Rating {
@@ -98,7 +99,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
             username: this.learningObject.author.username,
             loId: this.learningObject.id,
             fileId: file.id,
-            open: true
+            open: canViewInBrowser(file)
           });
           return file;
         }

--- a/src/app/onion/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/content-upload/app/upload/upload.component.ts
@@ -29,7 +29,10 @@ import 'rxjs/add/operator/takeUntil';
 import 'rxjs/add/operator/filter';
 import { ModalService, ModalListElement } from '../../../../shared/modals';
 import { USER_ROUTES, PUBLIC_LEARNING_OBJECT_ROUTES } from '@env/route';
-import { getPaths } from '../../../../shared/filesystem/file-functions';
+import {
+  getPaths,
+  canViewInBrowser
+} from '../../../../shared/filesystem/file-functions';
 import { AuthService } from '../../../../core/auth.service';
 
 type LearningObjectFile = File;
@@ -268,7 +271,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           username: this.learningObject.author.username,
           loId: this.learningObject.id,
           fileId: file.id,
-          open: true
+          open: canViewInBrowser(file)
         });
         return file;
       })

--- a/src/app/shared/filesystem/file-functions.ts
+++ b/src/app/shared/filesystem/file-functions.ts
@@ -1,3 +1,5 @@
+import { LearningObjectFile } from './DirectoryTree';
+
 /**
  * Breaks Path string into array of paths. Removes last element assuming last element is file name.
  *

--- a/src/app/shared/filesystem/file-functions.ts
+++ b/src/app/shared/filesystem/file-functions.ts
@@ -35,3 +35,16 @@ export function getExtension(file: LearningObjectFile) {
   }
   return ext;
 }
+
+const viewableInBrowser = ['.pdf'];
+
+/**
+ * Checks if extension is in the viewableInBrowser array
+ *
+ * @export
+ * @param {string} extension
+ * @returns
+ */
+export function canViewInBrowser(file: LearningObjectFile) {
+  return viewableInBrowser.includes(getExtension(file));
+}

--- a/src/app/shared/filesystem/file-functions.ts
+++ b/src/app/shared/filesystem/file-functions.ts
@@ -19,3 +19,19 @@ export function getPaths(path: string, removeLast: boolean = true): string[] {
   }
   return paths;
 }
+
+/**
+ * Gets file extension
+ *
+ * @export
+ * @param {LearningObjectFile} file
+ * @returns
+ */
+export function getExtension(file: LearningObjectFile) {
+  let ext = file.extension;
+  if (!ext) {
+    const extMatch = file.name.match(/(\.[^.]*$|$)/);
+    ext = extMatch ? extMatch[0] : '';
+  }
+  return ext;
+}


### PR DESCRIPTION
Resolves issue with word files not being able to be opened in Microsoft file preview.

**Issue**
The client was passing `true` to the function to get a file's url (for all files) which appended the open flag to the route. When the open flag is present, the service will not append the file name to the response header which caused Microsoft's file preview to throw an error.

**Fix**
This issue was resolved by creating a function to return whether or not a file can be opened in the browser depending on its extension. This function is used in place of passing `true` to the function to get a file's url. Now the file's url will only have the openn flag appended if its extension is included in the `viewableInBrowser` array.