### PR TITLE
Fix broken links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.15.6",
+  "version": "2.15.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -75,9 +75,10 @@ export class DetailsComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.route.params.pipe(takeUntil(this.isDestroyed$)).subscribe(params => {
+      const learningObjectName = decodeURIComponent(params['learningObjectName']);
       this.fetchLearningObject(
         params['username'],
-        params['learningObjectName']
+        learningObjectName,
       );
     });
 

--- a/src/app/cube/details/included-in/parent-listing.component.ts
+++ b/src/app/cube/details/included-in/parent-listing.component.ts
@@ -22,6 +22,6 @@ export class ParentListingComponent implements OnInit {
   ngOnInit() { }
 
   public buildLink(learningObject: LearningObject) {
-    return `/details/${learningObject.author.username}/${learningObject.name}`;
+    return `/details/${learningObject.author.username}/${encodeURIComponent(learningObject.name)}`;
   }
 }


### PR DESCRIPTION
This PR adds URL encoding to the learning object name field in the Included In component. This is done because we allow `/` characters in LO names, but they break URL structures if left in plain text.