### PR TITLE
Navigate to dashboard if accessed builder via url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -123,7 +123,14 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
 
       // if name parameter found, instruct store to fetch full learning object
       if (id) {
-        this.store.fetch(id).then(obj => this.setBuilderMode(obj));
+        this.store.fetch(id).then(obj => {
+          // redirect user to dashboard if the object is in the working stage
+          if (!obj.status.includes('waiting') && !obj.status.includes('review') && !obj.status.includes('proofing')) {
+            this.setBuilderMode(obj);
+          } else {
+            this.router.navigate(['onion/dashboard']);
+          }
+        });
       } else {
         // otherwise instruct store to initialize and store a blank learning object
         this.store.makeNew();


### PR DESCRIPTION
Navigates the user to their dashboard if they access a learning object in the builder via a URL when the object is in a working stage state.

Closes #737 