### PR TITLE
Implement sidebar component in collection dashboard

### DIFF
--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -1,6 +1,11 @@
 <div class="admin">
   <div class="admin__sidebar">
-    <clark-admin-sidebar></clark-admin-sidebar>
+    <clark-admin-sidebar
+      [authorizedCollections]="authorizedCollections"
+      [activeCollection]="activeCollection"
+      [initialized]="initialized"
+      [adminMode]="adminMode"
+    ></clark-admin-sidebar>
   </div>
   <div class="admin__main-content">
     <router-outlet></router-outlet>

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -60,7 +60,9 @@ export class AdminComponent implements OnInit, OnDestroy {
 
       this.retrieveAuthorizedCollections().then(() => {
         // collections array is now set and we should redirect to the first collection
-        this.router.navigate([this.authorizedCollections[0].abvName], { relativeTo: this.route });
+        if (!this.activeCollection) {
+          this.router.navigate([this.authorizedCollections[0].abvName], { relativeTo: this.route });
+        }
       });
     }
   }
@@ -75,9 +77,10 @@ export class AdminComponent implements OnInit, OnDestroy {
     return await this.authService.isLoggedIn.pipe(
       skipWhile(x => x === false),
       take(1)
-    ).subscribe(async () => {
+    ).toPromise().then(async () => {
       // we're sure the user is logged in here and so access groups should be defined
-      return await Promise.all(this.authService.user['accessGroups']
+      return await Promise.all(
+        this.authService.user['accessGroups']
         .filter(group => group.includes('curator@'))
         .map(group =>
           this.collectionService.getCollection(group.split('@')[1]).then(c => this.authorizedCollections.push(c))

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { NavbarService } from 'app/core/navbar.service';
+import { Subject } from 'rxjs';
+import { ActivatedRoute, Router } from '@angular/router';
+import { takeUntil, skipWhile, take } from 'rxjs/operators';
+import { AuthService } from 'app/core/auth.service';
+import { CollectionService, Collection } from 'app/core/collection.service';
+
 
 @Component({
   selector: 'clark-admin',
@@ -7,15 +13,72 @@ import { NavbarService } from 'app/core/navbar.service';
   styleUrls: ['./admin.component.scss']
 })
 export class AdminComponent implements OnInit, OnDestroy {
+  destroyed$: Subject<void> = new Subject();
 
-  constructor(private navbarService: NavbarService) { }
+  authorizedCollections: Collection[] = [];
+  activeCollection: string;
+
+  adminMode: boolean;
+
+  private _initialized: boolean[] = [false];
+
+  constructor(
+    private navbarService: NavbarService,
+    private router: Router,
+    private route: ActivatedRoute,
+    private authService: AuthService,
+    private collectionService: CollectionService
+  ) {}
+
+  get initialized(): boolean {
+    return !this._initialized.includes(false);
+  }
 
   ngOnInit() {
+    // hide CLARK navbar
     this.navbarService.hide();
+
+    if (this.authService.hasEditorAccess()) {
+      this.adminMode = true;
+    } else {
+      // fetch the route parameter representing the selected collection
+      this.route.paramMap
+        .pipe(takeUntil(this.destroyed$))
+        .subscribe(params => {
+          // we don't need to authorize here since that's done in the route guard
+          this.activeCollection = params.get('collection');
+        });
+
+      this.retrieveAuthorizedCollections().then(() => {
+        console.log(this.authorizedCollections);
+        // collections array is not set and we should redirect to the first collection
+        this.router.navigate([this.authorizedCollections[0].abvName], { relativeTo: this.route });
+      });
+    }
+  }
+
+  /**
+   * Retrieve a list of collection names for which the user is authorized to view (has curator status for)
+   *
+   * @memberof AdminComponent
+   */
+  async retrieveAuthorizedCollections() {
+    return await this.authService.isLoggedIn.pipe(
+      skipWhile(x => x === false),
+      take(1)
+    ).subscribe(async () => {
+      // we're sure the user is logged in here and so access groups should be defined
+      return await Promise.all(this.authService.user['accessGroups']
+        .filter(group => group.includes('curator@'))
+        .map(group =>
+          this.collectionService.getCollection(group.split('@')[1]).then(c => this.authorizedCollections.push(c))
+        )).then(() => {
+          this._initialized[0] = true;
+        });
+    });
   }
 
   ngOnDestroy() {
     this.navbarService.show();
   }
-
 }

--- a/src/app/admin/admin.routing.ts
+++ b/src/app/admin/admin.routing.ts
@@ -23,12 +23,12 @@ const admin_routes: Routes = [
       { path: '', redirectTo: 'analytics', pathMatch: 'full' }
     ],
   },
+  { path: ':collection', redirectTo: '/admin/:collection/analytics', pathMatch: 'full' },
   {
     path: ':collection', component: AdminComponent, children: [
       { path: 'analytics', component: AnalyticsComponent },
       { path: 'learning-objects', component: LearningObjectsComponent },
       { path: 'reviewers', component: UsersComponent },
-      { path: ':collection', redirectTo: '/admin/:collection/analytics' },
     ],
   },
 ];

--- a/src/app/admin/admin.routing.ts
+++ b/src/app/admin/admin.routing.ts
@@ -16,11 +16,20 @@ import { UsersComponent } from './pages/users/users.component';
 const admin_routes: Routes = [
   {
     path: '', component: AdminComponent, canActivate: [ AdminGuard ], children: [
-      // { path: 'analytics', component: AnalyticsComponent },
+      // TODO THESE NEED AN ADMIN GUARD TO PREVENT ACCESS BY CURATORS
+      { path: 'analytics', component: AnalyticsComponent },
       { path: 'learning-objects', component: LearningObjectsComponent },
-      // { path: 'users', component: UsersComponent },
-      { path: '**', redirectTo: 'learning-objects', pathMatch: 'full' }
-    ]
-  }
+      { path: 'users', component: UsersComponent },
+      { path: '', redirectTo: 'analytics', pathMatch: 'full' }
+    ],
+  },
+  {
+    path: ':collection', component: AdminComponent, children: [
+      { path: 'analytics', component: AnalyticsComponent },
+      { path: 'learning-objects', component: LearningObjectsComponent },
+      { path: 'reviewers', component: UsersComponent },
+      { path: ':collection', redirectTo: '/admin/:collection/analytics' },
+    ],
+  },
 ];
 export const AdminRoutingModule: ModuleWithProviders = RouterModule.forChild(admin_routes);

--- a/src/app/admin/components/sidebar/sidebar.component.html
+++ b/src/app/admin/components/sidebar/sidebar.component.html
@@ -5,8 +5,8 @@
     </a>
   </div>
   <div class="sidebar__bottom">
-    <div class="sidebar__menu">
-      <ng-container *ngTemplateOutlet="sidebarMenu"></ng-container>
+    <div *ngIf="initialized" class="sidebar__menu">
+      <ng-container *ngTemplateOutlet="!adminMode ? collectionMenu : sidebarMenu"></ng-container>
     </div>
   </div>
 </div>
@@ -17,4 +17,18 @@
     <a routerLink="./learning-objects" routerLinkActive="sidebar__menu--active"><li><i class="far fa-archive"></i>Objects</li></a>
     <a [routerLink]="adminMode ? './users' : './reviewers'" routerLinkActive="sidebar__menu--active"><li><i class="far fa-users"></i>{{ adminMode ? 'Users' : 'Reviewers' }}</li></a>
   </ul>
+</ng-template>
+
+<ng-template #collectionMenu>
+  <div  class="curator-menu" [ngClass]="{ 'curator-menu--active': activeCollection === collection.abvName }" *ngFor="let collection of authorizedCollections">
+    <a routerLink="../{{ collection.abvName }}">
+      <div class="curator-menu__title">
+        {{ collection.name }}
+        <i class="fas fa-chevron-right"></i>
+      </div>
+    </a>
+    <div [@sidebar] class="curator-menu__items" *ngIf="activeCollection === collection.abvName">
+      <ng-container *ngTemplateOutlet="sidebarMenu"></ng-container>
+    </div>
+  </div>
 </ng-template>

--- a/src/app/admin/components/sidebar/sidebar.component.html
+++ b/src/app/admin/components/sidebar/sidebar.component.html
@@ -20,7 +20,7 @@
 </ng-template>
 
 <ng-template #collectionMenu>
-  <div  class="curator-menu" [ngClass]="{ 'curator-menu--active': activeCollection === collection.abvName }" *ngFor="let collection of authorizedCollections">
+  <div  class="curator-menu" [ngClass]="{ 'curator-menu--active': activeCollection === collection.abvName }" *ngFor="let collection of collections">
     <a routerLink="../{{ collection.abvName }}">
       <div class="curator-menu__title">
         {{ collection.name }}

--- a/src/app/admin/components/sidebar/sidebar.component.html
+++ b/src/app/admin/components/sidebar/sidebar.component.html
@@ -6,11 +6,15 @@
   </div>
   <div class="sidebar__bottom">
     <div class="sidebar__menu">
-      <ul>
-        <!-- <a routerLink="analytics" routerLinkActive="sidebar__menu--active"><li><i class="far fa-chart-line"></i>Analytics</li></a> -->
-        <a routerLink="learning-objects" routerLinkActive="sidebar__menu--active"><li><i class="far fa-archive"></i>Objects</li></a>
-        <!-- <a routerLink="users" routerLinkActive="sidebar__menu--active"><li><i class="far fa-users"></i>Users</li></a> -->
-      </ul>
+      <ng-container *ngTemplateOutlet="sidebarMenu"></ng-container>
     </div>
   </div>
 </div>
+
+<ng-template #sidebarMenu>
+  <ul>
+    <a routerLink="./analytics" routerLinkActive="sidebar__menu--active"><li><i class="far fa-chart-line"></i>Analytics</li></a>
+    <a routerLink="./learning-objects" routerLinkActive="sidebar__menu--active"><li><i class="far fa-archive"></i>Objects</li></a>
+    <a [routerLink]="adminMode ? './users' : './reviewers'" routerLinkActive="sidebar__menu--active"><li><i class="far fa-users"></i>{{ adminMode ? 'Users' : 'Reviewers' }}</li></a>
+  </ul>
+</ng-template>

--- a/src/app/admin/components/sidebar/sidebar.component.scss
+++ b/src/app/admin/components/sidebar/sidebar.component.scss
@@ -109,7 +109,7 @@ a {
     }
   }
 
-  .curator-menu--active {
+  .curator-menu--active .curator-menu__title {
     .svg-inline--fa,
     .icon {
       transform: rotate(90deg);

--- a/src/app/admin/components/sidebar/sidebar.component.scss
+++ b/src/app/admin/components/sidebar/sidebar.component.scss
@@ -29,16 +29,16 @@ a {
 
     & > *:not(:last-child) {
       display: block;
-      margin-bottom: 10px;
+      margin-bottom: 5px;
     }
   }
-
+  .curator-menu__title,
   li {
-    padding: 12px 25px; 
+    padding: 10px 25px; 
     box-sizing: border-box;
     color: $light-text;
     list-style-type: none;
-    font-size: 18px;
+    font-size: 16px;
     position: relative;
     transition: all 0.2s ease;
 
@@ -64,13 +64,55 @@ a {
     }
   }
 
-  .sidebar__menu--active li {
-    background: rgba(red($bright-blue), green($bright-blue), blue($bright-blue), 0.15);
-    color: $bright-blue;
+  .sidebar__menu--active li,
+  .curator-menu--active .curator-menu__title {
+    position: relative;
+    background: rgba(red($bright-blue), green($bright-blue), blue($bright-blue), 0.13);
+    color: $bright-blue !important;
 
     &:before {
       opacity: 1;
       width: 4px;
+    }
+  }
+
+  .curator-menu__title {
+    color: $dark-text;
+    font-weight: 600;
+
+    .svg-inline--fa,
+    .icon {
+      font-size: 12px;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 20px;
+      margin: auto;
+      transition: all 0.2s ease;
+    }
+  }
+
+  .curator-menu li {
+    padding: 8px 20px 8px 45px;
+
+    &:hover {
+      color: inherit;
+    }
+  }
+
+  .curator-menu--active .sidebar__menu--active li {
+    background: transparent;
+
+    &:before {
+      opacity: 0;
+      width: 0px;
+    }
+  }
+
+  .curator-menu--active {
+    .svg-inline--fa,
+    .icon {
+      transform: rotate(90deg);
     }
   }
 }

--- a/src/app/admin/components/sidebar/sidebar.component.ts
+++ b/src/app/admin/components/sidebar/sidebar.component.ts
@@ -1,17 +1,32 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
-import { increaseElementDepthCount } from '@angular/core/src/render3/state';
+import { Collection } from 'app/core/collection.service';
+import { trigger, query, style, animate, transition } from '@angular/animations';
 
 @Component({
   selector: 'clark-admin-sidebar',
   templateUrl: './sidebar.component.html',
-  styleUrls: ['./sidebar.component.scss']
+  styleUrls: ['./sidebar.component.scss'],
+  animations: [
+    trigger('sidebar', [
+      transition('* => *', [
+        query(':enter', [
+          style({ opacity: 0, height: 0 }),
+          animate('200ms ease', style({ opacity: 1, height: '*' }))
+        ], { optional: true }),
+        query(':leave', [
+          style({ opacity: 1, height: '*' }),
+          animate('200ms ease', style({ opacity: 0, height: 0 }))
+        ], { optional: true })
+      ])
+    ])
+  ]
 })
 export class SidebarComponent implements OnInit, OnDestroy {
   destroyed$: Subject<void> = new Subject();
 
-  @Input() authorizedCollections: string[] = [];
+  @Input() authorizedCollections: Collection[] = [];
   @Input() activeCollection: string;
   @Input() adminMode: boolean;
 

--- a/src/app/admin/components/sidebar/sidebar.component.ts
+++ b/src/app/admin/components/sidebar/sidebar.component.ts
@@ -1,17 +1,25 @@
-import { Component, OnInit } from '@angular/core';
-import { Location } from '@angular/common';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
+import { increaseElementDepthCount } from '@angular/core/src/render3/state';
 
 @Component({
   selector: 'clark-admin-sidebar',
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })
-export class SidebarComponent implements OnInit {
+export class SidebarComponent implements OnInit, OnDestroy {
+  destroyed$: Subject<void> = new Subject();
 
-  constructor(private location: Location) { }
+  @Input() authorizedCollections: string[] = [];
+  @Input() activeCollection: string;
+  @Input() adminMode: boolean;
 
-  ngOnInit() {
-  }
+  @Input() initialized = false;
+
+  constructor(private router: Router) {}
+
+  ngOnInit() {}
 
   /**
    * Navigate to previous location
@@ -19,7 +27,13 @@ export class SidebarComponent implements OnInit {
    * @memberof SidebarComponent
    */
   navigateBack() {
-    this.location.back();
+    // TODO this should take a redirect URL
+    this.router.navigateByUrl('/'); // navigates home
   }
 
+  ngOnDestroy() {
+    // subscription clean up
+    this.destroyed$.next();
+    this.destroyed$.unsubscribe();
+  }
 }

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -14,7 +14,7 @@
             <div>Type</div>
             <div>Date</div>
           </div>
-          <div  [@listItem]="learningObjects.length">
+          <div>
             <clark-dashboard-item
               *ngFor="let l of learningObjects; let i = index"
               [learningObject]="l"

--- a/src/app/clark.routing.ts
+++ b/src/app/clark.routing.ts
@@ -13,4 +13,4 @@ const clark_routes: Routes = [
   { path: '**', redirectTo: '', pathMatch: 'full'},
 ];
 
-export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(clark_routes);
+export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(clark_routes, { enableTracing: true });

--- a/src/app/clark.routing.ts
+++ b/src/app/clark.routing.ts
@@ -13,4 +13,4 @@ const clark_routes: Routes = [
   { path: '**', redirectTo: '', pathMatch: 'full'},
 ];
 
-export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(clark_routes, { enableTracing: true });
+export const ClarkRoutingModule: ModuleWithProviders = RouterModule.forRoot(clark_routes);

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -363,14 +363,14 @@ export class AuthService {
    * @memberof AuthService
    */
   public hasCuratorAccess(): boolean {
-    return this.group.getValue() > AUTH_GROUP.CURATOR;
+    return this.group.getValue() > AUTH_GROUP.REVIEWER;
   }
 
   /**
    * Identifies if the current logged in user has editor privileges.
    */
   public hasEditorAccess(): boolean {
-    return this.group.getValue() > AUTH_GROUP.REVIEWER;
+    return this.group.getValue() > AUTH_GROUP.CURATOR;
   }
 
   /**


### PR DESCRIPTION
This PR implements the new sidebar for the collection dashboard

- Admins will see the correct three options (analytics, objects, users) across all collections
![screen shot 2019-03-01 at 1 34 50 pm](https://user-images.githubusercontent.com/7431390/53658442-cc912980-3c26-11e9-9a02-bf26bb970694.png)

- Curators will see a list all collections they curate for with a dropdown option.
![screen shot 2019-03-01 at 1 31 39 pm](https://user-images.githubusercontent.com/7431390/53658407-b4b9a580-3c26-11e9-9ed8-26f6a0d073aa.png)

Branched off of #688 so that should be merged first. First new commit is 8ddff72