### PR TITLE
Fix multipart upload from folder structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.22.15",
+  "version": "2.22.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.22.15",
+  "version": "2.22.16",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -338,6 +338,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           file.upload.uuid,
           this.inProgressFileUploads.length - 1
         );
+      }
         if (file.upload.chunked) {
           // Request multipart upload
           const learningObject = await this.learningObject$
@@ -368,7 +369,6 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           }
           this.uploadIds[file.upload.uuid] = uploadId;
         }
-      }
       this.dzDirectiveRef.dropzone().processFile(file);
     } catch (error) {
       this.error$.next(error);

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -338,37 +338,38 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           file.upload.uuid,
           this.inProgressFileUploads.length - 1
         );
-        if (file.upload.chunked) {
-          // Request multipart upload
-          const learningObject = await this.learningObject$
-            .pipe(take(1))
-            .toPromise();
-
-          // FIXME: Conditional block for TESTING PURPOSES ONLY. Remove after test of file upload service is completed
-          let uploadId = '';
-          if (this.userIsPrivileged) {
-            const fileUploadMeta: FileUploadMeta = {
-              name: file.name,
-              path: file.fullPath || file.name,
-              fileType: file.type,
-              size: file.size
-            };
-            uploadId = await this.fileStorage.initMultipartAdmin({
-              fileUploadMeta,
-              fileId: file.upload.uuid,
-              learningObjectId: learningObject.id,
-              authorUsername: learningObject.author.username
-            });
-          } else {
-            uploadId = await this.fileStorage.initMultipart({
-              learningObject,
-              fileId: file.upload.uuid,
-              filePath: file.fullPath ? file.fullPath : file.name
-            });
-          }
-          this.uploadIds[file.upload.uuid] = uploadId;
-        }
       }
+      if (file.upload.chunked) {
+        // Request multipart upload
+        const learningObject = await this.learningObject$
+          .pipe(take(1))
+          .toPromise();
+
+        // FIXME: Conditional block for TESTING PURPOSES ONLY. Remove after test of file upload service is completed
+        let uploadId = '';
+        if (this.userIsPrivileged) {
+          const fileUploadMeta: FileUploadMeta = {
+            name: file.name,
+            path: file.fullPath || file.name,
+            fileType: file.type,
+            size: file.size
+          };
+          uploadId = await this.fileStorage.initMultipartAdmin({
+            fileUploadMeta,
+            fileId: file.upload.uuid,
+            learningObjectId: learningObject.id,
+            authorUsername: learningObject.author.username
+          });
+        } else {
+          uploadId = await this.fileStorage.initMultipart({
+            learningObject,
+            fileId: file.upload.uuid,
+            filePath: file.fullPath ? file.fullPath : file.name
+          });
+        }
+        this.uploadIds[file.upload.uuid] = uploadId;
+      }
+
       this.dzDirectiveRef.dropzone().processFile(file);
     } catch (error) {
       this.error$.next(error);

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -338,38 +338,37 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
           file.upload.uuid,
           this.inProgressFileUploads.length - 1
         );
-      }
-      if (file.upload.chunked) {
-        // Request multipart upload
-        const learningObject = await this.learningObject$
-          .pipe(take(1))
-          .toPromise();
+        if (file.upload.chunked) {
+          // Request multipart upload
+          const learningObject = await this.learningObject$
+            .pipe(take(1))
+            .toPromise();
 
-        // FIXME: Conditional block for TESTING PURPOSES ONLY. Remove after test of file upload service is completed
-        let uploadId = '';
-        if (this.userIsPrivileged) {
-          const fileUploadMeta: FileUploadMeta = {
-            name: file.name,
-            path: file.fullPath || file.name,
-            fileType: file.type,
-            size: file.size
-          };
-          uploadId = await this.fileStorage.initMultipartAdmin({
-            fileUploadMeta,
-            fileId: file.upload.uuid,
-            learningObjectId: learningObject.id,
-            authorUsername: learningObject.author.username
-          });
-        } else {
-          uploadId = await this.fileStorage.initMultipart({
-            learningObject,
-            fileId: file.upload.uuid,
-            filePath: file.fullPath ? file.fullPath : file.name
-          });
+          // FIXME: Conditional block for TESTING PURPOSES ONLY. Remove after test of file upload service is completed
+          let uploadId = '';
+          if (this.userIsPrivileged) {
+            const fileUploadMeta: FileUploadMeta = {
+              name: file.name,
+              path: file.fullPath || file.name,
+              fileType: file.type,
+              size: file.size
+            };
+            uploadId = await this.fileStorage.initMultipartAdmin({
+              fileUploadMeta,
+              fileId: file.upload.uuid,
+              learningObjectId: learningObject.id,
+              authorUsername: learningObject.author.username
+            });
+          } else {
+            uploadId = await this.fileStorage.initMultipart({
+              learningObject,
+              fileId: file.upload.uuid,
+              filePath: file.fullPath ? file.fullPath : file.name
+            });
+          }
+          this.uploadIds[file.upload.uuid] = uploadId;
         }
-        this.uploadIds[file.upload.uuid] = uploadId;
       }
-
       this.dzDirectiveRef.dropzone().processFile(file);
     } catch (error) {
       this.error$.next(error);


### PR DESCRIPTION
This PR fixes a bug that affected mulitipart uploads for files within a directory structure. This issue was caused by the misplacement of a curly brace. 

The brace scoped the incorrect logic causing multipart uploads to not be initialized before attempting to upload its parts. This resulted in the service sending errors stating that no such multipart upload existed and upload failures for multipart uploads with a directory.