### PR TITLE
Implement the collection counter in the usage-stats component

### DIFF
--- a/src/app/cube/home/home.component.html
+++ b/src/app/cube/home/home.component.html
@@ -14,10 +14,13 @@
     <div class="title__icon">
       <i class="far fa-cube"></i>
     </div>
-    Learning Objects
+    Recently Released<br /> Learning Objects
   </div>
   <div class="subtitle-text">
-    A Learning Object is a shareable, self-contained piece of curriculum that has clearly identified learning outcomes.
+    A Learning Object is a self-contained piece of curriculum that has clearly identified learning outcomes. 
+  </div>
+  <div class="browse-cta">
+    <a routerLink="/browse">View all Learning Objects</a>
   </div>
   <cube-featured></cube-featured>
 </div>

--- a/src/app/cube/home/home.component.scss
+++ b/src/app/cube/home/home.component.scss
@@ -66,6 +66,18 @@
     text-align: center;
   }
 
+  .browse-cta {
+    font-size: 18px;
+    text-align: center;
+
+    a {
+      color: $bright-blue;
+      font-size: 18px;
+      text-decoration: underline;
+      padding: 10px;
+    }
+  }
+
   & > * {
     display: block;
     position: relative;

--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -61,6 +61,7 @@ export class UsageStatsComponent implements OnInit {
       this.usageStats.objects.released = stats.released;
       this.usageStats.objects.review = stats.review;
       this.usageStats.objects.downloads = stats.downloads;
+      this.usageStats.objects.collections = stats.collections;
       this.usageStats.objects.lengths = {
         nanomodule: stats.lengths.nanomodule,
         micromodule: stats.lengths.micromodule,
@@ -68,16 +69,12 @@ export class UsageStatsComponent implements OnInit {
         unit: stats.lengths.unit,
         course: stats.lengths.course
       };
-      this.usageStats.objects.outcomes = {
-        remember_and_understand: stats.outcomes.remember_and_understand,
-        apply_and_analyze: stats.outcomes.apply_and_analyze,
-        evaluate_and_synthesize: stats.outcomes.evaluate_and_synthesize
-      };
+
+      this.usageStats.objects.outcomes = stats.outcomes;
+
       this.buildCounterStats();
       this.buildOutcomeDistributionChart();
       this.buildLengthDistributionChart();
-
-      console.log(this.usageStats);
     });
 
     this.statsService.getUserStats().then(stats => {
@@ -96,9 +93,7 @@ export class UsageStatsComponent implements OnInit {
    */
   private buildCounterStats() {
     // Empty the array to avoid pushing duplicates
-    this.counterStats = [];
-    this.counterStats.push(
-      ...[
+    this.counterStats = [
         {
           title: 'Learning Objects Released',
           value: this.usageStats.objects.released
@@ -106,6 +101,10 @@ export class UsageStatsComponent implements OnInit {
         {
           title: 'Learning Objects Under Review',
           value: this.usageStats.objects.review
+        },
+        {
+          title: 'Quality-Assured Collections',
+          value: this.usageStats.objects.collections.number
         },
         {
           title: 'Users',
@@ -119,8 +118,7 @@ export class UsageStatsComponent implements OnInit {
           title: 'Downloads',
           value: this.usageStats.objects.downloads
         }
-      ]
-    );
+      ];
   }
 
   /**


### PR DESCRIPTION
This PR introduces the collection counter to the usage-stats component. This is branched off of design/homepage-redesign and thus #714 should be merged first.

![Screen Shot 2019-03-11 at 2 40 24 PM](https://user-images.githubusercontent.com/7431390/54148986-a4b27a80-440b-11e9-853d-9f3f196c0fab.png)


Requires #714 
Closes #632 