### PR TITLE
Fix rating UI tries to edit a deleted rating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -461,19 +461,6 @@
       "resolved": "https://registry.npmjs.org/@cyber4all/clark-taxonomy/-/clark-taxonomy-4.0.2.tgz",
       "integrity": "sha512-8lY8HIHdSQPDZuGC4OGMGKYe8Q1SG5LuW7vye1skhSGU/UgNbFafdXHhm03zNlIIUknUVbgE25rXeP8yNswYvA=="
     },
-    "@cyber4all/dropzone": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@cyber4all/dropzone/-/dropzone-5.4.0.tgz",
-      "integrity": "sha512-ajSgIMO3tAEVjN2nqU9MSxTXv4RsHVIWwqzG382/xMikj4JIv8wr5nvU014XNRPfClXIf0HeLl7iKCeZ9cWQXA=="
-    },
-    "@cyber4all/ngx-dropzone-wrapper": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@cyber4all/ngx-dropzone-wrapper/-/ngx-dropzone-wrapper-6.2.1.tgz",
-      "integrity": "sha512-hFi2I4xb3qlC2PHIVTKn3N3Yo2YoBp5j1TNMcNha3fDURE+wyYUQRXhT1DkUQz9XJO4MaqFZmW6FQmmyWGAYeQ==",
-      "requires": {
-        "@cyber4all/dropzone": "5.4.0"
-      }
-    },
     "@ngtools/webpack": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-7.3.1.tgz",
@@ -3074,6 +3061,11 @@
       "requires": {
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "dropzone": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-5.5.1.tgz",
+      "integrity": "sha512-3VduRWLxx9hbVr42QieQN25mx/I61/mRdUSuxAmDGdDqZIN8qtP7tcKMa3KfpJjuGjOJGYYUzzeq6eGDnkzesA=="
     },
     "duplexify": {
       "version": "3.7.1",
@@ -7808,6 +7800,14 @@
       "integrity": "sha512-YCak+Itql8EDkMfr9lzCNd2wEeV+uflbv2V1mi9LCzUyFcO+W53S/BbuZS5r9M8MZzUiBl4AmpEDEKYiXrb3Sw==",
       "requires": {
         "tslib": "^1.9.0"
+      }
+    },
+    "ngx-dropzone-wrapper": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-dropzone-wrapper/-/ngx-dropzone-wrapper-7.2.1.tgz",
+      "integrity": "sha512-gE09T4ombTSFzf9R+HmiVkxOjxa+JX9udC6rotpo3yhvNzTrSL1nFXmF9VKw6Yr1SUFl2xGyHDZ/Tkgk1jEczQ==",
+      "requires": {
+        "dropzone": "^5.5.0"
       }
     },
     "ngx-virtual-scroller": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.22.7",
+  "version": "2.22.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.22.7",
+  "version": "2.22.8",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/rating.service.ts
+++ b/src/app/core/rating.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { RATING_ROUTES } from '@env/route';
 import { AuthService } from './auth.service';
 import { throwError } from 'rxjs';
