### PR TITLE
Fix revision warning modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@angular-devkit/architect": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.32.2",
+  "version": "2.32.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/action-panel/revise-button.component.ts
+++ b/src/app/cube/details/action-panel/revise-button.component.ts
@@ -19,8 +19,8 @@ import { of } from 'rxjs';
           <i class="fas fa-exclamation-triangle"></i>
         </div>
         <p>
-          Revising a released Learning Object will move the working copy on the user's dashboard
-          back to proofing. The user will be able to see this, but will not be able to make any
+          Revising a released Learning Object will change the status on the user's dashboard
+          from released to proofing. The user will be able to see this, but will not be able to make any
           edits themselves.
         </p>
         <p> Are you sure you want to do this? </p>

--- a/src/app/cube/details/action-panel/revise-button.component.ts
+++ b/src/app/cube/details/action-panel/revise-button.component.ts
@@ -48,7 +48,7 @@ export class ReviseButtonComponent {
    * TODO: This flow must be updated after the implementation of ch26
    */
   makeRevision(): void {
-    if (!this.learningObject.hasRevision) {
+    if (this.learningObject.status === LearningObject.Status.RELEASED) {
       this.showPopup = true;
     } else {
       this.router.navigate([`/admin/learning-object-builder/${this.learningObject.id}`]);


### PR DESCRIPTION
This PR clarifies the context of the disclaimer that is shown when making revisions to a released Learning Object, as well as fixes the bug where the modal showed for all revisions - regardless of whether they are released or not.