### PR TITLE
Implement pagination on learning objects page of collection dashboard

### DIFF
--- a/src/app/admin/components/user-search-wrapper/user-search-wrapper.component.ts
+++ b/src/app/admin/components/user-search-wrapper/user-search-wrapper.component.ts
@@ -60,7 +60,7 @@ export class UserSearchWrapperComponent implements OnInit, OnDestroy {
    */
   findUser(query: string) {
     if (query && query !== '') {
-      this.user.searchUsers(query).then((results: User[]) => {
+      this.user.searchUsers({ text: query }).then((results: User[]) => {
         // remove current user from results
         this.searchResults = results.filter(result => result.username !== this.authService.username);
         this.loading = false;

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -3,17 +3,17 @@
   <div page-title>Learning Objects</div>
   <clark-admin-search-bar search 
     [placeholder]="searchBarPlaceholder"
-    (userInput)="getLearningObjects($event)"
+    (userInput)="userSearchInput$.next()"
   ></clark-admin-search-bar>
   <clark-admin-filter-search filter-options
-    (statusFilter)="getStatusFilteredLearningObjects($event,true)"
-    (collectionFilter)="getCollectionFilteredLearningObjects($event,false)"
+    (statusFilter)="getStatusFilteredLearningObjects($event)"
+    (collectionFilter)="getCollectionFilteredLearningObjects($event)"
   ></clark-admin-filter-search>
 
   <div #list class="list" main>
     <div #listInner>
-      <div *ngIf="!loading; else loadingTemplate" class="list__body">
-        <div *ngIf="learningObjects?.length; else emptyTemplate">
+      <div class="list__body">
+        <div *ngIf="learningObjects?.length || loading; else emptyTemplate">
           <div #headers class="body__column-headers">
             <div>Status</div>
             <div>Name</div>
@@ -25,6 +25,8 @@
               #scroll 
               [style.height]="'calc(100vh - ' + listViewHeightOffset + 'px)'"
               [items]="learningObjects"
+              [bufferAmount]="query.limit"
+              (vsEnd)="scroll.viewPortInfo.startIndex && getLearningObjects($event);"
             >
               <clark-dashboard-item
                 *ngFor="let l of scroll.viewPortItems"
@@ -37,6 +39,10 @@
                 (changeStatus)="openChangeStatusModal($event)"
                 >
               </clark-dashboard-item>
+              <div [@nonListItem] class="loading-template">
+                <i class="far fa-spinner-third fa-spin"></i>
+                Loading learning objects...
+              </div>
             </virtual-scroller>    
         </div>
       </div>
@@ -78,10 +84,6 @@
   </clark-popup>
 
   <ng-template #loadingTemplate>
-    <div [@nonListItem] class="loading-template">
-      <i class="far fa-spinner-third fa-spin"></i>
-      Loading learning objects...
-    </div>
   </ng-template>
   
   <ng-template #emptyTemplate>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.scss
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.scss
@@ -80,12 +80,6 @@
     justify-content: center;
     text-align: center;
   
-    position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-  
     color: rgba(red($dark-text), green($dark-text), blue($dark-text), 0.6);
     font-size: 20px;
     padding: 20px;

--- a/src/app/admin/pages/users/users.component.ts
+++ b/src/app/admin/pages/users/users.component.ts
@@ -41,7 +41,7 @@ export class UsersComponent implements OnInit {
 
   getUsers(text?: string) {
     this.loading = true;
-    this.user.searchUsers(text)
+    this.user.searchUsers({ text })
       .then(val => {
         this.users = val;
         this.loading = false;

--- a/src/app/core/user.service.ts
+++ b/src/app/core/user.service.ts
@@ -7,6 +7,7 @@ import { User } from '@entity';
 import * as md5 from 'md5';
 import { Observable, throwError } from 'rxjs';
 import { retry, catchError } from 'rxjs/operators';
+import { UserQuery } from 'app/shared/interfaces/query';
 
 @Injectable()
 export class UserService {
@@ -144,7 +145,7 @@ export class UserService {
    * @returns {Promise<User[]} array of users matching the text query
    * @memberof UserService
    */
-  searchUsers(query: string): Promise<User[]> {
+  searchUsers(query: UserQuery): Promise<User[]> {
     return this.http
       .get(
         USER_ROUTES.SEARCH_USERS(query),

--- a/src/app/onion/learning-object-builder/components/user-dropdown/user-dropdown.component.ts
+++ b/src/app/onion/learning-object-builder/components/user-dropdown/user-dropdown.component.ts
@@ -86,7 +86,7 @@ export class UserDropdownComponent implements OnInit, DoCheck, OnDestroy {
    */
   findUser(query: string) {
     if (query && query !== '') {
-      this.userService.searchUsers(query).then((results: User[]) => {
+      this.userService.searchUsers({ text: query }).then((results: User[]) => {
         // remove current user from results
         for (let i = 0; i < results.length; i++) {
           if (this.authService.username === results[i].username) {

--- a/src/app/shared/dashboard-item/dashboard-item.component.ts
+++ b/src/app/shared/dashboard-item/dashboard-item.component.ts
@@ -4,7 +4,8 @@ import {
   Output,
   EventEmitter,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  ChangeDetectionStrategy
 } from '@angular/core';
 
 import { CollectionService } from 'app/core/collection.service';
@@ -17,7 +18,8 @@ import { LearningObject } from '@entity';
 @Component({
   selector: 'clark-dashboard-item',
   templateUrl: './dashboard-item.component.html',
-  styleUrls: ['./dashboard-item.component.scss']
+  styleUrls: ['./dashboard-item.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DashboardItemComponent implements OnChanges {
   @Input()

--- a/src/app/shared/interfaces/query.ts
+++ b/src/app/shared/interfaces/query.ts
@@ -33,3 +33,9 @@ export interface FilterQuery extends Query {
   length?: string[];
   level?: string[];
 }
+
+export interface UserQuery {
+  currPage?: number;
+  limit?: number;
+  text?: string;
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiURL: 'http://localhost:3000',
+  apiURL: 'https://api-gateway.clark.center',
   STATE_STORAGE_LOCATION: 'state',
   suggestionUrl: 'https://api-outcome-suggestion.clark.center',
   contentManagerURL: 'https://api-learning-objects.clark.center',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: true,
-  apiURL: 'https://api-gateway.clark.center',
+  apiURL: 'http://localhost:3000',
   STATE_STORAGE_LOCATION: 'state',
   suggestionUrl: 'https://api-outcome-suggestion.clark.center',
   contentManagerURL: 'https://api-learning-objects.clark.center',

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -55,8 +55,8 @@ export const USER_ROUTES = {
       username
     )}/learning-objects/profile`;
   },
-  SEARCH_USERS(query: string) {
-    return `${environment.apiURL}/users/search?text=${encodeURIComponent(query)}`;
+  SEARCH_USERS(query: {}) {
+    return `${environment.apiURL}/users/search?text=${encodeURIComponent(querystring.stringify(query))}`;
   },
   VALIDATE_TOKEN(username) {
     return `${environment.apiURL}/users/${encodeURIComponent(username)}/tokens`;


### PR DESCRIPTION
This PR introduces an "infinite scrolling" pagination to the Learning Objects page of the collection dashboard. When built without AOT, the app performs very sluggishly. I heavily recommend to merge the branch `performance/aot` into the base branch before deploying.