### PR TITLE
Implement builder-store service error handling

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -733,8 +733,8 @@ export class BuilderStore {
       this.objectCache$.next(newValue);
     } else {
       const canSave =
-        !this.validator.saveable ||
-        (this.validator.submissionMode && !this.validator.submittable);
+        this.validator.saveable ||
+        (this.validator.submissionMode && this.validator.submittable);
       // don't attempt to save if object isn't saveable, but keep cache so that we can try again later
       if (!canSave) {
         return;
@@ -799,6 +799,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   private updateLearningObject(object: Partial<LearningObject>) {
+    this.serviceInteraction$.next(true);
     this.learningObjectService
       .save(this.learningObject.id, this.learningObject.author.username, object)
       .then(() => {
@@ -846,8 +847,6 @@ export class BuilderStore {
         return;
       }
 
-      this.serviceInteraction$.next(true);
-
       // clear the cache here so that new requests start a new cache
       this.outcomeCache$.next(undefined);
 
@@ -873,6 +872,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   private createLearningOutcome(newOutcome: LearningOutcome) {
+    this.serviceInteraction$.next(true);
     this.learningObjectService
       .addLearningOutcome(this.learningObject.id, newOutcome)
       .then((serviceId: string) => {
@@ -911,6 +911,7 @@ export class BuilderStore {
     }
     // delete any lingering serviceId properties before sending to service
     delete updateValue.serviceId;
+    this.serviceInteraction$.next(true);
     this.learningObjectService
       .saveOutcome(this.learningObject.id, updateValue as any)
       .then(() => {


### PR DESCRIPTION
This PR adds service interaction error handling within the builder-store by creating a public `Subject` that takes a type of `BUILDER_ERRORS`. 
The builder errors correspond to service actions that the builder store takes when processing an event trigger.

**Future Work**
The `serviceError$` subject will be subscribed to within the builder component. The builder will use the emitted enum value to display convey to the user the errors that have occurred.