### PR TITLE
Fix bug where the cookie-agreement component's close button is offscreen

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.43.1",
+  "version": "2.43.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/cookies/cookies.component.scss
+++ b/src/app/shared/cookies/cookies.component.scss
@@ -6,6 +6,7 @@
     position: relative;
     background: $dark-overlay;
     color: white;
+    box-sizing: border-box;
 
     .inner {
         width: 100%;


### PR DESCRIPTION
This PR fixes yet another bug caused by the removal of Bootstrap. It adjusts the spacing of the cookie component to bring the close button back on screen.