### PR TITLE
Fix bug where capital letters in emails are considered invalid in the registration page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.22.2",
+  "version": "2.22.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -338,7 +338,7 @@ export class RegisterComponent implements OnInit {
 
   getvalidEmail() {
     const email =
-      this.regForm.controls['email'].value.match(
+      this.regForm.controls['email'].value.toLowerCase().match(
         // tslint:disable-next-line:max-line-length
         /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/g
       ) !== null;


### PR DESCRIPTION
This PR addresses a bug wherein the registration validation breaks if a user's email contains capital letters. The regex used for comparison doesn't include capital letters. The fix is simply to lowercase the email string before comparison.