### PR TITLE
Sort verbs in dropdown for learning outcomes

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -338,7 +338,8 @@ export class BuilderStore {
 
     if (params.bloom && params.bloom !== outcome.bloom) {
       outcome.bloom = params.bloom;
-      outcome.verb = taxonomy.taxons[params.bloom].verbs[0];
+      // FIXME we shouldn't be sorting these verbs client side
+      outcome.verb = taxonomy.taxons[params.bloom].verbs.sort()[0];
     } else if (params.verb) {
       outcome.verb = params.verb;
     } else if (typeof params.text === 'string') {

--- a/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
+++ b/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
@@ -2,9 +2,6 @@ import { Component, OnInit, OnDestroy, ElementRef, ViewChild, HostListener, Outp
 import { Subject } from 'rxjs';
 import { map, takeUntil } from 'rxjs/operators';
 import { taxonomy, levels } from '@cyber4all/clark-taxonomy';
-import 'rxjs/add/operator/takeUntil';
-import { LearningOutcome } from '@cyber4all/clark-entity';
-import { text } from '@angular/core/src/render3/instructions';
 
 @Component({
   selector: 'clark-outcome-typeahead',
@@ -149,7 +146,8 @@ export class OutcomeTypeaheadComponent implements OnInit, OnChanges, OnDestroy {
    * Return list of verbs in selected category
    */
   get verbsInSelectedCategory(): string[] {
-    return taxonomy.taxons[this.bloom].verbs;
+    // FIXME we shouldn't be sorting these verbs client side
+    return (taxonomy.taxons[this.bloom].verbs as string[]).sort();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This PR implements verb sorting in the builder. Ideally, the verbs would not be sorted client side and this PR should be reverted when a more permanent solution is found.