### PR TITLE
Fix bug where users with privileged access can't download learning objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -16,6 +16,7 @@ export enum AUTH_GROUP {
   VISITOR,
   USER,
   REVIEWER,
+  CURATOR,
   EDITOR,
   ADMIN
 }
@@ -299,14 +300,14 @@ export class AuthService {
   }
 
   /**
-   * Identifies if the current logged in user has reviewer priviledges.
+   * Identifies if the current logged in user has reviewer privileges.
    */
   hasReviewerAccess(): boolean {
     return this.group.getValue() > AUTH_GROUP.USER;
   }
 
   /**
-   * Identifies if the current logged in user has editor priviledges.
+   * Identifies if the current logged in user has editor privileges.
    */
   public hasEditorAccess(): boolean {
     return this.group.getValue() > AUTH_GROUP.REVIEWER;
@@ -319,12 +320,17 @@ export class AuthService {
     if (!this.user['accessGroups']) {
       return;
     }
-    if (this.user['accessGroups'].includes('admin')) {
+
+    const groups = this.user['accessGroups'].map(x => x.split('@')[0]);
+
+    if (groups.includes('admin')) {
       this.group.next(AUTH_GROUP.ADMIN);
-    } else if (this.user['accessGroups'].includes('editor')) {
+    } else if (groups.includes('editor')) {
       this.group.next(AUTH_GROUP.EDITOR);
-    } else if (this.user['accessGroups'].includes('reviewer')) {
+    } else if (groups.includes('reviewer')) {
       this.group.next(AUTH_GROUP.REVIEWER);
+    } else if (groups.includes('curator')) {
+      this.group.next(AUTH_GROUP.CURATOR);
     } else {
       this.group.next(AUTH_GROUP.USER);
     }

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -321,6 +321,9 @@ export class AuthService {
       return;
     }
 
+    // Since the service will only pull down objects the authenticated user is authorized to see, we don't need
+    // to check the collection in the case of reviewers and curators. We can strip the collections from the roles
+    // in the access groups for ease of comparison.
     const groups = this.user['accessGroups'].map(x => x.split('@')[0]);
 
     if (groups.includes('admin')) {


### PR DESCRIPTION
**Problem:** With the addition of collections into the access groups (`reviewer` changing to `reviewer@collection`) the current implementation client side identified reviewers and curators as regular users and this denied them download access.

**Solution:** Before iterating the accessGroups array, remove references to collections entirely.

**Future:** A more robust solution should be implemented wherein there are collection checks client side to prevent a user downloading an object from a collection they're not privileged in. This isn't absolutely necessary at this time since the service will only send down objects that the current user is authorized to see. @gshaw1997 @davidnso can you confirm this last bit?