### PR TITLE
Hide revise button if Learning Object is released

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/action-panel/action-panel.component.ts
@@ -75,7 +75,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     this.auth.group
       .pipe(takeUntil(this.destroyed$))
       .subscribe(() => {
-        this.isEditButtonViewable = this.auth.hasEditorAccess();
+        this.isEditButtonViewable = this.learningObject.status !== LearningObject.Status.RELEASED && this.auth.hasEditorAccess();
       });
     this.hasDownloadAccess = this.auth.hasReviewerAccess() || this.isReleased;
     this.url = this.buildLocation();


### PR DESCRIPTION
This PR hides the "Revise" button if the Learning Object is released. 
This is to prevent accidental modification of a released Learning Object. This functionality is currently unsupported by the system as those changes will only be applied to the working copy of the Learning Object.

**Notable UI Changes**
- Hidden "Revise" button when Learning Object is released.

![screenshot from 2019-02-27 12-17-44](https://user-images.githubusercontent.com/15234476/53509560-07118f80-3a8a-11e9-9f36-9694a44faa52.png)
