### PR TITLE
Add Library Stats Request back into Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.7.11",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.7.11",
+  "version": "2.8.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/core/usage-stats/usage-stats.service.ts
+++ b/src/app/cube/core/usage-stats/usage-stats.service.ts
@@ -7,10 +7,16 @@ import { LearningObjectStats, UserStats } from 'app/cube/shared/types';
 export class UsageStatsService {
   constructor(private http: HttpClient) {}
 
-  getLearningObjectStats(): Promise<LearningObjectStats> {
-    return this.http
-      .get<LearningObjectStats>(STATS_ROUTES.LEARNING_OBJECT_STATS)
-      .toPromise();
+  async getLearningObjectStats(): Promise<LearningObjectStats> {
+    const [objects, library] = await Promise.all([
+      this.http
+        .get<Partial<LearningObjectStats>>(STATS_ROUTES.LEARNING_OBJECT_STATS)
+        .toPromise(),
+      this.http
+        .get<{ saves: number; downloads: number }>(STATS_ROUTES.LIBRARY_STATS)
+        .toPromise()
+    ]);
+    return { ...objects, ...library } as LearningObjectStats;
   }
   getUserStats(): Promise<UserStats> {
     return this.http.get<UserStats>(STATS_ROUTES.USERS_STATS).toPromise();

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -277,5 +277,6 @@ export const MISC_ROUTES = {
 
 export const STATS_ROUTES = {
   LEARNING_OBJECT_STATS: `${environment.apiURL}/learning-objects/stats`,
+  LIBRARY_STATS: `${environment.apiURL}/library/stats`,
   USERS_STATS: `${environment.apiURL}/users/stats`
 };


### PR DESCRIPTION
This reverts commit fb2290401839b0b4c1cd40261f58779330291cd0, which originally introduced this feature.

With this in place, that saves and downloads counters will update with live data, vs the previous snapshot data being fetched from Learning Object service.