### PR TITLE
Replace C.L.A.R.K. with CLARK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/home.copy.ts
+++ b/src/app/cube/home/home.copy.ts
@@ -1,7 +1,7 @@
 export const COPY = {
     HERO: `Effective cybersecurity curriculum at your fingertips`,
     SEARCH_PLACEHOLDER: 'Search Learning Objects by author, title, or keywords',
-    WHATISTITLE: `What is C.L.A.R.K.?`,
+    WHATISTITLE: `What is CLARK?`,
     WHATIS: `CLARK is a digital library that hosts a diverse collection of cybersecurity learning objects.
     It was created because there is a demonstrated need for a high-quality and high-availability repository for
     curricular and ancillary resources in the cybersecurity education community.`,


### PR DESCRIPTION
Text on the home page has been updated to use the non-acronym name of CLARK, which is in line with the updated branding guidelines.

Resolves #539