### PR TITLE
Fix bad refresh token request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.9",
+  "version": "2.7.10",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/email-verified/email-verified.component.html
+++ b/src/app/auth/email-verified/email-verified.component.html
@@ -3,12 +3,19 @@
     <div class="top">
       <div class="auth-title">CLARK</div>
       <div class="auth-title light">Cybersecurity Labs and Resource Knowledge-base</div>
-      <div class="done">
+      <div class="done" *ngIf="isLoading">
+        Verifying your email...
+        <i class="far fa-spinner-third fa-spin"></i>
+      </div>
+      <div class="done" *ngIf="!isLoading">
         <i class="far fa-shield-check"></i>
         Your email address has been verified successfully!
       </div>
     </div>
-    <div class="bottom-link" routerLink="../login">
+    <div class="bottom-link" *ngIf="hasValidToken" routerLink="/home">
+      <span>Continue</span>
+    </div>
+    <div class="bottom-link" *ngIf="hasValidToken === false" routerLink="../login">
       Want to get started? <span>Sign in!</span>
     </div>
   </div>

--- a/src/app/auth/email-verified/email-verified.component.html
+++ b/src/app/auth/email-verified/email-verified.component.html
@@ -4,7 +4,7 @@
       <div class="auth-title">CLARK</div>
       <div class="auth-title light">Cybersecurity Labs and Resource Knowledge-base</div>
       <div class="done" *ngIf="isLoading">
-        Verifying your email...
+        <p class="message--in-progress">Verifying your email...</p>
         <i class="far fa-spinner-third fa-spin"></i>
       </div>
       <div class="done" *ngIf="!isLoading">

--- a/src/app/auth/email-verified/email-verified.component.ts
+++ b/src/app/auth/email-verified/email-verified.component.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../../core/auth.service';
   selector: 'app-email-verified',
   styles: [
     `.message--in-progress {
-      color: red;
+      margin-bottom: 20px;
     }`
   ],
   templateUrl: './email-verified.component.html'

--- a/src/app/auth/email-verified/email-verified.component.ts
+++ b/src/app/auth/email-verified/email-verified.component.ts
@@ -3,12 +3,31 @@ import { AuthService } from '../../core/auth.service';
 
 @Component({
   selector: 'app-email-verified',
+  styles: [
+    `.message--in-progress {
+      color: red;
+    }`
+  ],
   templateUrl: './email-verified.component.html'
 })
 export class EmailVerifiedComponent implements OnInit {
+  isLoading = true;
+  hasValidToken;
+
   constructor(private auth: AuthService) {}
 
   ngOnInit() {
-    this.auth.refreshToken();
+    this.auth.validate()
+      .then(async () => {
+        // Token is good, refresh it and go home
+        await this.auth.refreshToken();
+        this.hasValidToken = true;
+        this.isLoading = false;
+      })
+      .catch(e => {
+        this.isLoading = false;
+        this.hasValidToken = false;
+        // Token is bad, they must sign in
+      });
   }
 }

--- a/src/app/auth/email-verified/email-verified.component.ts
+++ b/src/app/auth/email-verified/email-verified.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../../core/auth.service';
 
 @Component({
-  selector: 'app-email-verified',
+  selector: 'clark-email-verified',
   styles: [
     `.message--in-progress {
       margin-bottom: 20px;


### PR DESCRIPTION
The client app was making a request to refresh the user's token even when the token was invalid. Now the app first validates the token before it attempts to refresh it. The refresh operation only happens if the token is valid. If the token is not valid, it will prompt the user to sign in again.

This preserves the operation of automatically updating the user information stored in the token if the token is valid, while adding appropriate handling if it is not valid.

While the request is made, a loading spinner is shown to the user:

![image](https://user-images.githubusercontent.com/14933100/53068353-2ca90280-34a6-11e9-9e49-a55ee7a0b087.png)

Closes #607