### PR TITLE
Fix Status Error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/messages.service.ts
+++ b/src/app/core/messages.service.ts
@@ -4,23 +4,38 @@ import { MISC_ROUTES } from '@env/route';
 
 @Injectable()
 export class MessagesService {
-    private _message: Array<{}>;
-    
+    private _message: Message;
+
     get message() {
         return this._message;
     }
 
     constructor(private http: HttpClient) { }
 
-    getStatus(): Promise<Array<{}>> {
+    getStatus(): Promise<Message> {
         if (this._message) {
             return Promise.resolve(this._message);
         } else {
-            return this.http.get(MISC_ROUTES.CHECK_STATUS, { withCredentials: true }).toPromise().then((val: any) => {
-                this._message = val && val.length ? val : undefined;
-                return this._message;
-            });
+            return this.http.get(MISC_ROUTES.CHECK_STATUS, { withCredentials: true })
+                .toPromise()
+                .then((val: any) => {
+                    if (val && val.length) {
+                        this._message = new Message(val[0]['_id'], 'error', val[0]['maintenanceMessage']);
+                        return this._message;
+                    } else { throw new Error('System status returned a malformed message.'); }
+                });
         }
     }
 }
 
+export class Message {
+    id: string;
+    type: string;
+    message: string;
+
+    constructor(id: string, type: string, message: string) {
+        this.id = id;
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/src/app/shared/navbar/message/message.component.ts
+++ b/src/app/shared/navbar/message/message.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { MessagesService } from '../../../core/messages.service';
+import { MessagesService, Message } from '../../../core/messages.service';
 
 @Component({
   selector: 'clark-message',
@@ -8,24 +8,24 @@ import { MessagesService } from '../../../core/messages.service';
 })
 export class MessageComponent implements OnInit {
 
-  showing: boolean = false;
+  showing = false;
   message: Message;
 
   constructor(private messages: MessagesService) { }
 
   ngOnInit() {
-    this.messages.getStatus().then(val => {
-      if (val.length) {
-        // message is set!
-        this.message = new Message(val[0]['_id'], 'error', val[0]['maintenanceMessage']);
-
+    this.messages.getStatus()
+      .then(message => {
+        this.message = message;
         const lastMessage = localStorage.getItem('maintenance');
 
         if (!lastMessage || this.message.id !== lastMessage) {
           this.open();
         }
-      }
-    });
+      })
+      .catch(e => {
+        // FIXME: Suppress the error until we design a better backend solution
+      });
   }
 
   open() {
@@ -39,18 +39,5 @@ export class MessageComponent implements OnInit {
 
   toggle() {
     this.showing = !this.showing;
-  }
-
-}
-
-export class Message {
-  id: string;
-  type: string;
-  message: string;
-
-  constructor(id, type, message) {
-    this.id = id;
-    this.type = type;
-    this.message = message;
   }
 }

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -40,12 +40,12 @@ export const USER_ROUTES = {
   SUBMIT_LEARNING_OBJECT(learningObjectId: string) {
     return `${
       environment.apiURL
-    }/learning-objects/${learningObjectId}/submission`
+    }/learning-objects/${learningObjectId}/submission`;
   },
   UNSUBMIT_LEARNING_OBJECT(learningObjectId: string) {
     return `${
       environment.apiURL
-    }/learning-objects/${learningObjectId}/submission`
+    }/learning-objects/${learningObjectId}/submission`;
   },
   ADD_LEARNING_OBJET_TO_COLLECTION(learningObjectId: string) {
     return `${environment.apiURL}/learning-objects/${encodeURIComponent(


### PR DESCRIPTION
Some refactoring was done to hide the endpoint data formats from the component. The service now returns a `Message` type to the component for use.

The service now throws an Error on purpose if the response from the endpoint is malformed, as compared to previously returning undefined which caused a runtime error since the client tried to access `.length` of undefined.