### PR TITLE
Change disclaimer location on NCCP learning object pages

### DIFF
--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -17,6 +17,18 @@
       <div class="materials">
         <onion-file-details [length]="learningObject.length" [materials]="learningObject.materials"></onion-file-details>
       </div>
+      <div *ngIf="learningObject.collection === 'nccp'" class="disclaimer">
+        <div class="title">Notice Regarding NSA NCCP Course Materials</div>
+        <p>These course materials were created under a U.S. Government grant. The terms of the Call for Proposals advised the course
+          creator that the materials would be made "publicly available for educational institutions" to educate and prepare their
+          graduates for potential future employment with the U.S. Government in the cybersecurity field. The terms of the grant
+          further provided that, with respect to any copyright in the materials, the U.S. Government reserved a royalty-free, nonexclusive
+          and irrevocable license to reproduce, publish, or otherwise use the work for Federal purposes, and to authorize others
+          to do so. Strengthening the Nation's cybersecurity, particularly through cybersecurity education at all levels of education
+          to foster the knowledge and skills of individuals who may ultimately join the U.S. Government, is an important Federal
+          purpose. Consistent with the Call for Proposals and the terms of the grant, in making these materials publicly available
+          the U.S. Government authorizes others to reproduce, publish and use them in furtherance of this Federal purpose.</p>
+      </div>
       <div #ratingsWrapper class="ratings">
         <button *ngIf="!isMobile && loggedin && !isOwnObject" tip="You must verify your email in order to review learning objects." tipDisabled="{{ auth.user.emailVerified }}"
           class="button good" (click)="showAddRating = auth.user.emailVerified">{{ userRating.date ? 'Edit your' :

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -17,7 +17,7 @@
       <div class="materials">
         <onion-file-details [length]="learningObject.length" [materials]="learningObject.materials"></onion-file-details>
       </div>
-      <div class="disclaimer">
+      <div *ngIf="learningObject.collection === 'nccp'" class="disclaimer">
         <div class="title">Notice Regarding NSA NCCP Course Materials</div>
         <p>These course materials were created under a U.S. Government grant. The terms of the Call for Proposals advised the course
           creator that the materials would be made "publicly available for educational institutions" to educate and prepare their

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -17,6 +17,18 @@
       <div class="materials">
         <onion-file-details [length]="learningObject.length" [materials]="learningObject.materials"></onion-file-details>
       </div>
+      <div class="disclaimer">
+        <div class="title">Notice Regarding NSA NCCP Course Materials</div>
+        <p>These course materials were created under a U.S. Government grant. The terms of the Call for Proposals advised the course
+          creator that the materials would be made "publicly available for educational institutions" to educate and prepare their
+          graduates for potential future employment with the U.S. Government in the cybersecurity field. The terms of the grant
+          further provided that, with respect to any copyright in the materials, the U.S. Government reserved a royalty-free, nonexclusive
+          and irrevocable license to reproduce, publish, or otherwise use the work for Federal purposes, and to authorize others
+          to do so. Strengthening the Nation's cybersecurity, particularly through cybersecurity education at all levels of education
+          to foster the knowledge and skills of individuals who may ultimately join the U.S. Government, is an important Federal
+          purpose. Consistent with the Call for Proposals and the terms of the grant, in making these materials publicly available
+          the U.S. Government authorizes others to reproduce, publish and use them in furtherance of this Federal purpose.</p>
+      </div>
       <div #ratingsWrapper class="ratings">
         <button *ngIf="!isMobile && loggedin && !isOwnObject" tip="You must verify your email in order to review learning objects." tipDisabled="{{ auth.user.emailVerified }}"
           class="button good" (click)="showAddRating = auth.user.emailVerified">{{ userRating.date ? 'Edit your' :

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -17,18 +17,6 @@
       <div class="materials">
         <onion-file-details [length]="learningObject.length" [materials]="learningObject.materials"></onion-file-details>
       </div>
-      <div *ngIf="learningObject.collection === 'nccp'" class="disclaimer">
-        <div class="title">Notice Regarding NSA NCCP Course Materials</div>
-        <p>These course materials were created under a U.S. Government grant. The terms of the Call for Proposals advised the course
-          creator that the materials would be made "publicly available for educational institutions" to educate and prepare their
-          graduates for potential future employment with the U.S. Government in the cybersecurity field. The terms of the grant
-          further provided that, with respect to any copyright in the materials, the U.S. Government reserved a royalty-free, nonexclusive
-          and irrevocable license to reproduce, publish, or otherwise use the work for Federal purposes, and to authorize others
-          to do so. Strengthening the Nation's cybersecurity, particularly through cybersecurity education at all levels of education
-          to foster the knowledge and skills of individuals who may ultimately join the U.S. Government, is an important Federal
-          purpose. Consistent with the Call for Proposals and the terms of the grant, in making these materials publicly available
-          the U.S. Government authorizes others to reproduce, publish and use them in furtherance of this Federal purpose.</p>
-      </div>
       <div #ratingsWrapper class="ratings">
         <button *ngIf="!isMobile && loggedin && !isOwnObject" tip="You must verify your email in order to review learning objects." tipDisabled="{{ auth.user.emailVerified }}"
           class="button good" (click)="showAddRating = auth.user.emailVerified">{{ userRating.date ? 'Edit your' :

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -97,13 +97,27 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
           }
       }
 
-      .outcomes {
-        background: desaturate(lighten($blue-accent, 55), 20);
-      }
-
       .disclaimer {
         background: #fff;
         box-shadow: 1px 1px 10px 0 rgba(0, 0, 0, 0.05);
+        padding: 20px;  
+        margin-bottom: 40px;
+
+        .title {
+          width: 100%;
+          color: black;
+          font-size: 22px;
+          padding-left: 10px;
+        }
+
+        p {
+          padding-left: 10px;
+          padding-top: 8px;
+        }
+      }
+
+      .outcomes {
+        background: desaturate(lighten($blue-accent, 55), 20);
       }
 
       .ratings {

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -96,6 +96,24 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
             }
           }
       }
+      .disclaimer {
+        background: #fff;
+        box-shadow: 1px 1px 10px 0 rgba(0, 0, 0, 0.05);
+        padding: 20px;  
+        margin-bottom: 40px;
+
+        .title {
+          width: 100%;
+          color: black;
+          font-size: 22px;
+          padding-left: 10px;
+        }
+
+        p {
+          padding-left: 10px;
+          padding-top: 8px;
+        }
+      }
 
       .outcomes {
         background: desaturate(lighten($blue-accent, 55), 20);

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -101,6 +101,11 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
         background: desaturate(lighten($blue-accent, 55), 20);
       }
 
+      .disclaimer {
+        background: #fff;
+        box-shadow: 1px 1px 10px 0 rgba(0, 0, 0, 0.05);
+      }
+
       .ratings {
         background: white;
         border-radius: 3px;

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -97,25 +97,6 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
           }
       }
 
-      .disclaimer {
-        background: #fff;
-        box-shadow: 1px 1px 10px 0 rgba(0, 0, 0, 0.05);
-        padding: 20px;  
-        margin-bottom: 40px;
-
-        .title {
-          width: 100%;
-          color: black;
-          font-size: 22px;
-          padding-left: 10px;
-        }
-
-        p {
-          padding-left: 10px;
-          padding-top: 8px;
-        }
-      }
-
       .outcomes {
         background: desaturate(lighten($blue-accent, 55), 20);
       }

--- a/src/app/cube/shared/footer/footer.copy.ts
+++ b/src/app/cube/shared/footer/footer.copy.ts
@@ -1,14 +1,4 @@
 export const COPY = {
-    NOTICETITLE: 'Notice Regarding NSA NCCP Course Materials',
-    NOTICE: `These course materials were created under a U.S. Government grant. The terms of the Call for Proposals advised the course
-    creator that the materials would be made "publicly available for educational institutions" to educate and prepare their
-    graduates for potential future employment with the U.S. Government in the cybersecurity field. The terms of the grant
-    further provided that, with respect to any copyright in the materials, the U.S. Government reserved a royalty-free, nonexclusive
-    and irrevocable license to reproduce, publish, or otherwise use the work for Federal purposes, and to authorize others
-    to do so. Strengthening the Nation's cybersecurity, particularly through cybersecurity education at all levels of education
-    to foster the knowledge and skills of individuals who may ultimately join the U.S. Government, is an important Federal
-    purpose. Consistent with the Call for Proposals and the terms of the grant, in making these materials publicly available
-    the U.S. Government authorizes others to reproduce, publish and use them in furtherance of this Federal purpose.`,
     SUPPORTEDBY: 'The CLARK System at Towson University is supported by the National Security Agency under NSA Grant H9830-17-1-0405',
     TEAM: 'Meet the Team',
     USAGE: 'Usage Statistics',


### PR DESCRIPTION
Move disclaimer location to NCCP learning object pages and out of footer. Located between materials and ratings on those pages. 
Contributes to #563 