-import { retry, catchError, map } from 'rxjs/operators';
+import { retry, catchError, map, filter } from 'rxjs/operators';
 
 @Injectable()
 export class RatingService {
@@ -21,7 +21,7 @@ export class RatingService {
   createResponse(params: {
     learningObjectId: string;
     ratingId: string;
-    response: {comment: string}
+    response: { comment: string }
   }): Promise<any> {
     const res = this.http.post(
       RATING_ROUTES.CREATE_RESPONSE({
@@ -31,9 +31,9 @@ export class RatingService {
       params.response,
       { withCredentials: true },
     ).toPromise()
-    .catch(result => {
-      return Promise.resolve(result.status === 200);
-    });
+      .catch(result => {
+        return Promise.resolve(result.status === 200);
+      });
     return res;
   }
 
@@ -51,7 +51,7 @@ export class RatingService {
     learningObjectId: string;
     ratingId: string;
     responseId: string;
-    updates: {comment: string};
+    updates: { comment: string };
   }): Promise<any> {
     const res = this.http.patch(
       RATING_ROUTES.UPDATE_RESPONSE({
@@ -62,20 +62,20 @@ export class RatingService {
       params.updates,
       { withCredentials: true },
     ).toPromise()
-    .catch(result => {
-      return Promise.resolve(result.status === 200);
-    });
+      .catch(result => {
+        return Promise.resolve(result.status === 200);
+      });
     return res;
   }
 
-   /**
-   * Delete a response
-   *
-   * @param {string} learningObjectId
-   * @param {string} ratingId
-   * @param {string} responseId
-   * @returns {Promise<any>}
-   */
+  /**
+  * Delete a response
+  *
+  * @param {string} learningObjectId
+  * @param {string} ratingId
+  * @param {string} responseId
+  * @returns {Promise<any>}
+  */
   deleteResponse(params: {
     learningObjectId: string;
     ratingId: string;
@@ -89,22 +89,22 @@ export class RatingService {
       }),
       { withCredentials: true },
     ).toPromise()
-    .catch(result => {
-      return Promise.resolve(result.status === 200);
-    });
+      .catch(result => {
+        return Promise.resolve(result.status === 200);
+      });
     return res;
   }
 
-   /**
-   * Create a rating for a learning object
-   *
-   * @param {string} learningObjectId
-   * @param {{value: number, comment: string}} rating
-   * @returns {Promise<any>}
-   */
+  /**
+  * Create a rating for a learning object
+  *
+  * @param {string} learningObjectId
+  * @param {{value: number, comment: string}} rating
+  * @returns {Promise<any>}
+  */
   createRating(params: {
     learningObjectId: string,
-    rating: {value: number, comment: string };
+    rating: { value: number, comment: string };
   }) {
     return this.http
       .post(
@@ -123,18 +123,18 @@ export class RatingService {
       .toPromise();
   }
 
-   /**
-   * Edit a rating
-   *
-   * @param {string} learningObjectId
-   * @param {string} ratingId
-   * @param {{value: number, comment: string}} rating
-   * @returns {Promise<any>}
-   */
+  /**
+  * Edit a rating
+  *
+  * @param {string} learningObjectId
+  * @param {string} ratingId
+  * @param {{value: number, comment: string}} rating
+  * @returns {Promise<any>}
+  */
   editRating(params: {
     learningObjectId: string;
     ratingId: string;
-    rating: {value: number, comment: string};
+    rating: { value: number, comment: string };
   }) {
     return this.http
       .patch(
@@ -205,15 +205,14 @@ export class RatingService {
       .pipe(
         retry(3),
         catchError(this.handleError),
+        filter(response => response != null),
         map((response: any) => {
-          if (response) {
-            const ratings = response.ratings.map((r: any) => {
-              const x = ({...r, id: r.id ? r.id : r._id });
-              delete x._id;
-              return x;
-            });
-            return { ...response, ratings };
-          }
+          const ratings = response.ratings.map((r: any) => {
+            const x = ({ ...r, id: r.id ? r.id : r._id });
+            delete x._id;
+            return x;
+          });
+          return { ...response, ratings };
         })
       )
       .toPromise();
@@ -230,7 +229,7 @@ export class RatingService {
   flagLearningObjectRating(params: {
     learningObjectId: string;
     ratingId: string;
-    report: {concern: string, comment?: string}
+    report: { concern: string, comment?: string }
   }): Promise<any> {
     return this.http.post(
       RATING_ROUTES.FLAG_LEARNING_OBJECT_RATING({
@@ -240,11 +239,11 @@ export class RatingService {
       params.report,
       { withCredentials: true },
     )
-    .pipe(
-      retry(3),
-      catchError(this.handleError)
-    )
-    .toPromise();
+      .pipe(
+        retry(3),
+        catchError(this.handleError)
+      )
+      .toPromise();
   }
 
   // TODO implement this

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -633,8 +633,9 @@ export class DetailsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Retrieves list of learning object ratings from server and, if the user has a review in that list, assigns it to the
-   * userReview variable
+   * Retrieves list of learning object ratings from the RatingService.
+   * If the user has a review in that list, it is assigned to the userReview variable.
+   * If the service does not return any ratings, the UI resets to default rating values.
    */
   private async getLearningObjectRatings() {
     this.ratingService
@@ -642,6 +643,10 @@ export class DetailsComponent implements OnInit, OnDestroy {
         learningObjectId: this.learningObject.id
       })
       .then(val => {
+        if (!val) {
+          this.resetRatings();
+          return;
+        }
         this.ratings = val.ratings;
         this.averageRatingValue = val.avgValue;
 
@@ -670,5 +675,6 @@ export class DetailsComponent implements OnInit, OnDestroy {
   private resetRatings() {
     this.ratings = [];
     this.averageRatingValue = 0;
+    this.userRating = {};
   }
 }


### PR DESCRIPTION
This PR prevents the user from running into a situation where they delete their rating and are unable to leave a new rating. This was caused by the component keeping the user's rating in memory and not resetting when it was deleted server-side.

This PR also fixes a few instances where TypeErrors were thrown because a null rating was being passed around.