### PR TITLE
Add generic logos to collection submission selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.22.11",
+  "version": "2.22.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.22.11",
+  "version": "2.22.12",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/popups/templates/collection-selector/collection-selector.component.html
+++ b/src/app/shared/popups/templates/collection-selector/collection-selector.component.html
@@ -5,7 +5,7 @@
 <ng-container *ngIf="!loading; else loadingTemplate">
   <div *ngIf="collections; else noneTemplate" class="collection-chooser">
     <div *ngFor="let c of collections" class="collection-chooser__collection" [ngClass]="{'selected': currentCollection === c.abvName}" (click)="select(c.abvName)">
-      <div class="collection__logo" [ngStyle]="{backgroundImage: 'url(assets/images/collections/' + c.abvName + '.png)'}"></div>
+      <div class="collection__logo" *ngIf="c.abvName !== 'intro_to_cyber' && c.abvName !== 'secure_coding_community'; else genericLogoTemplate" [ngStyle]="{backgroundImage: 'url(assets/images/collections/' + c.abvName + '.png)'}"></div>
       <div class="collection__name">{{ c.name }}</div>
     </div>
   </div>
@@ -31,5 +31,11 @@
   <div class="none-template">
     <span><i class="far fa-times"></i></span>
     No collections found! This is probably an error.
+  </div>
+</ng-template>
+
+<ng-template #genericLogoTemplate>
+  <div class="collection__logo generic">
+    <i class="far fa-cubes"></i>
   </div>
 </ng-template>

--- a/src/app/shared/popups/templates/collection-selector/collection-selector.component.scss
+++ b/src/app/shared/popups/templates/collection-selector/collection-selector.component.scss
@@ -140,7 +140,7 @@ $light-blue-gradient: linear-gradient(45deg, darken($bright-blue, 10), lighten($
     // resize the popup
     max-width: 800px;
     width: 90vw;
-   display: block;
+    display: block;
 }
 
 .loading-template,

--- a/src/app/shared/popups/templates/collection-selector/collection-selector.component.scss
+++ b/src/app/shared/popups/templates/collection-selector/collection-selector.component.scss
@@ -96,6 +96,23 @@ $light-blue-gradient: linear-gradient(45deg, darken($bright-blue, 10), lighten($
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
+
+    &.generic {
+      background: $wrapper-background;
+      color: $bright-blue;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      margin: auto 0;
+      margin-right: 10px;
+      border-radius: 50px;
+
+      svg {
+        height: 20px;
+        width: 20px;
+      }
+    }
   }
 }
 
@@ -123,7 +140,7 @@ $light-blue-gradient: linear-gradient(45deg, darken($bright-blue, 10), lighten($
     // resize the popup
     max-width: 800px;
     width: 90vw;
-    display: block;
+   display: block;
 }
 
 .loading-template,


### PR DESCRIPTION
Now that the collections page has been deployed, we have been using the far fa-cubes selector as the generic logo for collections (if they do not already have a logo).  This PR updates it so that Intro to Cyber and Secure Coding Community now displays the generic logo instead of nothing or the wrong one.

Closes #779 

After:
![Screen Shot 2019-04-11 at 11 24 52 AM](https://user-images.githubusercontent.com/32078831/55969979-bb3b3400-5c4c-11e9-9201-65db49944f3c.png)
