### PR TITLE
Fix files not appearing on details page when navigating to a Learning Object that has files with the same path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -34,7 +34,6 @@ export class DirectoryTree {
         }
         return true;
       });
-
     const newFiles = getUpdatedFiles(files);
     for (const file of newFiles) {
       this.fileMap.set(file.id, {
@@ -65,10 +64,36 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   private cleanFilesystem(files: LearningObject.Material.File[]) {
-    const fileIds = files.map(file => file.id);
+    /**
+     * Checks if file is in array by matching against id and path
+     *
+     * @param {{
+     *       cachedFileData: { id: string; path: string };
+     *       file: LearningObject.Material.File
+     *     }} params
+     * @returns {boolean}
+     */
+    const findFile = (params: {
+      cachedFileData: { id: string; path: string };
+      file: LearningObject.Material.File;
+    }): boolean => {
+      const { cachedFileData, file } = params;
+      const filePath = file.fullPath || file.name;
+      return cachedFileData.id === file.id || cachedFileData.path === filePath;
+    };
+
     const folderPaths = [];
+
+    // Remove file for file system and cache
     this.fileMap.forEach((mappedFile, mappedId) => {
-      if (!fileIds.includes(mappedId)) {
+      const fileExists = files.find(file =>
+        findFile({
+          file,
+          cachedFileData: { id: mappedId, path: mappedFile.path }
+        })
+      );
+
+      if (!fileExists) {
         this.removeFile(mappedFile.path);
         this.fileMap.delete(mappedId);
         const folderPath = getPaths(mappedFile.path).join('/');
@@ -77,6 +102,8 @@ export class DirectoryTree {
         }
       }
     });
+
+    // Remove empty folders leftover from file removal
     for (const path of folderPaths) {
       const paths = getPaths(path, false);
       const node = this.traversePath(paths);

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -67,10 +67,6 @@ export class DirectoryTree {
     /**
      * Checks if file is in array by matching against id and path
      *
-     * @param {{
-     *       cachedFileData: { id: string; path: string };
-     *       file: LearningObject.Material.File
-     *     }} params
      * @returns {boolean}
      */
     const findFile = (params: {

--- a/src/app/shared/filesystem/file-browser/file-browser.component.ts
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { BehaviorSubject ,  Subscription } from 'rxjs';
+import { BehaviorSubject, Subscription } from 'rxjs';
 import { DirectoryNode, DirectoryTree } from '../DirectoryTree';
 import { LearningObject } from '@cyber4all/clark-entity';
 import { getPaths } from '../file-functions';
@@ -135,7 +135,8 @@ export class FileBrowserComponent implements OnInit {
    */
   private refreshNode(): void {
     const path = this.currentPath$.getValue();
-    this.currentNode$.next(this.filesystem.traversePath(path));
+    const node = this.filesystem.traversePath(path);
+    this.currentNode$.next(node);
     this.path.emit(path.join('/'));
   }
   /**


### PR DESCRIPTION
This PR fixes an issue in the file system where files with different `id`s, but the same path added back to back would not appear in the file browser. 

This occurred because the file system performed its clean operation after adding nodes to clear cached file references and remove files that should no longer exist. When a new array of files are added, the file system would compare the new files against what it has in its cache by the files' ids. This would trigger a delete operation of that file at the path stored in the cache. When the path of the new file and cached file were the same, the file system would end up removing the new file while attempting to remove the cached file (b/c paths are unique in the file system's context).

This was fixed by comparing both id and path before removing.

Closes #641 