### PR TITLE
Allow Admins/Editors to edit Learning Object in Builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.11.2",
+  "version": "2.12.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/clark.routing.ts
+++ b/src/app/clark.routing.ts
@@ -1,15 +1,30 @@
 import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { UnsupportedComponent } from './unsupported.component';
-import { NotFoundComponent} from './not-found.component';
+import { NotFoundComponent } from './not-found.component';
+import { AccessGroupGuard } from './core/access-group-guard';
 
 const clark_routes: Routes = [
-  { path: 'auth', loadChildren: 'app/auth/auth.module#AuthModule', data: { hideNavbar: true } },
+  {
+    path: 'auth',
+    loadChildren: 'app/auth/auth.module#AuthModule',
+    data: { hideNavbar: true }
+  },
+  {
+    path: 'admin/learning-object-builder/:learningObjectId',
+    loadChildren:
+      'app/onion/learning-object-builder/learning-object-builder.module#LearningObjectBuilderModule',
+    canActivate: [AccessGroupGuard],
+    data: { state: 'builder', accessGroups: ['admin', 'editor'] }
+  },
   { path: 'onion', loadChildren: 'app/onion/onion.module#OnionModule' },
+
   { path: 'unsupported', component: UnsupportedComponent },
   { path: 'not-found', component: NotFoundComponent },
   { path: '', loadChildren: 'app/cube/cube.module#CubeModule' },
-  { path: '**', redirectTo: '', pathMatch: 'full'},
+  { path: '**', redirectTo: '', pathMatch: 'full' }
 ];
 
-export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(clark_routes);
+export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(
+  clark_routes
+);

