### PR TITLE
Remove usage of released flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -40,7 +40,6 @@ export class BrowseComponent implements OnInit, OnDestroy {
     orderBy: undefined,
     sortType: undefined,
     collection: '',
-    released: this.auth.hasReviewerAccess() ? undefined : true
   };
 
   tooltipText = {
@@ -134,7 +133,6 @@ export class BrowseComponent implements OnInit, OnDestroy {
       // }
       const collections = await this.collectionService.getCollections();
       this.filters[0].values = collections.map(c => ({ name: c.name, value: c.abvName}));
-      this.query.released = this.auth.hasReviewerAccess() ? undefined : true;
       this.makeQuery(params);
       this.fetchLearningObjects(this.query);
     });

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -17,7 +17,6 @@ export class HomeComponent implements OnInit {
   copy = COPY;
   query: Query = {
     limit: 1,
-    released: this.auth.hasReviewerAccess() ? undefined : true
   };
   placeholderText = this.copy.SEARCH_PLACEHOLDER;
   collections: Collection[];

--- a/src/app/cube/shared/featured/featured.component.ts
+++ b/src/app/cube/shared/featured/featured.component.ts
@@ -20,7 +20,7 @@ export class FeaturedComponent implements OnInit {
     limit: 5,
     orderBy: OrderBy.Date,
     sortType: SortType.Descending,
-    released: true
+    status: [LearningObject.Status.RELEASED]
   };
   loading = false;
 
@@ -31,16 +31,12 @@ export class FeaturedComponent implements OnInit {
   ngOnInit() {
     if (this.collection) {
       this.loading = true;
-      this.collection
-        .pipe(
-          takeUntil(this.destroyed$)
-        )
-        .subscribe({
-          next: collection => {
-            this.query.collection = collection;
-            this.fetchLearningObjects();
-          }
-        });
+      this.collection.pipe(takeUntil(this.destroyed$)).subscribe({
+        next: collection => {
+          this.query.collection = collection;
+          this.fetchLearningObjects();
+        }
+      });
     } else {
       this.fetchLearningObjects();
     }
@@ -50,11 +46,12 @@ export class FeaturedComponent implements OnInit {
     this.loading = true;
 
     try {
-      this.learningObjects = (await this.learningObjectService.getLearningObjects(this.query)).learningObjects;
+      this.learningObjects = (await this.learningObjectService.getLearningObjects(
+        this.query
+      )).learningObjects;
       this.loading = false;
     } catch (e) {
       this.loading = false;
     }
   }
-
 }

--- a/src/app/shared/interfaces/query.ts
+++ b/src/app/shared/interfaces/query.ts
@@ -19,8 +19,8 @@ export interface Query {
   standardOutcomes?:
     | string[]
     | { id: string; name: string; date: string; outcome: string }[];
-  released?: boolean;
   collection?: string;
+  status?: string[];
 }
 
 export interface MappingQuery extends Query {


### PR DESCRIPTION
This PR removes usage of `released` flag to show objects in the review stage to authorized users.

Needs Cyber4All/learning-object-service#199