### PR TITLE
Feature/remove bullets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
+++ b/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
@@ -26,11 +26,11 @@ export class OutcomeTypeaheadComponent implements OnInit, OnChanges, OnDestroy {
 
   menu = false;
 
-  //Create event emitters
+  // Create event emitters
   @Output() selectedVerb: EventEmitter<string> = new EventEmitter();
   @Output() selectedCategory: EventEmitter<string> = new EventEmitter();
   @Output() enteredText: EventEmitter<string> = new EventEmitter();
-  //this event emitter helps to change the overflow value from hidden to visible when the dropdown button is clicked
+  // this event emitter helps to change the overflow value from hidden to visible when the dropdown button is clicked
   @Output() overflowValue: EventEmitter<any> = new EventEmitter();
 
   /**
@@ -58,11 +58,11 @@ export class OutcomeTypeaheadComponent implements OnInit, OnChanges, OnDestroy {
         map((event) => (event.target as HTMLInputElement).value.trim()),
         takeUntil(this.componentDestroyed$)
       ).subscribe((val: string) => {
+        // remove bullets and update the text of the outcome
+        val = val.replace(/\d\.\s+|[a-z]\)\s+|•\s+|[A-Z]\.\s+|[IVX]+\.\s+/g, '');
+
         const index = val.indexOf(' ');
         this.text = val;
-
-        // remove bullets and update the text of the outcome
-        this.text = this.text.replace(/\d\.\s+|[a-z]\)\s+|•\s+|[A-Z]\.\s+|[IVX]+\.\s+/g, '');
 
         if (!this.verb) {
           // we haven't set a verb yet, let's set the verb now

--- a/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
+++ b/src/app/onion/learning-object-builder/components/outcome/outcome-typeahead/outcome-typeahead.component.ts
@@ -61,6 +61,9 @@ export class OutcomeTypeaheadComponent implements OnInit, OnChanges, OnDestroy {
         const index = val.indexOf(' ');
         this.text = val;
 
+        // remove bullets and update the text of the outcome
+        this.text = this.text.replace(/\d\.\s+|[a-z]\)\s+|•\s+|[A-Z]\.\s+|[IVX]+\.\s+/g, '');
+
         if (!this.verb) {
           // we haven't set a verb yet, let's set the verb now
           if (index >= 0) {


### PR DESCRIPTION
Remove bullets from outcomes so when a user pastes an outcome with a bullet the builder automatically strips it out of the outcome.

Closes #751 