### PR TITLE
Fix bug where creating a new outcome doesn't auto selected 'Remember and Understand'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "1.21.6",
+  "version": "1.21.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
This PR closes #556 by manually setting the Learning Outcome's bloom level to 'Remember and Understand' on creation. It also removes calls to private properties by appropriately typing the outcome parameter.