### PR TITLE
Reimplement ability to view all learning objects from homepage

### DIFF
--- a/src/app/cube/home/home.component.html
+++ b/src/app/cube/home/home.component.html
@@ -14,10 +14,13 @@
     <div class="title__icon">
       <i class="far fa-cube"></i>
     </div>
-    Learning Objects
+    Recently Released<br /> Learning Objects
   </div>
   <div class="subtitle-text">
-    A Learning Object is a shareable, self-contained piece of curriculum that has clearly identified learning outcomes.
+    A Learning Object is a self-contained piece of curriculum that has clearly identified learning outcomes. 
+  </div>
+  <div class="browse-cta">
+    <a routerLink="/browse">View all Learning Objects</a>
   </div>
   <cube-featured></cube-featured>
 </div>

--- a/src/app/cube/home/home.component.scss
+++ b/src/app/cube/home/home.component.scss
@@ -66,6 +66,18 @@
     text-align: center;
   }
 
+  .browse-cta {
+    font-size: 18px;
+    text-align: center;
+
+    a {
+      color: $bright-blue;
+      font-size: 18px;
+      text-decoration: underline;
+      padding: 10px;
+    }
+  }
+
   & > * {
     display: block;
     position: relative;


### PR DESCRIPTION
This PR reimplements the ability for users to navigate to the browse page directly from the recently released section of the homepage.

![screencapture-localhost-4200-home-2019-03-11-13_51_01](https://user-images.githubusercontent.com/7431390/54145960-5dc18680-4405-11e9-8fd6-2c701a62bfa5.png)