--- a/src/app/core/access-group-guard.ts
+++ b/src/app/core/access-group-guard.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot
+} from '@angular/router';
+import { AuthService } from './auth.service';
+
+@Injectable()
+export class AccessGroupGuard implements CanActivate {
+  constructor(private router: Router, private authService: AuthService) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    const acceptedGroups = route.data['accessGroups'] as string[];
+    const userGroups = this.authService.accessGroups;
+    for (const group of acceptedGroups) {
+      if (userGroups.includes(group)) {
+        return true;
+      }
+    }
+    this.router.navigate(['/auth/login'], {
+      queryParams: { redirectUrl: state.url }
+    });
+    return false;
+  }
+}

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -27,7 +27,7 @@ export interface AuthUser extends User {
 
 @Injectable()
 export class AuthService {
-  user: User = undefined;
+  user: AuthUser;
   headers = new Headers();
   httpHeaders = new HttpHeaders();
   inUse: object;

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -50,6 +50,19 @@ export class AuthService {
     }
   }
 
+  /**
+   * Checks if user's group equals admin or editor
+   *
+   * @returns {boolean}
+   * @memberof AuthService
+   */
+  public isAdminOrEditor(): boolean {
+    return (
+      this.group.value === AUTH_GROUP.ADMIN ||
+      this.group.value === AUTH_GROUP.EDITOR
+    );
+  }
+
   private changeStatus(status: boolean) {
     if (this.isLoggedIn.getValue() !== status) {
       this.isLoggedIn.next(status);
@@ -74,6 +87,10 @@ export class AuthService {
 
   get username(): string {
     return this.user ? this.user.username : undefined;
+  }
+
+  get accessGroups(): string[] {
+    return this.user ? this.user.accessGroups : [];
   }
 
   async validate(): Promise<void> {

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -21,6 +21,7 @@ import { ContextMenuModule } from 'ngx-contextmenu';
 import { CollectionService } from './collection.service';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { HttpConfigInterceptor } from './interceptor/httpconfig.interceptor';
+import { AccessGroupGuard } from './access-group-guard';
 
 @NgModule({
   imports: [
@@ -37,6 +38,7 @@ export class CoreModule {
     return {
       ngModule: CoreModule,
       providers: [
+        AccessGroupGuard,
         AuthGuard,
         AuthService,
         CartV2Service,

--- a/src/app/cube/details/action-panel/action-panel.component.html
+++ b/src/app/cube/details/action-panel/action-panel.component.html
@@ -19,7 +19,7 @@
         <i class="fal fa-spinner-third fa-spin"></i>
       </span>
     </button>
-    <button *ngIf="isEditButtonViewable" class="button neutral on-white" (click)="openAdminApp()"> 
+    <button *ngIf="isEditButtonViewable" class="button neutral on-white" [routerLink]="['/admin/learning-object-builder/', learningObject?.id]">
       Revise
     </button>
   </div>

--- a/src/app/cube/details/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/action-panel/action-panel.component.ts
@@ -233,12 +233,6 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     return this.windowWidth <= 750;
   }
 
-  // Navigates the route from client to admin perspective
-  openAdminApp() {
-    const route = `${environment.adminAppUrl}/objects/details/${this.learningObject.id}`;
-    window.open(route);
-  }
-
   ngOnDestroy() {
     this.destroyed$.next();
     this.destroyed$.unsubscribe();

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -30,10 +30,8 @@ export class LearningObjectService {
    * @returns {Promise<string>}
    * @memberof LearningObjectService
    */
-  create(learningObject): Promise<LearningObject> {
-    const route = USER_ROUTES.ADD_TO_MY_LEARNING_OBJECTS(
-      this.auth.user.username
-    );
+  create(learningObject, authorUsername: string): Promise<LearningObject> {
+    const route = USER_ROUTES.ADD_TO_MY_LEARNING_OBJECTS(authorUsername);
 
     return this.http
       .post(
@@ -70,11 +68,11 @@ export class LearningObjectService {
    * @returns {Promise<LearningObject[]>}
    * @memberof LearningObjectService
    */
-  getLearningObjects(filters?: any): Promise<LearningObject[]> {
-    const route = USER_ROUTES.GET_MY_LEARNING_OBJECTS(
-      this.auth.user.username,
-      filters
-    );
+  getLearningObjects(
+    authorUsername: string,
+    filters?: any
+  ): Promise<LearningObject[]> {
+    const route = USER_ROUTES.GET_MY_LEARNING_OBJECTS(authorUsername, filters);
     return this.http
       .get(route, { headers: this.headers, withCredentials: true })
       .toPromise()
@@ -94,11 +92,12 @@ export class LearningObjectService {
    * @memberof LearningObjectService
    */
   // TODO type this parameter
-  save(id: string, learningObject: { [key: string]: any }): Promise<{}> {
-    const route = USER_ROUTES.UPDATE_MY_LEARNING_OBJECT(
-      this.auth.user.username,
-      id
-    );
+  save(
+    id: string,
+    authorUsername: string,
+    learningObject: { [key: string]: any },
+  ): Promise<{}> {
+    const route = USER_ROUTES.UPDATE_MY_LEARNING_OBJECT(authorUsername, id);
     return this.http
       .patch(
         route,
@@ -134,7 +133,9 @@ export class LearningObjectService {
 
   deleteOutcome(learningObjectId: string, outcomeId: string): Promise<any> {
     return this.http
-      .delete(USER_ROUTES.DELETE_OUTCOME(learningObjectId, outcomeId), { withCredentials: true })
+      .delete(USER_ROUTES.DELETE_OUTCOME(learningObjectId, outcomeId), {
+        withCredentials: true
+      })
       .toPromise();
   }
 
@@ -144,9 +145,7 @@ export class LearningObjectService {
    * @param {string} collection the abreviated name of the collection to which to submit this learning object
    */
   submit(learningObject: LearningObject, collection: string): Promise<{}> {
-    const route = USER_ROUTES.SUBMIT_LEARNING_OBJECT(
-      learningObject.id
-    );
+    const route = USER_ROUTES.SUBMIT_LEARNING_OBJECT(learningObject.id);
     return this.http
       .post(
         route,
@@ -161,15 +160,14 @@ export class LearningObjectService {
    * @param {learningObject} learningObject the learning object to be unpublished
    */
   unsubmit(learningObject: LearningObject) {
-    const route = USER_ROUTES.UNSUBMIT_LEARNING_OBJECT(
-      learningObject.id
-    );
+    const route = USER_ROUTES.UNSUBMIT_LEARNING_OBJECT(learningObject.id);
 
     return this.http
-      .delete(
-        route,
-        { headers: this.headers, withCredentials: true, responseType: 'text' }
-      )
+      .delete(route, {
+        headers: this.headers,
+        withCredentials: true,
+        responseType: 'text'
+      })
       .toPromise();
   }
 
@@ -180,9 +178,9 @@ export class LearningObjectService {
    * @returns {Promise<{}>}
    * @memberof LearningObjectService
    */
-  delete(learningObjectName: string): Promise<{}> {
+  delete(learningObjectName: string, authorUsername: string): Promise<{}> {
     const route = USER_ROUTES.DELETE_LEARNING_OBJECT(
-      this.auth.user.username,
+      authorUsername,
       learningObjectName
     );
     return this.http
@@ -201,11 +199,8 @@ export class LearningObjectService {
    * @returns {Promise<{}>}
    * @memberof LearningObjectService
    */
-  deleteMultiple(names: string[]): Promise<any> {
-    const route = USER_ROUTES.DELETE_MULTIPLE_LEARNING_OBJECTS(
-      this.auth.user.username,
-      names
-    );
+  deleteMultiple(names: string[], authorUsername: string): Promise<any> {
+    const route = USER_ROUTES.DELETE_MULTIPLE_LEARNING_OBJECTS(authorUsername, names);
 
     return this.http
       .delete(route, {
@@ -216,11 +211,12 @@ export class LearningObjectService {
       .toPromise();
   }
 
-  setChildren(learningObjectName: string, children: string[]): Promise<any> {
-    const route = USER_ROUTES.SET_CHILDREN(
-      this.auth.user.username,
-      learningObjectName
-    );
+  setChildren(
+    learningObjectName: string,
+    authorUsername: string,
+    children: string[]
+  ): Promise<any> {
+    const route = USER_ROUTES.SET_CHILDREN(authorUsername, learningObjectName);
 
     return this.http
       .post(
@@ -231,8 +227,8 @@ export class LearningObjectService {
       .toPromise();
   }
 
-  updateReadme(username: string, id: string): any {
-    const route = USER_ROUTES.UPDATE_PDF(username, id);
+  updateReadme(authorUsername: string, id: string): any {
+    const route = USER_ROUTES.UPDATE_PDF(authorUsername, id);
     return this.http.patch(
       route,
       {},
@@ -242,20 +238,20 @@ export class LearningObjectService {
   /**
    * Fetches Learning Object's Materials
    *
-   * @param {string} username
+   * @param {string} authorUsername
    * @param {string} objectId
    * @param {string} description
    * @returns {Promise<any>}
    * @memberof LearningObjectService
    */
-  getMaterials(username: string, objectId: string): Promise<any> {
-    const route = USER_ROUTES.GET_MATERIALS(username, objectId);
+  getMaterials(authorUsername: string, objectId: string): Promise<any> {
+    const route = USER_ROUTES.GET_MATERIALS(authorUsername, objectId);
     return this.http.get(route, { withCredentials: true }).toPromise();
   }
   /**
    * Makes request to update file description
    *
-   * @param {string} username
+   * @param {string} authorUsername
    * @param {string} objectId
    * @param {string} fileId
    * @param {string} description
@@ -263,13 +259,13 @@ export class LearningObjectService {
    * @memberof LearningObjectService
    */
   updateFileDescription(
-    username: string,
+    authorUsername: string,
     objectId: string,
     fileId: string,
     description: string
   ): Promise<any> {
     const route = USER_ROUTES.UPDATE_FILE_DESCRIPTION(
-      username,
+      authorUsername,
       objectId,
       fileId
     );

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -187,7 +187,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   async getLearningObjects(filters?: any): Promise<DashboardLearningObject[]> {
     this.loading = true;
     return this.learningObjectService
-      .getLearningObjects(filters)
+      .getLearningObjects(this.auth.username, filters)
       .then((learningObjects: LearningObject[]) => {
         this.loading = false;
         // deep copy list of learningObjects and initialize empty parents array
@@ -318,8 +318,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     if (!Array.isArray(objects) || objects.length === 1) {
+      const object = Array.isArray(objects) ? objects[0] : objects;
       this.learningObjectService
-        .delete(Array.isArray(objects) ? objects[0].name : objects.name)
+        .delete(object.name , object.author.username)
         .then(async () => {
           this.notificationService.notify(
             'Done!',
@@ -344,9 +345,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
       const canDelete = objects.filter(s => [LearningObject.Status.UNRELEASED, LearningObject.Status.REJECTED].includes(s.status));
 
       if (canDelete.length) {
+        const authorUsername = canDelete[0].author.username;
         this.learningObjectService
           // TODO: Verify selected is an array of names
-          .deleteMultiple(canDelete.map(s => s.name))
+          .deleteMultiple(canDelete.map(s => s.name), authorUsername)
           .then(async () => {
             this.clearSelected();
             if (canDelete.length === objects.length) {
@@ -486,7 +488,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
           .filter(l => names.includes(l.name))
           .map(l => l.id);
         this.learningObjectService
-          .setChildren(this.focusedLearningObject.name, ids)
+          .setChildren(this.focusedLearningObject.name, this.focusedLearningObject.author.username, ids)
           .then(val => {
             this.notificationService.notify(
               'Success!',

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -684,7 +684,7 @@ export class BuilderStore {
 
         // create the object
         this.learningObjectService
-          .create(value)
+          .create(value, this.auth.username)
           .then((object: LearningObject) => {
             this.learningObject = object;
             this.serviceInteraction$.next(false);
@@ -706,7 +706,7 @@ export class BuilderStore {
 
         // send cached changes to server
         this.learningObjectService
-          .save(this.learningObject.id, value)
+          .save(this.learningObject.id, this.learningObject.author.username, value)
           .then(() => {
             this.serviceInteraction$.next(false);
           })

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
@@ -1,34 +1,50 @@
 <div class="builder-navbar-wrapper">
   <div class="top">
     <div class="top__left">
-      <a routerLink="onion/dashboard"><i class="far fa-arrow-left"></i> Back to Dashboard</a>
+      <a *ngIf="!adminMode" routerLink="onion/dashboard"><i class="far fa-arrow-left"></i> Back to Dashboard</a>
+      <!-- FIXME: Convert to routerLink when admin dashboard is pulled into CLARK -->
+      <a *ngIf="adminMode" href="https://admin.clark.center"><i class="far fa-arrow-left"></i> Back to Dashboard</a>
     </div>
     <div class="top__right">
-      <div *ngIf="!['unreleased', 'rejected'].includes(learningObject?.status) && learningObject?.collection" class="top__collection" tip="This learning object has been submitted to the {{ collection.name }} collection." tipLocation="bottom" >
+      <div *ngIf="!['unreleased', 'rejected'].includes(learningObject?.status) && learningObject?.collection" class="top__collection"
+        tip="This learning object has been submitted to the {{ collection.name }} collection." tipLocation="bottom">
         <span>{{ collection.name }}</span>
         <div class="collection__image" [style.background-image]="'url(assets/images/collections/' + learningObject?.collection + '.png)'"></div>
       </div>
-      <div *ngIf="learningObject?.status" class="top__status" [ngClass]="learningObject?.status" tip="{{ states?.get(learningObject.status)?.tip }}" tipDisabled="{{ !states?.get(learningObject.status)?.tip }}" tipLocation="bottom">
+      <div *ngIf="learningObject?.status" class="top__status" [ngClass]="learningObject?.status" tip="{{ states?.get(learningObject.status)?.tip }}"
+        tipDisabled="{{ !states?.get(learningObject.status)?.tip }}" tipLocation="bottom">
         <span *ngIf="learningObject?.status === 'unreleased'"><i class="fas fa-eye-slash"></i></span>
         <span *ngIf="learningObject?.status === 'waiting'"><i class="fas fa-hourglass"></i></span>
         <span *ngIf="learningObject?.status === 'review'"><i class="fas fa-sync"></i></span>
         <span *ngIf="learningObject?.status === 'released'"><i class="fas fa-eye"></i></span>
         <span *ngIf="learningObject?.status === 'denied'"><i class="fas fa-ban"></i></span>
       </div>
-      <ng-container *ngIf="!learningObject?.status || ['unreleased', 'rejected'].includes(learningObject?.status); else submittedButtonTemplate">
-        <button class="button" [ngClass]="{'good': !submissionError, 'bad': validator.submissionMode && submissionError, 'disabled': !auth.user.emailVerified}" (click)="auth.user.emailVerified && triggerSubmit()">
-          <div *ngIf="validator.submissionMode && submissionError" class="button__cancel" tip="Cancel Submission" tipLocation="bottom" (click)="$event.stopPropagation(); validator.submissionMode = false;">
-            <i class="far fa-times"></i>
-          </div>
-          {{ validator.submissionMode && submissionError ? 'Try Again' : 'Submit for review' }} 
-          <i class="far fa-arrow-right"></i>
-        </button>
+      <ng-container *ngIf="!adminMode">
+
+        <ng-container *ngIf="!learningObject?.status || ['unreleased', 'rejected'].includes(learningObject?.status); else submittedButtonTemplate">
+          <button class="button" [ngClass]="{'good': !submissionError, 'bad': validator.submissionMode && submissionError, 'disabled': !auth.user.emailVerified}"
+            (click)="auth.user.emailVerified && triggerSubmit()">
+            <div *ngIf="validator.submissionMode && submissionError" class="button__cancel" tip="Cancel Submission"
+              tipLocation="bottom" (click)="$event.stopPropagation(); validator.submissionMode = false;">
+              <i class="far fa-times"></i>
+            </div>
+            {{ validator.submissionMode && submissionError ? 'Try Again' : 'Submit for review' }}
+            <i class="far fa-arrow-right"></i>
+          </button>
+        </ng-container>
+
+        <ng-template #submittedButtonTemplate>
+          <button class="button good" (click)="toggleSubmissionOptionsMenu($event)" [ngClass]="{'shadow': showSubmissionOptions, 'disabled': !auth.user.emailVerified}">
+            Submitted <i class=" far fa-angle-down"></i>
+          </button>
+        </ng-template>
+
       </ng-container>
-      <ng-template #submittedButtonTemplate>
-        <button class="button good" (click)="toggleSubmissionOptionsMenu($event)" [ngClass]="{'shadow': showSubmissionOptions, 'disabled': !auth.user.emailVerified}">
-          Submitted <i class=" far fa-angle-down"></i>
-        </button>
-      </ng-template>
+      <div *ngIf="adminMode" class="builder-navbar-wrapper__bottom-right">
+        <div class="builder-navbar-wrapper__bottom-right__admin-badge">
+          <span>Editor Mode</span>
+        </div>
+      </div>
     </div>
   </div>
   <div class="builder-navbar-wrapper__bottom">
@@ -50,12 +66,14 @@
         <span *ngIf="!isSaving" class="builder-navbar-wrapper__saving-indicator">All changes saved</span>
       </div>
     </div>
+
   </div>
 </div>
 
 <clark-popup *ngIf="showSubmission" (closed)="showSubmission = false">
   <div #popupInner>
-    <clark-collection-selector [currentCollection]="store.learningObjectEvent.getValue().collection" (choice)="submitForReview($event)" (cancel)="showSubmission = false"></clark-collection-selector>
+    <clark-collection-selector [currentCollection]="store.learningObjectEvent.getValue().collection" (choice)="submitForReview($event)"
+      (cancel)="showSubmission = false"></clark-collection-selector>
   </div>
 </clark-popup>
 
@@ -70,6 +88,8 @@
 </clark-context-menu>
 
 <ng-template #navItemTemplate let-link="link" let-disabled="disabled" let-text="text">
-  <a *ngIf="!disabled" [ngClass]="{'new': isNewRoute(link)}" routerLink="{{ link }}" routerLinkActive="active" (click)="triggerRouteClick(link)">{{ text }}</a>
-  <a *ngIf="disabled" class="disabled" tip="Please give this learning object a name before adding outcomes or uploading materials" tipLocation="above"><i class="fas fa-lock"></i>{{ text }}</a>
+  <a *ngIf="!disabled" [ngClass]="{'new': isNewRoute(link)}" routerLink="{{ link }}" routerLinkActive="active" (click)="triggerRouteClick(link)">{{
+    text }}</a>
+  <a *ngIf="disabled" class="disabled" tip="Please give this learning object a name before adding outcomes or uploading materials"
+    tipLocation="above"><i class="fas fa-lock"></i>{{ text }}</a>
 </ng-template>

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
@@ -1,26 +1,24 @@
 @import '~_vars.scss';
 
 $dark-text: #545e64;
-$light-blue-gradient: linear-gradient(
-  45deg,
-  darken($bright-blue, 10),
-  lighten($bright-blue, 5)
-);
+$light-blue-gradient: linear-gradient(45deg,
+darken($bright-blue, 10),
+lighten($bright-blue, 5));
 
 button {
   border: 0;
   padding: 10px 20px 10px 25px;
 
   &.good {
-      background: $light-blue-gradient;
+    background: $light-blue-gradient;
   }
 
   &.neutral {
-      color: $dark-text;
+    color: $dark-text;
   }
 
   &.shadow {
-      box-shadow: inset 0 1px 2px 1px rgba(0, 0, 0, 0.1);
+    box-shadow: inset 0 1px 2px 1px rgba(0, 0, 0, 0.1);
   }
 }
 
@@ -38,23 +36,23 @@ button {
   box-shadow: none;
 
   &.waiting {
-      background: #5ec9da;
+    background: #5ec9da;
   }
 
   &.review {
-      background: #f5a623;
+    background: #f5a623;
   }
 
   &.released {
-      background: $green;
+    background: $green;
   }
 
   &.denied {
-      background: saturate($error-red, 15);
+    background: saturate($error-red, 15);
   }
 
   &:hover {
-      box-shadow: 0 0 20px 2px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 0 20px 2px rgba(0, 0, 0, 0.08);
   }
 }
 
@@ -110,7 +108,7 @@ button {
     align-items: center;
     justify-content: flex-end;
 
-    & > *:not(:last-child) {
+    &>*:not(:last-child) {
       margin-right: 15px;
     }
 
@@ -228,4 +226,17 @@ button {
   font-size: 16px;
   text-decoration: underline;
   padding-top: 1px;
+}
+
+
+.builder-navbar-wrapper__bottom-right {
+  // padding: 0 0 10px 0;
+}
+
+.builder-navbar-wrapper__bottom-right__admin-badge {
+  background: linear-gradient(45deg, #fea200, #ffd000);
+  color: #ffffff;
+  padding: 5px 10px;
+  border-radius: 2px;
+  font-size: 16px;
 }

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
@@ -108,7 +108,7 @@ button {
     align-items: center;
     justify-content: flex-end;
 
-    &>*:not(:last-child) {
+    & > *:not(:last-child) {
       margin-right: 15px;
     }
 

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.scss
@@ -74,7 +74,6 @@ button {
 .builder-navbar-wrapper {
   background: white;
   padding: 35px 25px 0;
-  // padding: 65px 25px 0;
   width: 100%;
   margin-bottom: 25px;
   box-shadow: 0 2px 4px 0 rgba(136, 135, 135, 0.3);

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
@@ -38,6 +38,8 @@ export class BuilderNavbarComponent implements OnDestroy {
 
   destroyed$: Subject<void> = new Subject();
 
+  @Input() adminMode = false;
+
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
@@ -46,7 +48,7 @@ export class BuilderNavbarComponent implements OnDestroy {
     private collectionService: CollectionService,
     private contextMenuService: ContextMenuService,
     public validator: LearningObjectValidator,
-    public store: BuilderStore,
+    public store: BuilderStore
   ) {
     // subscribe to the serviceInteraction observable to display in the client when the application
     // is interacting with the service
@@ -60,16 +62,20 @@ export class BuilderNavbarComponent implements OnDestroy {
         }
       });
 
-    this.store.learningObjectEvent.pipe(
-      filter(val => typeof val !== 'undefined'),
-      takeUntil(this.destroyed$)
-    ).subscribe(val => {
-      this.learningObject = val;
-      this.collectionService.getCollection(this.learningObject.collection).then(col => {
-        this.collection = col;
-        this.buildTooltip();
+    this.store.learningObjectEvent
+      .pipe(
+        filter(val => typeof val !== 'undefined'),
+        takeUntil(this.destroyed$)
+      )
+      .subscribe(val => {
+        this.learningObject = val;
+        this.collectionService
+          .getCollection(this.learningObject.collection)
+          .then(col => {
+            this.collection = col;
+            this.buildTooltip();
+          });
       });
-    });
 
     // check to see if we're editing a learning object or creating a new one by checking for an id in the url
     this.editing = !!this.activatedRoute.snapshot.params['learningObjectId'];
@@ -84,7 +90,11 @@ export class BuilderNavbarComponent implements OnDestroy {
   toggleSubmissionOptionsMenu(event: MouseEvent) {
     if (this.submissionOptionsMenu) {
       if (event && !this.showSubmissionOptions) {
-        this.contextMenuService.open(this.submissionOptionsMenu, (event.currentTarget as HTMLElement), { top: 5, left: 0 });
+        this.contextMenuService.open(
+          this.submissionOptionsMenu,
+          event.currentTarget as HTMLElement,
+          { top: 5, left: 0 }
+        );
       } else {
         this.contextMenuService.destroy(this.submissionOptionsMenu);
       }
@@ -110,7 +120,11 @@ export class BuilderNavbarComponent implements OnDestroy {
         result = this.validator.saveable && this.store.touched;
         break;
       case 'materials':
-        result = !!(this.auth.user.emailVerified && this.validator.saveable && this.store.touched);
+        result = !!(
+          this.auth.user.emailVerified &&
+          this.validator.saveable &&
+          this.store.touched
+        );
         break;
     }
 
@@ -135,7 +149,11 @@ export class BuilderNavbarComponent implements OnDestroy {
    * @memberof BuilderNavbarComponent
    */
   isNewRoute(route: string) {
-    return !this.initialRouteStates.get(route) && this.firstRouteChanges.has(route) && !this.routesClicked.has(route);
+    return (
+      !this.initialRouteStates.get(route) &&
+      this.firstRouteChanges.has(route) &&
+      !this.routesClicked.has(route)
+    );
   }
 
   /**
@@ -168,12 +186,20 @@ export class BuilderNavbarComponent implements OnDestroy {
 
         // check for submission errors not related to outcomes
         if (
-          this.validator.errors.submitErrors.size > 1 || (this.validator.errors.submitErrors.size === 1 && !this.validator.get('outcomes'))) {
+          this.validator.errors.submitErrors.size > 1 ||
+          (this.validator.errors.submitErrors.size === 1 &&
+            !this.validator.get('outcomes'))
+        ) {
           errorPages.set('info', true);
         }
 
         // notify user
-        this.toasterService.notify('Error!', 'Please correct the errors and try again!', 'bad', 'far fa-times');
+        this.toasterService.notify(
+          'Error!',
+          'Please correct the errors and try again!',
+          'bad',
+          'far fa-times'
+        );
 
         if (errorPages.size && !errorPages.get(currentRoute)) {
           // we've found errors on other pages and none on our current page, so route to that page
@@ -205,51 +231,53 @@ export class BuilderNavbarComponent implements OnDestroy {
    * @memberof BuilderNavbarComponent
    */
   buildTooltip() {
-    this.collectionService.getCollection(this.learningObject.collection).then(val => {
-      this.states = new Map([
-        [
-          LearningObject.Status.REJECTED,
-          {
-            tip:
-              'This learning object was rejected. Contact your review team for further information'
-          }
-        ],
-        [
-          LearningObject.Status.RELEASED,
-          {
-            tip:
-              'This learning object is published to the ' +
-              (val ? val.name : '') +
-              ' collection and can be browsed for.'
-          }
-        ],
-        [
-          LearningObject.Status.REVIEW,
-          {
-            tip:
-              'This object is currently under review by the ' +
-              (val ? val.name : '') +
-              ' review team, It is not yet published and cannot be edited until the review process is complete.'
-          }
-        ],
-        [
-          LearningObject.Status.WAITING,
-          {
-            tip:
-              'This learning object is waiting to be reviewed by the next available reviewer from the ' +
-              (val ? val.name : '') +
-              ' review team'
-          }
-        ],
-        [
-          LearningObject.Status.UNRELEASED,
-          {
-            tip:
-              'This learning object is visible only to you. Submit it for review to make it publicly available.'
-          }
-        ]
-      ]);
-    });
+    this.collectionService
+      .getCollection(this.learningObject.collection)
+      .then(val => {
+        this.states = new Map([
+          [
+            LearningObject.Status.REJECTED,
+            {
+              tip:
+                'This learning object was rejected. Contact your review team for further information'
+            }
+          ],
+          [
+            LearningObject.Status.RELEASED,
+            {
+              tip:
+                'This learning object is published to the ' +
+                (val ? val.name : '') +
+                ' collection and can be browsed for.'
+            }
+          ],
+          [
+            LearningObject.Status.REVIEW,
+            {
+              tip:
+                'This object is currently under review by the ' +
+                (val ? val.name : '') +
+                ' review team, It is not yet published and cannot be edited until the review process is complete.'
+            }
+          ],
+          [
+            LearningObject.Status.WAITING,
+            {
+              tip:
+                'This learning object is waiting to be reviewed by the next available reviewer from the ' +
+                (val ? val.name : '') +
+                ' review team'
+            }
+          ],
+          [
+            LearningObject.Status.UNRELEASED,
+            {
+              tip:
+                'This learning object is visible only to you. Submit it for review to make it publicly available.'
+            }
+          ]
+        ]);
+      });
   }
 
   /**
@@ -258,22 +286,30 @@ export class BuilderNavbarComponent implements OnDestroy {
    */
   submitForReview(collection: string) {
     this.submissionError = false;
-    this.store.submitForReview(collection).then(val => {
-      this.showSubmission = false;
-      this.toasterService.notify('Success!', 'Learning object submitted successfully!', 'good', 'far fa-check');
-    }).catch(error => {
-      console.error(error);
-      this.toasterService.notify('Error!', error, 'bad', 'far fa-times');
-      this.showSubmission = false;
-      this.submissionError = true;
-    });
+    this.store
+      .submitForReview(collection)
+      .then(val => {
+        this.showSubmission = false;
+        this.toasterService.notify(
+          'Success!',
+          'Learning object submitted successfully!',
+          'good',
+          'far fa-check'
+        );
+      })
+      .catch(error => {
+        console.error(error);
+        this.toasterService.notify('Error!', error, 'bad', 'far fa-times');
+        this.showSubmission = false;
+        this.submissionError = true;
+      });
   }
 
   /**
    * Return a learning object to unpublished status
    */
   cancelSubmission() {
-    this.store.cancelSubmission()
+    this.store.cancelSubmission();
   }
 
   ngOnDestroy() {

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.html
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.html
@@ -10,11 +10,12 @@
     <div class="materials-slides">
       <div [@fadeIn] *ngIf="slide === 1" class="slide slide1">
         <div *ngIf="solutionUpload" class="solutions-warning">
-          Note: While the upload of solution files are not prohibited, they won't be included during a learning object's download.
+          Note: While the upload of solution files are not prohibited, they won't be included during a learning
+          object's download.
         </div>
         <!-- This element has a dropzone tag as a backup in case the browser doesn't support the dragover event or something goes wrong -->
         <onion-file-manager *ngIf="!retrieving; else loadingTemplate" [confirmDeletion]="confirmDeletion$" [files$]="files$"
-          [folderMeta$]="folderMeta$" (openDZ)="openDZ()" (fileDeleted)="handleDeletion($event)" (fileEdited)="handleEdit($event)"
+          [folderMeta$]="folderMeta$" (openDZ)="openDZ()" (fileDeleted)="handleDeleteGenerator = handleDeletion($event); handleDeleteGenerator.next()" (fileEdited)="handleEdit($event)"
           (path)="openPath=$event" (solutionUpload)="handleSolution($event)"></onion-file-manager>
       </div>
       <div [@fadeIn] *ngIf="slide === 2" class="slide slide2">
@@ -38,9 +39,10 @@
   </div>
 
   <clark-teleporter>
-    <div #teleporterPayload class="uploader" [ngClass]="{'dragging': showDragMenu, 'dropped': dropped}" [dropzone]="config" (drop)="handleDrop()"
-      (addedFile)="addFile($event)" (dragLeave)="toggleDrag(false)" (sending)="fileSending($event)" (uploadProgress)="uploadProgress($event)"
-      (complete)="dzComplete($event)" (success)="uploadSuccess()" (queueComplete)="queueComplete($event)" (error)="handleError($event)">
+    <div #teleporterPayload class="uploader" [ngClass]="{'dragging': showDragMenu, 'dropped': dropped}" [dropzone]="config"
+      (drop)="handleDrop()" (addedFile)="addFile($event)" (dragLeave)="toggleDrag(false)" (sending)="fileSending($event)"
+      (uploadProgress)="uploadProgress($event)" (complete)="dzComplete($event)" (success)="uploadSuccess()"
+      (queueComplete)="queueComplete($event)" (error)="handleError($event)">
       <div class="uploader-content">
         <div class="uploader-icon">
           <i class='far fa-arrow-up'></i>
@@ -59,3 +61,16 @@
     </div>
   </ng-template>
 </div>
+
+
+<!-- Delete Confirmation Popup -->
+<clark-popup *ngIf="showDeletePopup" (closed)="cancelDeletion()">
+  <div #popupInner class="popup-inner">
+    <div class="modal-title">Are you sure?</div>
+    <div class="modal-text">You cannot undo this action!</div>
+    <div class="btn-group center">
+      <button class="button bad" (click)="confirmDeletion()">Yep, do it! <i class="far fa-trash"></i></button>
+      <button class="button neutral" (click)="cancelDeletion()">Wait, nevermind! <i class="far fa-ban"></i></button>
+    </div>
+  </div>
+</clark-popup>

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -1,5 +1,4 @@
-
-import {takeUntil, debounceTime, take} from 'rxjs/operators';
+import { takeUntil, debounceTime, take } from 'rxjs/operators';
 import { trigger, style, animate, transition } from '@angular/animations';
 import {
   Component,
@@ -19,16 +18,11 @@ import {
 import { ToasterService } from '../../../../../../shared/toaster';
 import { environment } from '../../environments/environment';
 import { TOOLTIP_TEXT } from '@env/tooltip-text';
-import {
-  LearningObject,
-} from '@cyber4all/clark-entity';
-import { BehaviorSubject ,  fromEvent ,  Observable ,  Subject } from 'rxjs';
-
-
+import { LearningObject } from '@cyber4all/clark-entity';
+import { BehaviorSubject, fromEvent, Observable, Subject } from 'rxjs';
 
 import {
   ModalService,
-  ModalListElement
 } from '../../../../../../shared/modals';
 import { USER_ROUTES } from '@env/route';
 import { getPaths } from '../../../../../../shared/filesystem/file-functions';
@@ -60,11 +54,17 @@ export type DZFile = {
     trigger('uploadQueue', [
       transition(':enter', [
         style({ transform: 'translateY(20px)', opacity: 0 }),
-        animate('200ms 200ms ease-out', style({ transform: 'translateY(0px)', opacity: 1 }))
+        animate(
+          '200ms 200ms ease-out',
+          style({ transform: 'translateY(0px)', opacity: 1 })
+        )
       ]),
       transition(':leave', [
         style({ transform: 'translateY(-0px)', opacity: 1 }),
-        animate('200ms ease-out', style({ transform: 'translateY(20px)', opacity: 0 }))
+        animate(
+          '200ms ease-out',
+          style({ transform: 'translateY(20px)', opacity: 0 })
+        )
       ])
     ])
   ]
@@ -90,7 +90,10 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   @Output()
   urlAdded: EventEmitter<void> = new EventEmitter<void>();
   @Output()
-  urlUpdated: EventEmitter<{ index: string; url: LearningObject.Material.Url }> = new EventEmitter<{
+  urlUpdated: EventEmitter<{
+    index: string;
+    url: LearningObject.Material.Url;
+  }> = new EventEmitter<{
     index: string;
     url: LearningObject.Material.Url;
   }>();
@@ -130,11 +133,11 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   };
 
   files$: BehaviorSubject<LearningObject.Material.File[]> = new BehaviorSubject<
-  LearningObject.Material.File[]
+    LearningObject.Material.File[]
   >([]);
-  folderMeta$: BehaviorSubject<LearningObject.Material.FolderDescription[]> = new BehaviorSubject<
-  LearningObject.Material.FolderDescription[]
-  >([]);
+  folderMeta$: BehaviorSubject<
+    LearningObject.Material.FolderDescription[]
+  > = new BehaviorSubject<LearningObject.Material.FolderDescription[]>([]);
 
   inProgressFileUploads = [];
   inProgressFolderUploads = [];
@@ -145,11 +148,12 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
 
   openPath: string;
 
-  private uploadIds = {
-
-  };
-
   solutionUpload = false;
+
+  showDeletePopup = false;
+  handleDeleteGenerator: Iterator<void>;
+
+  private uploadIds = {};
 
   constructor(
     private notificationService: ToasterService,
@@ -159,23 +163,27 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.learningObject$.pipe(takeUntil(this.unsubscribe$)).subscribe(object => {
-      if (object) {
-        this.config.url = USER_ROUTES.POST_FILE_TO_LEARNING_OBJECT(object.id);
-        this.files$.next(object.materials.files);
-        this.folderMeta$.next(object.materials.folderDescriptions);
-        this.solutionUpload = false;
-        this.files$.value.forEach(file => {
-          if (file.name.toLowerCase().indexOf('solution') >= 0) {
-            this.solutionUpload = true;
-          }
-        });
-      }
-    });
+    this.learningObject$
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(object => {
+        if (object) {
+          this.config.url = USER_ROUTES.POST_FILE_TO_LEARNING_OBJECT(object.id);
+          this.files$.next(object.materials.files);
+          this.folderMeta$.next(object.materials.folderDescriptions);
+          this.solutionUpload = false;
+          this.files$.value.forEach(file => {
+            if (file.name.toLowerCase().indexOf('solution') >= 0) {
+              this.solutionUpload = true;
+            }
+          });
+        }
+      });
 
-    this.notes$.pipe(
-      takeUntil(this.unsubscribe$),
-      debounceTime(650), )
+    this.notes$
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        debounceTime(650)
+      )
       .subscribe(notes => {
         this.notesUpdated.emit(notes);
       });
@@ -192,8 +200,8 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngAfterViewInit() {
     // create an observable from the dragover event and subscribe to it to show the dropzone popover
-    fromEvent(document.getElementsByTagName('body')[0], 'dragover').pipe(
-      takeUntil(this.unsubscribe$))
+    fromEvent(document.getElementsByTagName('body')[0], 'dragover')
+      .pipe(takeUntil(this.unsubscribe$))
       .subscribe((event: any) => {
         const types = event.dataTransfer.types;
         if (types.filter(x => x === 'Files').length >= 1) {
@@ -202,8 +210,8 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
       });
 
     // create an observable from the dragover event and subscribe to it to show the dropzone popover
-    fromEvent(document.getElementsByTagName('body')[0], 'dragleave').pipe(
-      takeUntil(this.unsubscribe$))
+    fromEvent(document.getElementsByTagName('body')[0], 'dragleave')
+      .pipe(takeUntil(this.unsubscribe$))
       .subscribe((event: any) => {
         if (event.target.classList.contains('uploader')) {
           this.toggleDrag(false);
@@ -285,8 +293,10 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
         );
         if (file.upload.chunked) {
           // Request multipart upload
-          const learningObject = await this.learningObject$.pipe(take(1)).toPromise();
-          const uploadId  = await this.fileStorage.initMultipart({
+          const learningObject = await this.learningObject$
+            .pipe(take(1))
+            .toPromise();
+          const uploadId = await this.fileStorage.initMultipart({
             learningObject,
             fileId: file.upload.uuid,
             filePath: file.fullPath ? file.fullPath : file.name
@@ -364,7 +374,9 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           mimetype: file.type
         };
         const uploadId = this.uploadIds[file.upload.uuid];
-        const learningObject = await this.learningObject$.pipe(take(1)).toPromise();
+        const learningObject = await this.learningObject$
+          .pipe(take(1))
+          .toPromise();
         await this.fileStorage.finalizeMultipart({
           fileMeta,
           learningObject,
@@ -524,23 +536,10 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    * @returns {Promise<void>}
    * @memberof UploadComponent
    */
-  async handleDeletion(files: string[]): Promise<void> {
-    const confirmed = await this.modalService
-      .makeDialogMenu(
-        'materialDelete',
-        'Are you sure?',
-        'You cannot undo this action!',
-        false,
-        'title-bad',
-        'center',
-        [
-          new ModalListElement('Yup, do it!', 'confirm', 'bad'),
-          new ModalListElement('Nevermind!', 'cancel', 'neutral')
-        ]
-      )
-      .toPromise();
-
-    if (confirmed === 'confirm') {
+  async *handleDeletion(files: string[]) {
+    this.showDeleteConfirmation();
+    const confirmed: boolean = yield;
+    if (confirmed) {
       this.saving$.next(true);
       try {
         const object = await this.learningObject$.pipe(take(1)).toPromise();
@@ -555,6 +554,44 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
       }
       this.saving$.next(false);
     }
+  }
+
+  /**
+   * Handles showing deletion confirmation modal
+   *
+   * @memberof UploadComponent
+   */
+  showDeleteConfirmation() {
+    this.showDeletePopup = true;
+  }
+
+  /**
+   * Handles hiding deletion confirmation modal
+   *
+   * @memberof UploadComponent
+   */
+  hideDeleteConfirmation() {
+    this.showDeletePopup = false;
+  }
+
+  /**
+   * Confirms deletion
+   *
+   * @memberof UploadComponent
+   */
+  confirmDeletion() {
+    this.handleDeleteGenerator.next(true);
+    this.hideDeleteConfirmation();
+  }
+
+  /**
+   * Cancels deletion
+   *
+   * @memberof UploadComponent
+   */
+  cancelDeletion() {
+    this.handleDeleteGenerator.next(false);
+    this.hideDeleteConfirmation();
   }
 
   /**

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.html
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.html
@@ -1,6 +1,6 @@
 <clark-toaster [content]="noteService.content"></clark-toaster>
 <div class="learning-object-builder-wrapper" [@builderTransition]="getState(o)">
-  <onion-builder-navbar *ngIf="true"></onion-builder-navbar>
+  <onion-builder-navbar [adminMode]="adminMode"></onion-builder-navbar>
   <router-outlet #o="outlet"></router-outlet>
 </div>
 


### PR DESCRIPTION
This PR adds routing and authorization logic to clark-client to allow admins/editors to access the builder and edit other users' Learning Objects.

Closes #668 

**Notable UI changes** 
- "Submit/Save" button was replaced with "Editor Mode" badge to indicate the admin/editor is editing an object that is not their own. 
- "Back to Dashboard" button will route to admin dashboard while in "Editor Mode".

![screenshot from 2019-02-26 17-25-49](https://user-images.githubusercontent.com/15234476/53451230-53a68d80-39ec-11e9-9719-bb646cbbd9c8.png)
