### PR TITLE
Change delete to remove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.41.0",
+  "version": "2.41.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.41.0",
+  "version": "2.41.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
@@ -101,7 +101,7 @@ export class ScaffoldComponent implements OnInit {
    * @param index of the LO selected for deletion
    */
   deleteButton(index) {
-    this.childrenConfirmationMessage = `Just to confirm, you want to delete '
+    this.childrenConfirmationMessage = `Just to confirm, you want to remove '
         ${this.children[index].name}' as a child of '${
       this.learningObject.name
     }'?`;


### PR DESCRIPTION
Tiny change here so I figured I would put it in myself. It simply changes the word `delete` to `remove` in the confirmation dialog when deleting a child in the builder.

I think remove is a better candidate here because the user will not permanently lose any data in the operation, they can always add it back.