### PR TITLE
Fix bug where column height for builder isn't calculated if message service returns a malformed response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.8",
+  "version": "2.7.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.8",
+  "version": "2.7.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/column-wrapper/column-wrapper.component.ts
+++ b/src/app/onion/learning-object-builder/components/column-wrapper/column-wrapper.component.ts
@@ -29,26 +29,27 @@ export class ColumnWrapperComponent implements OnInit, AfterViewInit, OnDestroy 
   async ngOnInit() {
     try {
       this.messageBar = !!(await this.messagesService.getStatus());
-
-      // calculate the height of the scroll wrapper
-      this.columnOffset = (this.columnWrapper
-        .nativeElement as HTMLElement).offsetTop;
-      this.columnHeight =
-        window.innerHeight -
-        this.columnOffset -
-        (this.messageBar
-          ? (document.querySelector('clark-message .wrapper') as HTMLElement)
-              .offsetHeight
-          : 0) +
-        30; // this +30 offsets the wrappers -30 offset
-
-      // set overflow of body to hidden to prevent parent scrolling
-      if (this.columnHeight >= 560) {
-        // this check prevents obsucring the outcomes sidebar
-        document.body.style.overflow = 'hidden';
-      }
     } catch (error) {
       // FIXME this suppresses the error resulting in the lambda function for messages being disabled
+    }
+
+    // calculate the height of the scroll wrapper
+    this.columnOffset = (this.columnWrapper
+      .nativeElement as HTMLElement).offsetTop;
+
+    this.columnHeight =
+      window.innerHeight -
+      this.columnOffset -
+      (this.messageBar
+        ? (document.querySelector('clark-message .wrapper') as HTMLElement)
+            .offsetHeight
+        : 0) +
+      30; // this +30 offsets the wrappers -30 offset
+
+    // set overflow of body to hidden to prevent parent scrolling
+    if (this.columnHeight >= 560) {
+      // this check prevents obsucring the outcomes sidebar
+      document.body.style.overflow = 'hidden';
     }
   }
 


### PR DESCRIPTION
This PR addresses a bug wherein the columns in the builder don't have the correct height if the message service returns a malformed response. This is due to the try-catch block failing and skipping the calculations instead of simply calculating with a 0 for the height the message bar.