### PR TITLE
Force page reload on logout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -146,6 +146,7 @@ export class AuthService {
     this.user = undefined;
     this.changeStatus(false);
     this.group.next(AUTH_GROUP.VISITOR);
+    window.location.reload();
   }
 
   async register(user: any): Promise<User> {

--- a/src/app/shared/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar.component.ts
@@ -157,7 +157,9 @@ export class NavbarComponent implements OnInit, AfterContentChecked, OnDestroy {
   }
 
   logout() {
-    this.authService.logout();
+    this.authService.logout().then(() => {
+      window.location.reload();
+    });
   }
 
   /**

--- a/src/app/shared/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar.component.ts
@@ -157,9 +157,7 @@ export class NavbarComponent implements OnInit, AfterContentChecked, OnDestroy {
   }
 
   logout() {
-    this.authService.logout().then(() => {
-      window.location.reload();
-    });
+    this.authService.logout();
   }
 
   /**


### PR DESCRIPTION
This PR implements a page reload on user logout. This helps to ensure that all user data from the previously logged-in user is scrubbed from the system and that relevant security properties such as access groups don't linger.