### PR TITLE
Fix bug where opening the builder before the children route has resolved causes angular template errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.15.5",
+  "version": "2.15.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.html
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.html
@@ -32,7 +32,7 @@
     </div>
   </ng-template>
 
-<ng-template [ngIf]="children.length == 0">
+<ng-template [ngIf]="children?.length == 0">
   <div class= "no-children">
     This learning object has no children  
   </div>


### PR DESCRIPTION
This PR addresses the bug where, upon opening the builder, a request is fired to load the object's children. In the time before that request resolves, the `children` object is undefined and thus has no property `length`. Accessing the `length` property from the template markup before the object is defined throws an error. This PR uses Angular's safety operator to ensure that the children object is defined before it attempts to access `.length`