### PR TITLE
Update review stat to accurately reflect objects under review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -59,7 +59,7 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
     this.statsService.getLearningObjectStats().then(stats => {
       this.usageStats.objects.released = stats.released;
-      this.usageStats.objects.underReview = stats.total - stats.released;
+      this.usageStats.objects.underReview = stats.total - stats.released - stats.working;
       this.usageStats.objects.downloads = stats.downloads;
       this.objectStatsLoaded = true;
     });

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -59,7 +59,7 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
     this.statsService.getLearningObjectStats().then(stats => {
       this.usageStats.objects.released = stats.released;
-      this.usageStats.objects.underReview = stats.total - stats.released - stats.working;
+      this.usageStats.objects.underReview = stats.review;
       this.usageStats.objects.downloads = stats.downloads;
       this.objectStatsLoaded = true;
     });

--- a/src/app/cube/shared/types/learning-object-stats.ts
+++ b/src/app/cube/shared/types/learning-object-stats.ts
@@ -1,6 +1,7 @@
 export interface LearningObjectStats {
   downloads: number;
   saves: number;
+  working: number;
   total: number;
   released: number;
   lengths: {

--- a/src/app/cube/shared/types/learning-object-stats.ts
+++ b/src/app/cube/shared/types/learning-object-stats.ts
@@ -1,7 +1,7 @@
 export interface LearningObjectStats {
   downloads: number;
   saves: number;
-  working: number;
+  review: number;
   total: number;
   released: number;
   lengths: {


### PR DESCRIPTION
Update review stat to accurately reflect number objects under review.
Needs Cyber4All/learning-object-service#221
Closes #611 