### PR TITLE
Fix bug where DirectoryTree attempts to delete from a null node

### DIFF
--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -238,7 +238,7 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   private removeEmptyFolders(node: DirectoryNode): void {
-    if (!node.getChildren().length && !node.getFiles().length) {
+    if (!node && !node.getChildren().length && !node.getFiles().length) {
       const parent = node.getParent();
       this.removeFolder(node.getPath());
       this.removeEmptyFolders(parent);

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -238,13 +238,26 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   private removeEmptyFolders(node: DirectoryNode): void {
-    if (!node && !node.getChildren().length && !node.getFiles().length) {
+    if (!this.isRoot(node) && !node.getChildren().length && !node.getFiles().length) {
       const parent = node.getParent();
       this.removeFolder(node.getPath());
       this.removeEmptyFolders(parent);
     }
   }
+
+  /**
+   * Checks whether or not a node is the root by comparing the node's path to the root path
+   *
+   * @private
+   * @param {DirectoryNode} node [Node to check in directory tree]
+   * @returns {boolean}
+   * @memberof DirectoryTree
+   */
+  private isRoot(node: DirectoryNode): boolean {
+    return node.getPath() === this._root.getPath();
+  }
 }
+
 /**
  * Class representing simple Node in DirectoryTree
  *


### PR DESCRIPTION
This PR addresses a bug wherein after deleting the contents of the root directory, the DirectoryTree attempts to delete the root directory (since it's empty) and throws a javascript error, preventing further interaction with the FileBrowser.