### PR TITLE
:bug: Fix folder structure displaying incorrectly

### DIFF
--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -424,6 +424,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   queueComplete() {
     this.uploadErrors = {};
+    this.uploadComplete.emit();
   }
 
   /**
@@ -431,9 +432,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    *
    * @memberof UploadComponent
    */
-  uploadSuccess() {
-    this.uploadComplete.emit();
-  }
+  uploadSuccess() {}
 
   /**
    * Checks if file as fullPath or webkitRelativePath property and sets the fullPath prop;

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -140,7 +140,7 @@ export class DirectoryTree {
 
     const parentPath = parent.getPath();
     const childPath = `${parentPath}/${currentPath}`;
-    const index = this.pathMap.get(childPath) || 0;
+    const index = this.pathMap.get(childPath) || -1;
     const children = parent.getChildren();
     const node = children[index] || this.findNodeAtLevel(currentPath, children);
     if (node) {

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -140,7 +140,8 @@ export class DirectoryTree {
 
     const parentPath = parent.getPath();
     const childPath = `${parentPath}/${currentPath}`;
-    const index = this.pathMap.get(childPath) || -1;
+    const cachedIndex = this.pathMap.get(childPath);
+    const index = cachedIndex !== undefined ? cachedIndex : -1;
     const children = parent.getChildren();
     const node = children[index] || this.findNodeAtLevel(currentPath, children);
     if (node) {

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
@@ -143,7 +143,6 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   openFile(file: LearningObject.Material.File): void {
     const url = this.previewUrl(file.extension);
     if (url) {
-      console.log(url + file.url);
       window.open(url + file.url, '_blank');
       this.preview = true;
     } else {


### PR DESCRIPTION
**Issue**
When a folder was uploaded with subfolders, the subfolders' files would be shown as if they were inside of the parent's folder. This was caused by an issue in the filesystem's caching logic.

**Solution**
Set cached folder index to `-1` instead of `0` if the value returned from the `pathMap` is `undefined`.