### PR TITLE
Fix review pending banner not showing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.18.6",
+  "version": "1.18.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/action-panel/action-panel.component.html
+++ b/src/app/cube/details/action-panel/action-panel.component.html
@@ -3,15 +3,15 @@
     tipLocation="top">
     <i class="fas fa-exclamation"></i>Review Pending
   </div>
-  <div class="btn-group vertical" [ngClass]="{'no-download': !isReleased}">
-    <button tip="{{ tips.DOWNLOAD_NOW }}" tipLocation="top" tipDisabled="{{isReleased || !loggedin}}" [ngClass]="{'disabled': !auth.user || !canDownload || downloading}"
+  <div class="btn-group vertical" [ngClass]="{'review-pending': !isReleased}">
+    <button tip="{{ tips.DOWNLOAD_NOW }}" tipLocation="top" tipDisabled="{{hasDownloadAccess || !loggedin}}" [ngClass]="{'disabled': !auth.user || !hasDownloadAccess || downloading}"
       class="button good" id="download-button" (click)="addToCart(true)">
-      <span *ngIf="isReleased">{{!downloading ? 'Download Now' : 'Downloading'}}
+      <span *ngIf="hasDownloadAccess">{{!downloading ? 'Download Now' : 'Downloading'}}
         <span *ngIf="downloading">
           <i class="fal fa-spinner-third fa-spin"></i>
         </span>
       </span>
-      <span *ngIf="!isReleased">Not available for download</span>
+      <span *ngIf="!hasDownloadAccess">Not available for download</span>
     </button>
     <button *ngIf="!userIsAuthor" [ngClass]="{'disabled': !auth.user, 'saved': saved}" class="button neutral on-white" id="save-to-library" (click)="addToCart()">
       {{ saved ? 'Saved to your library!' : 'Save to Library' }}

--- a/src/app/cube/details/action-panel/action-panel.component.scss
+++ b/src/app/cube/details/action-panel/action-panel.component.scss
@@ -26,7 +26,7 @@
     }
   }
 
-  .btn-group.no-download {
+  .btn-group.review-pending {
     margin-top: 40px;
   }
 

--- a/src/app/cube/details/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/action-panel/action-panel.component.ts
@@ -1,14 +1,10 @@
-import { CartV2Service, iframeParentID } from '../../../core/cartv2.service';
+import { Component, ElementRef, HostListener, Input, OnDestroy, OnInit, Renderer2, ViewChild } from '@angular/core';
 import { LearningObject, User } from '@cyber4all/clark-entity';
-import { Component, OnInit, OnDestroy, ViewChild, ElementRef, Renderer2, HostListener, Input } from '@angular/core';
-import { AuthService, DOWNLOAD_STATUS } from '../../../core/auth.service';
-import { environment } from '@env/environment';
 import { TOOLTIP_TEXT } from '@env/tooltip-text';
-import { RatingService } from '../../../core/rating.service';
-import { ModalService, ModalListElement } from '../../../shared/modals';
 import { Subject } from 'rxjs/Subject';
+import { AuthService } from '../../../core/auth.service';
+import { CartV2Service, iframeParentID } from '../../../core/cartv2.service';
 import { ToasterService } from '../../../shared/toaster/toaster.service';
-import { Restriction } from '@cyber4all/clark-entity/dist/learning-object';
 
 // TODO move this to clark entity?
 export interface Rating {
@@ -32,7 +28,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   @ViewChild('savesRef') savesRef: ElementRef;
 
   private isDestroyed$ = new Subject<void>();
-  downloadStatus: DOWNLOAD_STATUS = 0;
+  hasDownloadAccess = false;
   downloading = false;
   addingToLibrary = false;
   author: string;
@@ -73,12 +69,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.auth.isLoggedIn.subscribe(val => {
-      this.loggedin = val;
-      this.auth.userCanDownload(this.learningObject).then(isAuthorized => {
-        this.downloadStatus = isAuthorized;
-      });
-    });
+    this.hasDownloadAccess = this.auth.hasPrivelagedAccess() || this.isReleased;
 
     this.url = this.buildLocation();
     this.saved = this.cartService.has(this.learningObject);
@@ -86,12 +77,8 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     this.userIsAuthor = (this.learningObject.author.username === userName);
   }
 
-  get canDownload(): boolean {
-    return this.downloadStatus === DOWNLOAD_STATUS.CAN_DOWNLOAD;
-  }
-
   get isReleased(): boolean {
-    return this.downloadStatus !== DOWNLOAD_STATUS.NOT_RELEASED;
+    return this.learningObject['status'] === 'released';
   }
 
 

--- a/src/app/cube/details/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/action-panel/action-panel.component.ts
@@ -78,6 +78,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   }
 
   get isReleased(): boolean {
+    // FIXME status should be accessed as learningObject.status and should be compared to the enum in clark-entity
     return this.learningObject['status'] === 'released';
   }
 


### PR DESCRIPTION
Due to a recent change in the authorization logic, the review pending banner no longer shows for Learning Objects that are not released. This is due to the fact that the `isReleased` variable was being set based on the user's privilege level and not the Learning Object's status.

This PR updates the component logic related to download access and release status.