### PR TITLE
Remove No Description Here!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.html
@@ -16,7 +16,7 @@
         {{ folder.name }}
       </div>
       <div class="text-contained description">
-        <span>{{ folder.description || 'No description here!' }}</span>
+        <span>{{ folder.description }}</span>
         <!-- <input #folderDesc (click)="setEditable(folder)" *ngIf="canManage" class="description" name="file-description" placeholder="Enter description" [value]="folder.description ? folder.description: ''"
           [formControl]="descriptionControl" /> -->
       </div>
@@ -36,7 +36,7 @@
         <span class="external-link-icon" *ngIf="previewUrl(file.extension)"><i class="far fa-external-link"></i></span>
       </div>
       <div class="text-contained description">
-        <span>{{ file.description || 'No description here!' }}</span>
+        <span>{{ file.description }}</span>
         <!-- <input #fileDesc (click)="setEditable(file)" *ngIf="canManage" class="description" name="file-description" placeholder="Enter description" [value]="file.description ? file.description: ''"
           [formControl]="descriptionControl" /> -->
       </div>


### PR DESCRIPTION
<img width="1054" alt="Screen Shot 2019-04-19 at 10 05 00 AM" src="https://user-images.githubusercontent.com/43140629/56427707-dfb99080-628a-11e9-84b1-e7015134ea65.png">

Removes "No Description here!" and replaces it with blank if there is no description. 

Resolves #799 