### PR TITLE
Implement user agent detection to identify Windows users and display a download warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.18.3",
+  "version": "1.18.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -21,7 +21,7 @@ import { CollectionService } from './collection.service';
 
 @NgModule({
   imports: [
-  CookieModule.forRoot(),
+    CookieModule.forRoot(),
     ModalModule.forRoot(),
     ToasterModule.forRoot(),
     ContextMenuModule.forRoot()

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -13,6 +13,7 @@ import { RatingService } from './rating.service';
 import { ToasterModule } from '../shared/toaster';
 import { ModalModule } from '../shared/modals';
 import { UserService } from './user.service';
+import { UserAgentService } from './user-agent.service';
 import { MessagesService } from './messages.service';
 import { RavenErrorHandler } from './error-handler';
 import { ContextMenuModule } from 'ngx-contextmenu';
@@ -20,7 +21,7 @@ import { CollectionService } from './collection.service';
 
 @NgModule({
   imports: [
-    CookieModule.forRoot(),
+  CookieModule.forRoot(),
     ModalModule.forRoot(),
     ToasterModule.forRoot(),
     ContextMenuModule.forRoot()
@@ -41,6 +42,7 @@ export class CoreModule {
         MessagesService,
         UserVerifiedGuard,
         RatingService,
+        UserAgentService,
         { provide: ErrorHandler, useClass: RavenErrorHandler }
       ]
     };

--- a/src/app/core/user-agent.service.ts
+++ b/src/app/core/user-agent.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserAgentService {
+
+  isWindows: boolean;
+
+  constructor() {
+    this.isWindows = (navigator.appVersion.indexOf('Win') != -1);
+  }
+}

--- a/src/app/cube/details/action-panel/action-panel.component.html
+++ b/src/app/cube/details/action-panel/action-panel.component.html
@@ -59,12 +59,6 @@
 
 <clark-popup *ngIf="showDownloadModal" (closed)="toggleDownloadModal(false)">
   <div style="max-width: 600px;" #popupInner>
-    <div class="modal-title">Notice about large files!</div>
-    <div class='modal-text'>
-      To keep download times short files over 100 megabytes are not included in the download package. You can find links to download them inside the 'ReadMe' PDF.
-    </div>
-    <div class="btn-group center">
-      <button class="button good" (click)="toggleDownloadModal(false)">Ok, got it!</button>
-    </div>
+    <clark-download-notice (close)="toggleDownloadModal(false)"></clark-download-notice>
   </div>
 </clark-popup>

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -12,6 +12,7 @@
   <div class="small-links">
     <a id="clark-about" href="http://about.clark.center" target="_blank">{{ copy.TEAM }}</a>
     <a id="clark-stats" href="https://datastudio.google.com/open/1jbVUWbqt4_L11PzrPZYNS5d4hbB5VojN" target="_blank">{{ copy.USAGE }}</a>
+    <a id="clark-troubleshoot" href="http://help.clark.center" target="_blank">Troubleshooting</a>
     <a href="mailto:skaza@towson.edu?subject=CLARK Help">{{ copy.HELP }}</a>
     <a id="clark-tutorial" href="http://about.clark.center/tutorial" target="_blank">{{ copy.TUTORIAL }}</a>
   </div>

--- a/src/app/shared/learning-object/learning-object.component.html
+++ b/src/app/shared/learning-object/learning-object.component.html
@@ -26,12 +26,6 @@
 
 <clark-popup *ngIf="showDownloadModal" (closed)="toggleDownloadModal(false)">
   <div style="max-width: 600px;" #popupInner>
-    <div class="modal-title">Notice about large files!</div>
-    <div class='modal-text'>
-      To keep download times short files over 100 megabytes are not included in the download package. You can find links to download them inside the 'ReadMe' PDF.
-    </div>
-    <div class="btn-group center">
-      <button class="button good" (click)="toggleDownloadModal(false)">Ok, got it!</button>
-    </div>
+    <clark-download-notice (close)="toggleDownloadModal(false)"></clark-download-notice>
   </div>
 </clark-popup>

--- a/src/app/shared/popups/popup.module.ts
+++ b/src/app/shared/popups/popup.module.ts
@@ -4,6 +4,7 @@ import { PopupComponent } from './popup.component';
 import { PopupViewerComponent } from './popup-viewer/popup-viewer.component';
 import { CollectionSelectorComponent } from './templates/collection-selector/collection-selector.component';
 import { FormsModule } from '@angular/forms';
+import { DownloadNoticeComponent } from './templates/download-notice/download-notice.component';
 
 @NgModule({
   imports: [
@@ -13,11 +14,13 @@ import { FormsModule } from '@angular/forms';
   declarations: [
     PopupComponent,
     PopupViewerComponent,
-    CollectionSelectorComponent
+    CollectionSelectorComponent,
+    DownloadNoticeComponent
   ],
   exports: [
     PopupComponent,
-    CollectionSelectorComponent
+    CollectionSelectorComponent,
+    DownloadNoticeComponent
   ],
   entryComponents: [
     PopupViewerComponent

--- a/src/app/shared/popups/templates/download-notice/download-notice.component.html
+++ b/src/app/shared/popups/templates/download-notice/download-notice.component.html
@@ -1,0 +1,12 @@
+<div class="download-notice-component">
+  <div class="modal-title">Information about this download!</div>
+  <div class='modal-text'>
+    To keep download times short files over 100 megabytes are not included in the download package. You can find links to download them inside the 'ReadMe' PDF.
+    <div *ngIf="UAService.isWindows" class="windows-warning">
+      Due to the internal workings of the Windows operating system, deeply nested learning objects might not be able to be unzipped. Learn how to solve that <a target="_blank" href="http://help.clark.center/#i-downloaded-a-learning-object-on-windows-and-i-cant-open-it">here</a>.
+    </div>
+  </div>
+  <div class="btn-group center">
+    <button class="button good" (click)="close.emit()">Ok, got it!</button>
+  </div>
+</div>

--- a/src/app/shared/popups/templates/download-notice/download-notice.component.scss
+++ b/src/app/shared/popups/templates/download-notice/download-notice.component.scss
@@ -1,0 +1,19 @@
+@import '~_vars.scss';
+
+.windows-warning {
+  margin-top: 25px;
+  padding-top: 20px;
+  position: relative;
+
+  &:after {
+    position: absolute;
+    content: '';
+    height: 1px;
+    width: 40%;
+    left: 0;
+    right: 0;
+    top: 0;
+    margin: auto;
+    background: lighten($placeholder, 10);
+  }
+}

--- a/src/app/shared/popups/templates/download-notice/download-notice.component.spec.ts
+++ b/src/app/shared/popups/templates/download-notice/download-notice.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DownloadNoticeComponent } from './download-notice.component';
+
+describe('DownloadNoticeComponent', () => {
+  let component: DownloadNoticeComponent;
+  let fixture: ComponentFixture<DownloadNoticeComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DownloadNoticeComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DownloadNoticeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/popups/templates/download-notice/download-notice.component.ts
+++ b/src/app/shared/popups/templates/download-notice/download-notice.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { UserAgentService } from 'app/core/user-agent.service';
+
+@Component({
+  selector: 'clark-download-notice',
+  templateUrl: './download-notice.component.html',
+  styleUrls: ['./download-notice.component.scss']
+})
+export class DownloadNoticeComponent implements OnInit {
+
+  @Output() close: EventEmitter<void> = new EventEmitter();
+
+  constructor(public UAService: UserAgentService) { }
+
+  ngOnInit() {
+  }
+
+}


### PR DESCRIPTION
This PR attempts to address the issue wherein Windows users can't unzip deeply nested learning objects after downloading them. This is due to Windows including a restriction on the maximum length of a file path. 

**This PR introduces an addition to the download modal; Windows users will see an additional warning and receive a link to the troubleshooting page for a solution. Also, this PR adds a link to the troubleshooting page to the CLARK footer.**