### PR TITLE
Fix Editors being kicked from builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -290,6 +290,10 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
     return outlet.activatedRouteData.state;
   }
 
+  /**
+   * Determines whether or not a Learning Object is in the Review Stage.
+   * @param object the Learning Object in question.
+   */
   private isInReviewStage(object): boolean {
     return object.status.includes('waiting') && object.status.includes('review') && object.status.includes('proofing');
   }


### PR DESCRIPTION
Editors were no longer able to access the builder for an object in the Review Stage. This was due to editors' privileges not being considered in patch #744.

Resolves #770 