### PR TITLE
Filter unreleased parents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/included-in/included-in.service.ts
+++ b/src/app/cube/details/included-in/included-in.service.ts
@@ -1,16 +1,24 @@
 
-import {take} from 'rxjs/operators';
+import { map, take } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { PUBLIC_LEARNING_OBJECT_ROUTES } from '@env/route';
+import { LearningObject } from '@cyber4all/clark-entity';
 
 @Injectable()
 export class IncludedInService {
   constructor(private httpClient: HttpClient) { }
 
   fetchParents(id: string) {
-    return this.httpClient.get(PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id)).pipe(
-      take(1))
-      .toPromise();
+    return this.httpClient.get<LearningObject[]>(PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id))
+    .pipe(
+      take(1),
+      /* TODO: Remove this. 
+       * It is a stopcap until the service stops returning unreleased.
+       * More info at https://github.com/Cyber4All/learning-object-service/pull/282
+       */
+      map(parents => parents.filter(parent => parent.status !== 'unreleased')),
+    )
+    .toPromise();
   }
 }

--- a/src/app/cube/details/included-in/included-in.service.ts
+++ b/src/app/cube/details/included-in/included-in.service.ts
@@ -13,7 +13,7 @@ export class IncludedInService {
     return this.httpClient.get<LearningObject[]>(PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id))
     .pipe(
       take(1),
-      /* TODO: Remove this. 
+      /* TODO: Remove this.
        * It is a stopcap until the service stops returning unreleased.
        * More info at https://github.com/Cyber4All/learning-object-service/pull/282
        */


### PR DESCRIPTION
This PR puts a temporary solution in place for unreleased parent Learning Objects showing up on the details page of their released child. For now, the parents are bing filtered out client-side, since there is quite a bit more work to be done to get the service in a position to handle the data flows outlined in Cyber4All/learning-object-service#282.