### PR TITLE
Optimize DirectoryTree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@angular-devkit/architect": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
@@ -156,7 +156,7 @@ export class FileManagerComponent implements OnInit, OnDestroy {
    * @memberof FileManagerComponent
    */
   getFileIds(folder: DirectoryNode): string[] {
-    const children = folder.getChildren();
+    const children = folder.getFolders();
     const files = folder.getFiles();
     if (!children.length && !files.length) {
       return [];

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -8,15 +8,23 @@ import { LearningObject } from '@entity';
  * @class DirectoryTree
  */
 export class DirectoryTree {
-  private _root: DirectoryNode;
-  private lastNode: DirectoryNode;
-  private fileMap: Map<string, { path: string; file: string }> = new Map<
-    string,
-    { path: string; file: string }
-  >();
-  private pathMap: Map<string, number> = new Map<string, number>();
+  private root: DirectoryNode;
+  private lastTouchedNode: DirectoryNode;
+
   constructor() {
-    this._root = new DirectoryNode('', '', null);
+    this.root = new DirectoryNode('', '', null);
+  }
+
+  /**
+   * Returns folder DirectoryNode object if the folder exists within parent DirectoryNode
+   *
+   * @param {DirectoryNode} parent [The folder that contains the sub folder to be returned]
+   * @param {string} folderName [The name of the sub folder that should be returned]
+   * @returns {DirectoryNode}
+   * @memberof DirectoryTree
+   */
+  public getFolder(parent: DirectoryNode, folderName: string): DirectoryNode {
+    return parent.getFolder(folderName);
   }
   /**
    * Adds new Files to Directory Tree
@@ -25,23 +33,9 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   public addFiles(files: LearningObject.Material.File[]) {
-    // Returns new files and files that have had their metadata changed
-    const getUpdatedFiles = (fileList: LearningObject.Material.File[]) =>
-      fileList.filter(file => {
-        const mappedFile = this.fileMap.get(file.id);
-        if (mappedFile && mappedFile.file === JSON.stringify(file)) {
-          return false;
-        }
-        return true;
-      });
-    const newFiles = getUpdatedFiles(files);
-    for (const file of newFiles) {
-      this.fileMap.set(file.id, {
-        path: file.fullPath ? file.fullPath : file.name,
-        file: JSON.stringify(file)
-      });
+    files.forEach(file => {
       if (!file.fullPath) {
-        this._root.addFile(file);
+        this.root.addFile(file);
       } else {
         const paths = getPaths(file.fullPath);
         let node = this.traversePath(paths);
@@ -52,75 +46,33 @@ export class DirectoryTree {
           node.addFile(file);
         }
       }
-    }
-    this.cleanFilesystem(files);
+    });
   }
 
   /**
-   * Removes cached files that are no longer in the array of files
+   * Appends a new node for all missing directory paths
    *
    * @private
-   * @param {LearningObject.Material.File[]} files
+   * @param {string[]} paths [All path segments of the file]
+   * @returns
    * @memberof DirectoryTree
    */
-  private cleanFilesystem(files: LearningObject.Material.File[]) {
-    /**
-     * Checks if file is in array by matching against id and path
-     *
-     * @returns {boolean}
-     */
-    const findFile = (params: {
-      cachedFileData: { id: string; path: string };
-      file: LearningObject.Material.File;
-    }): boolean => {
-      const { cachedFileData, file } = params;
-      const filePath = file.fullPath || file.name;
-      return cachedFileData.id === file.id || cachedFileData.path === filePath;
-    };
-
-    const folderPaths = [];
-
-    // Remove file for file system and cache
-    this.fileMap.forEach((mappedFile, mappedId) => {
-      const fileExists = files.find(file =>
-        findFile({
-          file,
-          cachedFileData: { id: mappedId, path: mappedFile.path }
-        })
-      );
-
-      if (!fileExists) {
-        this.removeFile(mappedFile.path);
-        this.fileMap.delete(mappedId);
-        const folderPath = getPaths(mappedFile.path).join('/');
-        if (!folderPaths.includes(folderPath)) {
-          folderPaths.push(folderPath);
-        }
-      }
-    });
-
-    // Remove empty folders leftover from file removal
-    for (const path of folderPaths) {
-      const paths = getPaths(path, false);
-      const node = this.traversePath(paths);
-      if (node) {
-        this.removeEmptyFolders(node);
-      }
-    }
-  }
   private buildSubTree(paths: string[]) {
-    const last_touched_node_paths = getPaths(this.lastNode.getPath(), false);
-    const _paths = [...last_touched_node_paths];
+    const last_touched_node_paths = getPaths(
+      this.lastTouchedNode.getPath(),
+      false
+    );
+    const currentPaths = [...last_touched_node_paths];
     const continueFromIndex = last_touched_node_paths.length;
     let lastCreatedNode: DirectoryNode;
     for (let i = continueFromIndex; i < paths.length; i++) {
-      const p = paths[i];
-      _paths.push(p);
-      const _node = this.traversePath(_paths);
-      if (!_node) {
-        const name = p;
-        lastCreatedNode = this.add(name, `${_paths.join('/')}`, this.lastNode);
-      }
+      const folderName = paths[i];
+      currentPaths.push(folderName);
+      lastCreatedNode = this.addFolder(
+        folderName,
+        `${currentPaths.join('/')}`,
+        lastCreatedNode || this.lastTouchedNode
+      );
     }
     return lastCreatedNode;
   }
@@ -138,22 +90,16 @@ export class DirectoryTree {
     const currentPath = paths.shift();
     if (!parent) {
       if (!currentPath) {
-        return this._root;
+        return this.root;
       }
 
-      const nodeIndex = this.pathMap.get(currentPath);
-      const nodeChildren = this._root.getChildren();
-
-      const currentNode =
-        nodeIndex !== undefined
-          ? nodeChildren[nodeIndex]
-          : this.findNodeAtLevel(currentPath, nodeChildren);
+      const currentNode = this.root.getFolder(currentPath);
 
       if (currentNode) {
         return this.traversePath(paths, currentNode);
       }
 
-      this.lastNode = this._root;
+      this.lastTouchedNode = this.root;
       return null;
     }
 
@@ -161,45 +107,15 @@ export class DirectoryTree {
       return parent;
     }
 
-    const parentPath = parent.getPath();
-    const childPath = `${parentPath}/${currentPath}`;
-    const children = parent.getChildren();
-    const cachedIndex = this.pathMap.get(childPath);
-    const index = cachedIndex !== undefined ? cachedIndex : -1;
-    let node = children[index] || this.findNodeAtLevel(currentPath, children);
-    if (node && node.getName() !== currentPath) {
-      node = this.findNodeAtLevel(currentPath, children);
-    }
+    const node = parent.getFolder(currentPath);
     if (node) {
       return this.traversePath(paths, node);
     }
 
-    this.lastNode = parent;
+    this.lastTouchedNode = parent;
     return null;
   }
-  /**
-   * Finds Node within array of children and caches location
-   *
-   * @param {string} path
-   * @param {DirectoryNode[]} elements
-   * @returns {DirectoryNode}
-   * @memberof DirectoryTree
-   */
-  public findNodeAtLevel(
-    path: string,
-    elements: DirectoryNode[]
-  ): DirectoryNode {
-    let node;
-    for (let i = 0; i < elements.length; i++) {
-      const child = elements[i];
-      if (child.getName() === path) {
-        this.pathMap.set(child.getPath(), i);
-        node = child;
-        break;
-      }
-    }
-    return node;
-  }
+
   /**
    * Adds new Node to Parent Node
    *
@@ -210,16 +126,14 @@ export class DirectoryTree {
    * @returns {DirectoryNode}
    * @memberof DirectoryTree
    */
-  private add(
+  private addFolder(
     name: string,
     path: string,
     parent: DirectoryNode
   ): DirectoryNode {
     const newNode = new DirectoryNode(name, path, parent);
-    parent.addChild(newNode);
-    // Cache path's index
-    this.pathMap.set(path, parent.getChildren().length - 1);
-    return parent.getChildren()[parent.getChildren().length - 1];
+    parent.addFolder(newNode);
+    return newNode;
   }
 
   /**
@@ -228,17 +142,16 @@ export class DirectoryTree {
    * @param {string[]} paths Array of paths to folder
    * @memberof DirectoryTree
    */
-  public removeFolder(path: string) {
+  public removeFolder(path: string): DirectoryNode {
     const paths = getPaths(path, false);
     const node = this.traversePath(paths);
     if (node) {
       const parent = node.getParent();
-      const index = this.pathMap.get(node.getPath());
-      const removingFrom = parent ? parent : this._root;
-      removingFrom.getChildren().splice(index, 1);
-    } else {
-      throw new Error(`Node at path: ${path} does not exist`);
+      const deleted = parent.removeFolder(node.getName());
+      this.removeEmptyFolders(parent);
+      return deleted;
     }
+    return null;
   }
   /**
    * Removes file at path from Tree
@@ -251,29 +164,38 @@ export class DirectoryTree {
     const fileName = path.split('/').pop();
     const node = this.traversePath(folderPath);
     if (node) {
-      return node.removeFile(fileName);
-    } else {
-      throw new Error(`Node at path: ${folderPath.join('/')} does not exist`);
+      const deleted = node.removeFile(fileName);
+      this.removeEmptyFolders(node);
+      return deleted;
     }
+    return null;
   }
 
   /**
-   * Recursively removes empty folders starting for leaf node
+   * Recursively removes empty folders starting from leaf node
    *
    * @private
    * @param {DirectoryNode} node
    * @memberof DirectoryTree
    */
   private removeEmptyFolders(node: DirectoryNode): void {
-    if (
-      !this.isRoot(node) &&
-      !node.getChildren().length &&
-      !node.getFiles().length
-    ) {
+    if (!this.isRoot(node) && this.isFolderEmpty(node)) {
       const parent = node.getParent();
-      this.removeFolder(node.getPath());
+      parent.removeFolder(node.getName());
       this.removeEmptyFolders(parent);
     }
+  }
+
+  /**
+   * Checks if folder is empty by checking the length folders and files
+   *
+   * @private
+   * @param {DirectoryNode} folder [The folder to check]
+   * @returns {boolean}
+   * @memberof DirectoryTree
+   */
+  private isFolderEmpty(folder: DirectoryNode): boolean {
+    return !folder.getFolders().length && !folder.getFiles().length;
   }
 
   /**
@@ -285,7 +207,7 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   private isRoot(node: DirectoryNode): boolean {
-    return node.getPath() === this._root.getPath();
+    return node.getPath() === this.root.getPath();
   }
 }
 
@@ -299,15 +221,18 @@ export class DirectoryNode {
   private path: string;
   private files: LearningObject.Material.File[];
   private parent: DirectoryNode;
-  private children: DirectoryNode[];
+  private folders: DirectoryNode[];
   public description: string;
+
+  private fileMap: Map<string, number> = new Map();
+  private folderMap: Map<string, number> = new Map();
 
   constructor(name: string, path: string, parent: DirectoryNode) {
     this.name = name;
     this.path = path;
     this.files = [];
     this.parent = parent;
-    this.children = [];
+    this.folders = [];
     this.description = '';
   }
   /**
@@ -337,14 +262,27 @@ export class DirectoryNode {
   public getPath(): string {
     return this.path;
   }
+
   /**
-   * Get Node's children
+   * Returns folder by name
+   *
+   * @param {string} name [The name of the folder to return]
+   * @returns {DirectoryNode}
+   * @memberof DirectoryNode
+   */
+  public getFolder(name: string): DirectoryNode {
+    const cachedIndex = this.folderMap.get(name);
+    const childIndex = cachedIndex != null ? cachedIndex : -1;
+    return this.folders[childIndex];
+  }
+  /**
+   * Get Node's folders
    *
    * @returns {DirectoryNode[]}
    * @memberof DirectoryNode
    */
-  public getChildren(): DirectoryNode[] {
-    return this.children;
+  public getFolders(): DirectoryNode[] {
+    return this.folders;
   }
   /**
    * Gets Files in Directory
@@ -356,24 +294,18 @@ export class DirectoryNode {
     return this.files;
   }
   /**
-   * Add Child to Node
+   * Add Folder to Node
    *
-   * @param {DirectoryNode} child
+   * @param {DirectoryNode} newFolder
    * @returns {DirectoryNode}
    * @memberof DirectoryNode
    */
-  public addChild(newChild: DirectoryNode): DirectoryNode {
-    let canAdd = true;
-    for (const child of this.children) {
-      if (newChild.name === child.name) {
-        canAdd = false;
-        break;
-      }
+  public addFolder(newFolder: DirectoryNode): DirectoryNode {
+    if (this.folderMap.get(newFolder.name) == null) {
+      this.folderMap.set(newFolder.name, this.folders.length);
+      this.folders.push(newFolder);
     }
-    if (canAdd) {
-      this.children.push(newChild);
-    }
-    return newChild;
+    return newFolder;
   }
   /**
    * Add File to Node's files
@@ -382,16 +314,28 @@ export class DirectoryNode {
    * @memberof DirectoryNode
    */
   public addFile(newFile: LearningObject.Material.File) {
-    let canAdd = true;
-    for (const file of this.files) {
-      if (file.name === newFile.name) {
-        canAdd = false;
-        break;
-      }
-    }
-    if (canAdd) {
+    if (this.fileMap.get(newFile.name) == null) {
+      this.fileMap.set(newFile.name, this.files.length);
       this.files.push(newFile);
     }
+  }
+  /**
+   * Remove folder from Node's children by folderName
+   *
+   * @param {string} folderName
+   * @returns {DirectoryNode}
+   * @memberof DirectoryNode
+   */
+  public removeFolder(folderName: string): DirectoryNode {
+    const index = this.folderMap.get(folderName);
+    if (index >= 0) {
+      const deleted = this.folders[index];
+      this.folders.splice(index, 1);
+      this.folderMap.delete(folderName);
+      this.reIndexCacheMap(index, this.folders, this.folderMap);
+      return deleted;
+    }
+    return null;
   }
   /**
    * Remove file from Node's files by filename
@@ -401,27 +345,37 @@ export class DirectoryNode {
    * @memberof DirectoryNode
    */
   public removeFile(filename: string): LearningObject.Material.File {
-    const index = this.findFile(filename);
-    const deleted = this.files[index];
-    this.files.splice(index, 1);
-    return deleted;
+    const index = this.fileMap.get(filename);
+    if (index >= 0) {
+      const deleted = this.files[index];
+      this.files.splice(index, 1);
+      this.fileMap.delete(filename);
+      this.reIndexCacheMap(index, this.files, this.fileMap);
+      return deleted;
+    }
+    return null;
   }
+
   /**
-   * Finds file by filename
+   * Re-indexes cache map to match modified array
+   * Only values after the deleted index get re-indexed
    *
    * @private
-   * @param {string} filename
-   * @returns {number}
+   * @param {number} deletedIndex [The index the element was deleted at]
+   * @param {Array<DirectoryNode | LearningObject.Material.File>} modifiedArray [The array the element was spliced from]
+   * @param {Map<string, number>} cacheMap [The cache map to be re-indexed]
    * @memberof DirectoryNode
    */
-  private findFile(filename: string): number {
-    let index = 0;
-    for (let i = 0; i < this.files.length; i++) {
-      if (this.files[i].name === filename) {
-        index = i;
-        break;
+  private reIndexCacheMap(
+    deletedIndex: number,
+    modifiedArray: Array<DirectoryNode | LearningObject.Material.File>,
+    cacheMap: Map<string, number>
+  ): void {
+    if (deletedIndex <= modifiedArray.length - 1) {
+      for (let i = deletedIndex; i < modifiedArray.length; i++) {
+        const element = modifiedArray[i];
+        cacheMap.set((element as any).name, i);
       }
     }
-    return index;
   }
 }

--- a/src/app/shared/filesystem/DirectoryTree.ts
+++ b/src/app/shared/filesystem/DirectoryTree.ts
@@ -179,23 +179,11 @@ export class DirectoryTree {
    * @memberof DirectoryTree
    */
   private removeEmptyFolders(node: DirectoryNode): void {
-    if (!this.isRoot(node) && this.isFolderEmpty(node)) {
+    if (!this.isRoot(node) && node.isEmpty()) {
       const parent = node.getParent();
       parent.removeFolder(node.getName());
       this.removeEmptyFolders(parent);
     }
-  }
-
-  /**
-   * Checks if folder is empty by checking the length folders and files
-   *
-   * @private
-   * @param {DirectoryNode} folder [The folder to check]
-   * @returns {boolean}
-   * @memberof DirectoryTree
-   */
-  private isFolderEmpty(folder: DirectoryNode): boolean {
-    return !folder.getFolders().length && !folder.getFiles().length;
   }
 
   /**
@@ -235,6 +223,17 @@ export class DirectoryNode {
     this.folders = [];
     this.description = '';
   }
+
+  /**
+   * Checks if folder is empty by checking the length folders and files
+   *
+   * @returns {boolean}
+   * @memberof DirectoryNode
+   */
+  public isEmpty(): boolean {
+    return !this.folders.length && !this.files.length;
+  }
+
   /**
    * Gets Parent Node
    *

--- a/src/app/shared/filesystem/file-breadcrumb/file-breadcrumb.component.html
+++ b/src/app/shared/filesystem/file-breadcrumb/file-breadcrumb.component.html
@@ -1,9 +1,14 @@
 <div class="file-breadcrumb">
-  <span class="crumb" [ngClass]="{'link': (paths$|async)?.length}" (click)="jumpTo(0, true)">Materials</span>
-  <ng-container *ngFor="let path of (paths$ | async); let i=index;">
+  <span
+    class="crumb"
+    [ngClass]="{ link: paths?.length }"
+    (click)="jumpTo(0, true)"
+    >Materials</span
+  >
+  <ng-container *ngFor="let path of paths; let i = index">
     <span>
       <i class="far fa-chevron-right arrow"></i>
     </span>
-    <span class="crumb link" (click)="jumpTo(i)">{{path}}</span>
+    <span class="crumb link" (click)="jumpTo(i)">{{ path }}</span>
   </ng-container>
 </div>

--- a/src/app/shared/filesystem/file-breadcrumb/file-breadcrumb.component.ts
+++ b/src/app/shared/filesystem/file-breadcrumb/file-breadcrumb.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'clark-file-breadcrumb',
@@ -8,7 +7,9 @@ import { BehaviorSubject } from 'rxjs';
 })
 export class FileBreadcrumbComponent implements OnInit {
   @Input()
-  paths$: BehaviorSubject<string[]> = new BehaviorSubject<string[]>([]);
+  paths: string[] = [];
+
+  @Output() pathChanged: EventEmitter<string[]> = new EventEmitter();
 
   constructor() {}
 
@@ -19,10 +20,11 @@ export class FileBreadcrumbComponent implements OnInit {
     if (root) {
       path = [];
     } else {
-      path = this.paths$.getValue().slice(0, index + 1);
+      path = this.paths.slice(0, index + 1);
     }
-    if (JSON.stringify(path) !== JSON.stringify(this.paths$.getValue())) {
-      this.paths$.next(path);
+    if (JSON.stringify(path) !== JSON.stringify(this.paths)) {
+      this.paths = path;
+      this.pathChanged.emit(this.paths);
     }
   }
 }

--- a/src/app/shared/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.html
@@ -2,7 +2,7 @@
   <clark-file-breadcrumb [paths$]="currentPath$"></clark-file-breadcrumb>
   <div class="view-switcher inline-flex right">
     <div class="inline-flex">
-      <button *ngIf="canManage && ((currentNode$| async)?.children.length || (currentNode$| async)?.files.length)" id="new-file" (click)="emitNewOptionClick($event)" class="button new">
+      <button *ngIf="canManage && ((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)" id="new-file" (click)="emitNewOptionClick($event)" class="button new">
         New Upload <i class="fas fa-upload"></i>
       </button>
       <!-- <span *ngIf="view==='list'" (click)="view='grid'" class="button clean">
@@ -15,14 +15,14 @@
   </div>
 
 </div>
-<div (click)="emitContainerClick($event)" class="flex-wrapper" [ngClass]="{empty: !(currentNode$| async)?.children.length && !(currentNode$| async)?.files.length}">
-  <div *ngIf="canManage && !(currentNode$| async)?.children.length && !(currentNode$| async)?.files.length" class="dropzone-message">
+<div (click)="emitContainerClick($event)" class="flex-wrapper" [ngClass]="{empty: !(currentNode$| async)?.folders.length && !(currentNode$| async)?.files.length}">
+  <div *ngIf="canManage && !(currentNode$| async)?.folders.length && !(currentNode$| async)?.files.length" class="dropzone-message">
     <i class="fal fa-cloud-upload"></i>
     <div class="empty-title">No materials here!</div>
     <button class="button" id="new-file" (click)="emitNewOptionClick($event)">Click here to upload</button>
     <span>or drag and drop files and folders here</span>
   </div>
-  <clark-file-list-view *ngIf="((currentNode$| async)?.children.length || (currentNode$| async)?.files.length)"
+  <clark-file-list-view *ngIf="((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)"
     class="full-width" [node$]="currentNode$" [canManage]="canManage" (emitPath)="openFolder($event)" (emitDesc)="emitDesc($event)" (emitContextOpen)="meatballClick.emit($event)">
   </clark-file-list-view>
 </div>

--- a/src/app/shared/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.html
@@ -1,5 +1,5 @@
 <div class="top-wrapper">
-  <clark-file-breadcrumb [paths$]="currentPath$"></clark-file-breadcrumb>
+  <clark-file-breadcrumb [paths]="currentPath" (pathChanged)="handlePathChanged($event)"></clark-file-breadcrumb>
   <div class="view-switcher inline-flex right">
     <div class="inline-flex">
       <button *ngIf="canManage && ((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)" id="new-file" (click)="emitNewOptionClick($event)" class="button new">

--- a/src/app/shared/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.html
@@ -2,21 +2,21 @@
   <clark-file-breadcrumb [paths]="currentPath" (pathChanged)="handlePathChanged($event)"></clark-file-breadcrumb>
   <div class="view-switcher inline-flex right">
     <div class="inline-flex">
-      <button *ngIf="canManage && ((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)" id="new-file" (click)="emitNewOptionClick($event)" class="button new">
+      <button *ngIf="canManage && !(currentNode$ | async)?.isEmpty()" id="new-file" (click)="emitNewOptionClick($event)" class="button new">
         New Upload <i class="fas fa-upload"></i>
       </button>
     </div>
   </div>
 
 </div>
-<div (click)="emitContainerClick($event)" class="flex-wrapper" [ngClass]="{empty: !(currentNode$| async)?.folders.length && !(currentNode$| async)?.files.length}">
-  <div *ngIf="canManage && !(currentNode$| async)?.folders.length && !(currentNode$| async)?.files.length" class="dropzone-message">
+<div (click)="emitContainerClick($event)" class="flex-wrapper" [ngClass]="{empty: (currentNode$| async)?.isEmpty()}">
+  <div *ngIf="canManage && (currentNode$| async)?.isEmpty()" class="dropzone-message">
     <i class="fal fa-cloud-upload"></i>
     <div class="empty-title">No materials here!</div>
     <button class="button" id="new-file" (click)="emitNewOptionClick($event)">Click here to upload</button>
     <span>or drag and drop files and folders here</span>
   </div>
-  <clark-file-list-view *ngIf="((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)"
+  <clark-file-list-view *ngIf="!(currentNode$ | async)?.isEmpty()"
     class="full-width" [node$]="currentNode$" [canManage]="canManage" (emitPath)="openFolder($event)" (emitDesc)="emitDesc($event)" (emitContextOpen)="meatballClick.emit($event)">
   </clark-file-list-view>
 </div>

--- a/src/app/shared/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.html
@@ -5,12 +5,6 @@
       <button *ngIf="canManage && ((currentNode$| async)?.folders.length || (currentNode$| async)?.files.length)" id="new-file" (click)="emitNewOptionClick($event)" class="button new">
         New Upload <i class="fas fa-upload"></i>
       </button>
-      <!-- <span *ngIf="view==='list'" (click)="view='grid'" class="button clean">
-        <i class="fas fa-th icon-clean"></i>
-      </span>
-      <span *ngIf="view==='grid'" (click)="view='list'" class="button clean">
-        <i class="fas fa-list icon-clean"></i>
-      </span> -->
     </div>
   </div>
 

--- a/src/app/shared/filesystem/file-browser/file-browser.component.ts
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.ts
@@ -135,8 +135,6 @@ export class FileBrowserComponent implements OnInit, OnDestroy {
     let node;
     if (this.currentPath.length - paths.length === 1) {
       node = this.currentNode$.value.getParent();
-      this.currentNode$.next(node);
-      this.path.emit(this.currentPath.join('/'));
     } else {
       node = this.filesystem.traversePath(paths);
     }

--- a/src/app/shared/filesystem/file-browser/file-browser.component.ts
+++ b/src/app/shared/filesystem/file-browser/file-browser.component.ts
@@ -122,7 +122,11 @@ export class FileBrowserComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Determines what node to refresh the view with by checking the path change
+   * If the path decreased in length by 1, we know that the user clicked one directory higher from breadcrumbs
+   * So, no traversal is needed. Just emit the parent node
    *
+   * If the path changed by more than 1, the user jumped multiple directories and we need to traverse to find node to emit
    *
    * @param {string[]} paths
    * @memberof FileBrowserComponent

--- a/src/app/shared/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -42,7 +42,7 @@ export class FolderListItemComponent implements OnInit {
       .sort((a, b) => (a < b ? 1 : -1))[0];
     timestamp = timestamp > derivedTimestamp ? timestamp : derivedTimestamp;
 
-    for (const folder of node.getChildren()) {
+    for (const folder of node.getFolders()) {
       return this.getLatestDate(folder, timestamp);
     }
 

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.html
@@ -20,7 +20,7 @@
       >
         <!-- Folder -->
         <clark-folder-list-item
-          *ngIf="item.children"
+          *ngIf="item.folders"
           class="folder"
           (clicked)="openFolder(item.name)"
           (menuClicked)="handleMenuClicked($event, item)"
@@ -32,7 +32,7 @@
 
         <!-- File -->
         <clark-file-list-item
-          *ngIf="!item.children"
+          *ngIf="!item.folders"
           class="file"
           (clicked)="openFile(item)"
           (menuClicked)="handleMenuClicked($event, item)"

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
@@ -63,7 +63,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
    */
   private subToDirChange() {
     this.node$.pipe(takeUntil(this.killSub$)).subscribe(node => {
-      this.directoryListing = node.getChildren().concat(node.getFiles() as any);
+      this.directoryListing = node.getFolders().concat(node.getFiles() as any);
     });
   }
 


### PR DESCRIPTION
This PR refactors and optimizes logic inside of the `DirectoryTree` to reduce the time complexity of most operations to O(1), and the traversal of the tree to O(n). This was accomplished through the use of maps to cache node and file locations which reduced iteration and unnecessary recursion.

Additionally, this PR optimizes file browser navigation by only traversing the tree for a node if the user jumps more that one directory which only occurs when the user navigates via breadcrumbs.
If the user is navigating folder to folder, the file browser uses the current node's cache map of locations to get the next node in constant time. Similarly, if the user navigates via breadcrumbs and only jumps one directory, the parent of the current node is returned in constant time.


**Note** The diff for the `DirectoryTree` is large, so GitHub collapsed the view by default, but most changes have been made here https://github.com/Cyber4All/clark-client/compare/refactor/file-directory?expand=1#diff-6dd9d9601f9431816929bc1fde3e0856