### PR TITLE
Hotfix/object card right click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/learning-object/learning-object.component.html
+++ b/src/app/shared/learning-object/learning-object.component.html
@@ -1,28 +1,30 @@
-<div class="learning-object" id="learning-object" [ngClass]="learningObject.length" [routerLink]="['/details', learningObject.author.username, learningObject.name]">
-  <div class="image">
-    <div *ngIf="!loading" class="collection">
-      <div>
-        {{ collections.get(learningObject.collection) }}
+<a [routerLink]="['/details', learningObject.author.username, learningObject.name]">
+  <div class="learning-object" id="learning-object" [ngClass]="learningObject.length">
+    <div class="image">
+      <div *ngIf="!loading" class="collection">
+        <div>
+          {{ collections.get(learningObject.collection) }}
+        </div>
       </div>
+      <div class="initials">{{ learningObject.length.toUpperCase() }}</div>
     </div>
-    <div class="initials">{{ learningObject.length.toUpperCase() }}</div>
-  </div>
-  <div class="learning-object-content">
-    <div class="title">
-      {{ truncateText(learningObject.name, 45) }}
-      <button *ngIf="!loading && (auth.isLoggedIn | async) && canDownload" class="download-btn" (click)="download($event)"><i class="fas fa-download"></i></button>      
-    </div>
-    <div class="details">
-      <span class="author" [tip]="contributors" tipDisabled="{{ !contributorsDisplay }}">
-        {{ contributorsDisplay || contributors }}
-      </span>
-      <div class="date">
-        Updated {{ date | date:'mediumDate' }}
+    <div class="learning-object-content">
+      <div class="title">
+        {{ truncateText(learningObject.name, 45) }}
+        <button *ngIf="!loading && (auth.isLoggedIn | async) && canDownload" class="download-btn" (click)="download($event)"><i class="fas fa-download"></i></button>      
       </div>
+      <div class="details">
+        <span class="author" [tip]="contributors" tipDisabled="{{ !contributorsDisplay }}">
+          {{ contributorsDisplay || contributors }}
+        </span>
+        <div class="date">
+          Updated {{ date | date:'mediumDate' }}
+        </div>
+      </div>
+      <div class="goals" *ngIf="this.learningObject.description" [innerHtml]="goals()"></div>
     </div>
-    <div class="goals" *ngIf="this.learningObject.description" [innerHtml]="goals()"></div>
   </div>
-</div>
+</a>
 
 <clark-popup *ngIf="showDownloadModal" (closed)="toggleDownloadModal(false)">
   <div style="max-width: 600px;" #popupInner>

--- a/src/app/shared/learning-object/learning-object.component.scss
+++ b/src/app/shared/learning-object/learning-object.component.scss
@@ -1,5 +1,9 @@
 @import '~_vars.scss';
 
+a {
+  text-decoration: none;
+}
+
 @media (min-width: 751px) {
   :host.card {
     min-height: 350px;

--- a/src/app/shared/new-rating/new-rating.component.ts
+++ b/src/app/shared/new-rating/new-rating.component.ts
@@ -42,10 +42,6 @@ export class NewRatingComponent implements OnInit, OnChanges {
         this.advance();
       }
     }
-
-    if (changes.editing) {
-      console.log('editing', changes.editing.currentValue);
-    }
   }
 
   regress() {


### PR DESCRIPTION
Allows the user to right click a learning object card (featured and searched cards) and open the object in a new tab.

Closes #702 