### PR TITLE
Modify usage-stats page to display correct number of review objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -58,7 +58,7 @@ export class UsageStatsComponent implements OnInit {
     this.buildCounterStats();
     this.statsService.getLearningObjectStats().then(stats => {
       this.usageStats.objects.released = stats.released;
-      this.usageStats.objects.underReview = stats.total - stats.released;
+      this.usageStats.objects.underReview = stats.review;
       this.usageStats.objects.downloads = stats.downloads;
       this.usageStats.objects.lengths = {
         nanomodule: stats.lengths.nanomodule,


### PR DESCRIPTION
Modify the usage stats page to display the correct number of objects under review.