### PR TITLE
Modify the user-information component to use new profile route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/learning-object.service.ts
+++ b/src/app/cube/learning-object.service.ts
@@ -2,7 +2,7 @@ import { PUBLIC_LEARNING_OBJECT_ROUTES, USER_ROUTES } from '@env/route';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { LearningObject, User } from '@cyber4all/clark-entity';
+import { LearningObject } from '@cyber4all/clark-entity';
 import { Query } from '../shared/interfaces/query';
 
 import * as querystring from 'querystring';
@@ -92,7 +92,7 @@ export class LearningObjectService {
       });
   }
   getUsersLearningObjects(username: string): Promise<LearningObject[]> {
-    const route = PUBLIC_LEARNING_OBJECT_ROUTES.GET_USERS_PUBLIC_LEARNING_OBJECTS(
+    const route = USER_ROUTES.LOAD_USER_PROFILE(
       username
     );
 

--- a/src/app/cube/user-profile/user-information/user-information.component.ts
+++ b/src/app/cube/user-profile/user-information/user-information.component.ts
@@ -41,9 +41,6 @@ export class UserInformationComponent implements OnInit, OnChanges {
     this.objects = await this.learningObjectService.getUsersLearningObjects(
       this.user.username
     );
-    this.objects = this.objects.filter(
-      obj => obj.status === LearningObject.Status.RELEASED
-    );
     this.loading = false;
   }
 

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -10,6 +10,11 @@ export const USER_ROUTES = {
       username
     )}/profile`;
   },
+  LOAD_USER_PROFILE(username: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(
+      username
+    )}/learning-objects/profile`;
+  },
   SEARCH_USERS(query: {}) {
     return `${environment.apiURL}/users/search?text=` + query;
   },


### PR DESCRIPTION
This PR simply points the user-profile to the new route added in Cyber4All/CLARK-Gateway#67

Requires Cyber4All/CLARK-Gateway#67
Requires Cyber4All/learning-object-service#229