### PR TITLE
Fix issue with preview url appending file url twice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.28.4",
+  "version": "2.28.5",
   "lockfileVersion": 1,
   "dependencies": {
     "@angular-devkit/architect": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.28.4",
+  "version": "2.28.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/filesystem/file-list-view/file-list-view.component.ts
@@ -105,7 +105,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   openFile(file: LearningObject.Material.File): void {
     const url = this.auth.isLoggedIn.value ? getPreviewUrl(file) : '';
     if (url) {
-      window.open(url + file.url, '_blank');
+      window.open(url, '_blank');
       this.preview = true;
     } else {
       this.preview = false;


### PR DESCRIPTION
This PR fixes the issues faced with file previews. The logic seemed to append the file's url twice causing the url to be invalid.

