### PR TITLE
Add Page Titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.43.2",
+  "version": "2.43.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/admin.routing.ts
+++ b/src/app/admin/admin.routing.ts
@@ -15,8 +15,11 @@ import { UsersComponent } from './pages/users/users.component';
 const admin_routes: Routes = [
   {
     path: '', component: AdminComponent, canActivate: [ AdminGuard ], children: [
-      { path: 'learning-objects', component: LearningObjectsComponent, data: { canScroll: false } },
-      { path: 'users', component: UsersComponent },
+      { path: 'learning-objects',
+      component: LearningObjectsComponent,
+      data: { canScroll: false, title: 'Collection Dashboard Learning Objects'}
+      },
+      { path: 'users', component: UsersComponent, data: { title: 'Collection Dashboard Users'} },
       { path: '', redirectTo: 'learning-objects', pathMatch: 'full' }
     ],
   },

--- a/src/app/admin/admin.routing.ts
+++ b/src/app/admin/admin.routing.ts
@@ -26,8 +26,9 @@ const admin_routes: Routes = [
   { path: ':collection', redirectTo: '/admin/:collection/learning-objects', pathMatch: 'full' },
   {
     path: ':collection', component: AdminComponent, children: [
-      { path: 'learning-objects', component: LearningObjectsComponent, data: { canScroll: false } },
-      { path: 'reviewers', component: UsersComponent },
+      { path: 'learning-objects', component: LearningObjectsComponent,
+        data: { canScroll: false, title: 'Collection Dashboard Learning Objects' } },
+      { path: 'reviewers', component: UsersComponent, data: { title: 'Collection Dashboard Reviewers'}},
     ],
   },
 ];

--- a/src/app/auth/auth.routing.ts
+++ b/src/app/auth/auth.routing.ts
@@ -15,15 +15,16 @@ const auth_routes: Routes = [
     component: AuthComponent,
     children: [
       { path: '', redirectTo: 'login', pathMatch: 'full' },
-      { path: 'login', component: LoginComponent },
-      { path: 'register', component: RegisterComponent },
-      { path: 'forgot-password', component: ForgotPasswordComponent },
+      { path: 'login', component: LoginComponent, data: { title: 'Login' } },
+      { path: 'register', component: RegisterComponent, data: { title: 'Register' } },
+      { path: 'forgot-password', component: ForgotPasswordComponent, data: { title: 'Change Password'} },
       {
         path: 'reset-password',
         component: ResetPasswordComponent,
-        canActivate: [CanResetPasswordGuard]
+        canActivate: [CanResetPasswordGuard],
+        data: { title: 'Reset-Password'}
       },
-      { path: 'email-verified', component: EmailVerifiedComponent },
+      { path: 'email-verified', component: EmailVerifiedComponent, data: { title: 'Email Verfication'} },
       // Catch All
       { path: '**', redirectTo: 'login', pathMatch: 'full' }
     ]

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -1,9 +1,14 @@
-import { Router } from '@angular/router';
+import { Router , NavigationEnd, ActivatedRoute} from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from './core/auth.service';
 import { CartV2Service } from './core/cartv2.service';
 import { ModalService, ModalListElement } from './shared/modals';
 import { trigger, transition, style, animate } from '@angular/animations';
+import { Title } from '@angular/platform-browser';
+import 'rxjs/add/operator/filter';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/mergeMap';
+import { LearningObject } from '@entity';
 
 @Component({
   selector: 'clark-root',
@@ -46,7 +51,13 @@ export class ClarkComponent implements OnInit {
   isOldVersion = false;
   errorMessage: string;
 
-  constructor(private authService: AuthService, private cartService: CartV2Service, private router: Router) {
+  constructor(
+    private authService: AuthService,
+    private cartService: CartV2Service,
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private titleService: Title
+    ) {
     this.isSupportedBrowser = !(/msie\s|trident\/|edge\//i.test(window.navigator.userAgent));
     !this.isSupportedBrowser ? this.router.navigate(['/unsupported']) :
       this.authService.isLoggedIn.subscribe(val => {
@@ -72,6 +83,8 @@ export class ClarkComponent implements OnInit {
         this.isOldVersion = true;
       }
     }, 600000); // 10 minute interval
+
+    this.setPageTitle();
   }
 
   reloadPage() {
@@ -85,5 +98,35 @@ export class ClarkComponent implements OnInit {
   setCookieAgreement(val: boolean) {
     localStorage.setItem('cookieAgreement', val + '');
     this.cookiesAgreement = val;
+  }
+
+  /* set the document title to show location in
+  browser tabs and notify AT's of current location */
+  setPageTitle() {
+    this.router.events
+    .filter(event => event instanceof NavigationEnd)
+    .subscribe(() => {
+      let data;
+      const activeRoutes: ActivatedRoute[] = this.activatedRoute.children;
+
+      activeRoutes.forEach((route: ActivatedRoute) => {
+        let activeRoute: ActivatedRoute = route;
+        while (activeRoute.firstChild) {
+          activeRoute = activeRoute.firstChild;
+        }
+        if (activeRoute.snapshot.params.username) {
+          if (activeRoute.snapshot.params.learningObjectName) {
+            data = activeRoute.snapshot.params.learningObjectName;
+          } else {
+            data = activeRoute.snapshot.params.username;
+          }
+        } else {
+          data = activeRoute.snapshot.data.title;
+        }
+        if (data !== undefined) {
+          this.titleService.setTitle('CLARK: ' + data);
+        }
+      });
+    });
   }
 }

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -6,9 +6,6 @@ import { ModalService, ModalListElement } from './shared/modals';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { Title } from '@angular/platform-browser';
 import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/mergeMap';
-import { LearningObject } from '@entity';
 
 @Component({
   selector: 'clark-root',

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -121,7 +121,7 @@ export class ClarkComponent implements OnInit {
           data = activeRoute.snapshot.data.title;
         }
         if (data !== undefined) {
-          this.titleService.setTitle('CLARK: ' + data);
+          this.titleService.setTitle(data + ' | CLARK');
         }
       });
     });

--- a/src/app/clark.module.ts
+++ b/src/app/clark.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { BrowserModule, Title } from '@angular/platform-browser';
 
 import { UrlSerializer } from '@angular/router';
 import { CustomUrlSerializer } from './core/custom-url-serliazer';

--- a/src/app/clark.module.ts
+++ b/src/app/clark.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule, Title } from '@angular/platform-browser';
+import { TitleCasePipe } from '@angular/common';
 
 import { UrlSerializer } from '@angular/router';
 import { CustomUrlSerializer } from './core/custom-url-serliazer';
@@ -23,6 +24,6 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
   ],
   declarations: [ClarkComponent, UnsupportedComponent, NotFoundComponent],
   bootstrap: [ClarkComponent],
-  providers: [{ provide: UrlSerializer, useClass: CustomUrlSerializer }]
+  providers: [ TitleCasePipe, Title, { provide: UrlSerializer, useClass: CustomUrlSerializer }]
 })
 export class ClarkModule {}

--- a/src/app/clark.routing.ts
+++ b/src/app/clark.routing.ts
@@ -19,8 +19,8 @@ const clark_routes: Routes = [
   },
   { path: 'onion', loadChildren: 'app/onion/onion.module#OnionModule' },
   { path: 'admin', loadChildren: 'app/admin/admin.module#AdminModule' },
-  { path: 'unsupported', component: UnsupportedComponent },
-  { path: 'not-found', component: NotFoundComponent },
+  { path: 'unsupported', component: UnsupportedComponent, data: { title: 'Unsupported'}},
+  { path: 'not-found', component: NotFoundComponent, data: { title: 'Not Found'}},
   { path: '', loadChildren: 'app/cube/cube.module#CubeModule' },
   { path: '**', redirectTo: '', pathMatch: 'full' }
 ];

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { CollectionService } from '../../core/collection.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'cube-collection-details',
@@ -21,8 +22,9 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
 
   constructor(
     private route: ActivatedRoute,
-    private collectionService: CollectionService
-  ) { }
+    private collectionService: CollectionService,
+    private titleService: Title
+  ) { this.titleService.setTitle('CLARK2: ' + this.collection.name ) }
 
   ngOnInit() {
     this.route.params

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 
+// This component sets its own page title
 @Component({
   selector: 'cube-collection-details',
   templateUrl: 'collection-details.component.html',
@@ -24,7 +25,7 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private collectionService: CollectionService,
     private titleService: Title
-  ) { this.titleService.setTitle('CLARK2: ' + this.collection.name ) }
+  ) {}
 
   ngOnInit() {
     this.route.params
@@ -47,5 +48,6 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
     if (this.collection.abvName !== 'intro_to_cyber' && this.collection.abvName !== 'secure_coding_community') {
       this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
     }
+    this.titleService.setTitle('CLARK: ' + this.collection.name);
   }
 }

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -48,6 +48,6 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
     if (this.collection.abvName !== 'intro_to_cyber' && this.collection.abvName !== 'secure_coding_community') {
       this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
     }
-    this.titleService.setTitle('CLARK: ' + this.collection.name);
+    this.titleService.setTitle(this.collection.name + ' | CLARK');
   }
 }

--- a/src/app/cube/cube.routing.ts
+++ b/src/app/cube/cube.routing.ts
@@ -27,7 +27,8 @@ const cube_routes: Routes = [
       { path: 'organization/:query', component: OrganizationListComponent },
       {
         path: 'browse/:query',
-        component: BrowseComponent
+        component: BrowseComponent,
+        data: { title: 'Search Results'}
       },
       {
         path: 'browse',

--- a/src/app/cube/cube.routing.ts
+++ b/src/app/cube/cube.routing.ts
@@ -27,8 +27,7 @@ const cube_routes: Routes = [
       { path: 'organization/:query', component: OrganizationListComponent },
       {
         path: 'browse/:query',
-        component: BrowseComponent,
-        data: { title: ''}
+        component: BrowseComponent
       },
       {
         path: 'browse',
@@ -37,8 +36,7 @@ const cube_routes: Routes = [
       },
       {
         path: 'details/:username/:learningObjectName',
-        component: DetailsComponent,
-        data: { title: ''}
+        component: DetailsComponent
       },
       {
         path: 'library',

--- a/src/app/cube/cube.routing.ts
+++ b/src/app/cube/cube.routing.ts
@@ -21,34 +21,40 @@ const cube_routes: Routes = [
     path: '',
     component: CubeComponent,
     children: [
-      { path: 'home', component: HomeComponent },
+      { path: 'home', component: HomeComponent, data: { title: 'Home'} },
       { path: 'c/:abvName', component: CollectionDetailsComponent },
       { path: 'c', component: CollectionsComponent },
       { path: 'organization/:query', component: OrganizationListComponent },
       {
         path: 'browse/:query',
-        component: BrowseComponent
+        component: BrowseComponent,
+        data: { title: ''}
       },
       {
         path: 'browse',
-        component: BrowseComponent
+        component: BrowseComponent,
+        data: { title: 'Browse Learning Objects'}
       },
       {
         path: 'details/:username/:learningObjectName',
-        component: DetailsComponent
+        component: DetailsComponent,
+        data: { title: ''}
       },
       {
         path: 'library',
         component: CartComponent,
-        canActivate: [AuthGuard]
+        canActivate: [AuthGuard],
+        data: { title: 'Your Library'}
       },
       {
         path: 'system/usage',
-        loadChildren: 'app/cube/usage-stats/usage-stats.module#UsageStatsModule'
+        loadChildren: 'app/cube/usage-stats/usage-stats.module#UsageStatsModule',
+        data: { title: 'System Usage'}
       },
       {
         path: 'system/termsofservice',
-        component: TermsOfServiceComponent
+        component: TermsOfServiceComponent,
+        data: { title: 'Terms of Service'}
       },
       {
         path: 'users/:username',

--- a/src/app/cube/organization-list/organization-list.component.ts
+++ b/src/app/cube/organization-list/organization-list.component.ts
@@ -32,7 +32,7 @@ export class OrganizationListComponent implements OnInit {
     });
     this.fetchMembers();
     const title = this.titleCasePipe.transform(this.organization);
-    this.titleService.setTitle('CLARK: ' + title);
+    this.titleService.setTitle(title + ' | CLARK');
   }
 
   async fetchMembers() {

--- a/src/app/cube/organization-list/organization-list.component.ts
+++ b/src/app/cube/organization-list/organization-list.component.ts
@@ -3,7 +3,10 @@ import { ActivatedRoute } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { UserService } from '../../core/user.service';
 import { COPY } from './organization-list.copy';
+import { Title } from '@angular/platform-browser';
+import { TitleCasePipe } from '@angular/common';
 
+// This component sets its own page title
 @Component({
   selector: 'clark-organization-list',
   templateUrl: './organization-list.component.html',
@@ -16,7 +19,9 @@ export class OrganizationListComponent implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
-    private userService: UserService
+    private userService: UserService,
+    private titleService: Title,
+    private titleCasePipe: TitleCasePipe
   ) {}
 
   ngOnInit() {
@@ -26,6 +31,8 @@ export class OrganizationListComponent implements OnInit {
         : (this.organization = '');
     });
     this.fetchMembers();
+    const title = this.titleCasePipe.transform(this.organization);
+    this.titleService.setTitle('CLARK: ' + title);
   }
 
   async fetchMembers() {

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -14,6 +14,7 @@ import { LearningObjectValidator } from './validators/learning-object.validator'
 import { CollectionService } from 'app/core/collection.service';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FileUploadMeta } from './components/content-upload/app/services/typings';
+import { Title } from '@angular/platform-browser';
 
 /**
  * Defines a list of actions the builder can take
@@ -105,7 +106,8 @@ export class BuilderStore {
     private auth: AuthService,
     private learningObjectService: LearningObjectService,
     private collectionService: CollectionService,
-    private validator: LearningObjectValidator
+    private validator: LearningObjectValidator,
+    private titleService: Title
   ) {
     // subscribe to our objectCache$ observable and initiate calls to save object after a debounce
     this.objectCache$
@@ -208,6 +210,8 @@ export class BuilderStore {
           this.learningObject,
           this.outcomes
         );
+        // set the title of page to the learning object name
+        this.titleService.setTitle('CLARK: ' + this.learningObject.name);
         return this.learningObject;
       })
       .catch(e => {
@@ -261,6 +265,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   makeNew(): LearningObject {
+    this.titleService.setTitle('CLARK: New Learning Object');
     this.learningObject = new LearningObject({ author: this.auth.user });
     this.outcomes = new Map();
     return this.learningObject;
@@ -742,6 +747,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   private saveObject(data: any, delay?: boolean) {
+    this.titleService.setTitle('CLARK: ' + this.learningObject.name);
     let value = this.objectCache$.getValue();
     this.touched = true;
 

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -211,7 +211,7 @@ export class BuilderStore {
           this.outcomes
         );
         // set the title of page to the learning object name
-        this.titleService.setTitle('CLARK: ' + this.learningObject.name);
+        this.titleService.setTitle(this.learningObject.name + ' | CLARK');
         return this.learningObject;
       })
       .catch(e => {
@@ -265,7 +265,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   makeNew(): LearningObject {
-    this.titleService.setTitle('CLARK: New Learning Object');
+    this.titleService.setTitle('New Learning Object | CLARK');
     this.learningObject = new LearningObject({ author: this.auth.user });
     this.outcomes = new Map();
     return this.learningObject;
@@ -747,7 +747,7 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   private saveObject(data: any, delay?: boolean) {
-    this.titleService.setTitle('CLARK: ' + this.learningObject.name);
+    this.titleService.setTitle(this.learningObject.name + ' | CLARK');
     let value = this.objectCache$.getValue();
     this.touched = true;
 

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -74,6 +74,7 @@ export const builderTransitions = trigger('builderTransition', [
   ])
 ]);
 
+// This component sets its own page title within the builder store
 @Component({
   selector: 'clark-learning-object-builder',
   templateUrl: './learning-object-builder.component.html',

--- a/src/app/onion/onion.routing.ts
+++ b/src/app/onion/onion.routing.ts
@@ -24,21 +24,21 @@ const onion_routes: Routes = [
         path: 'dashboard',
         component: environment.experimental ? DashboardComponent : OldDashboardComponent,
         canActivate: [AuthGuard],
-        data: { state: 'dashboard' }
+        data: { state: 'dashboard', title: 'Your Dashboard' }
       },
       {
         path: 'learning-object-builder',
         loadChildren:
           'app/onion/learning-object-builder/learning-object-builder.module#LearningObjectBuilderModule',
         canActivate: [AuthGuard],
-        data: { state: 'builder' }
+        data: { state: 'builder', title: 'New Learning Object'}
       },
       {
         path: 'learning-object-builder/:learningObjectId',
         loadChildren:
           'app/onion/learning-object-builder/learning-object-builder.module#LearningObjectBuilderModule',
         canActivate: [AuthGuard],
-        data: { state: 'builder' }
+        data: { state: 'builder', title: 'Learning Object Builder'}
       },
       { path: '**', redirectTo: 'dashboard' }
     ]

--- a/src/app/onion/onion.routing.ts
+++ b/src/app/onion/onion.routing.ts
@@ -30,15 +30,13 @@ const onion_routes: Routes = [
         path: 'learning-object-builder',
         loadChildren:
           'app/onion/learning-object-builder/learning-object-builder.module#LearningObjectBuilderModule',
-        canActivate: [AuthGuard],
-        data: { state: 'builder', title: 'New Learning Object'}
+        canActivate: [AuthGuard]
       },
       {
         path: 'learning-object-builder/:learningObjectId',
         loadChildren:
           'app/onion/learning-object-builder/learning-object-builder.module#LearningObjectBuilderModule',
-        canActivate: [AuthGuard],
-        data: { state: 'builder', title: 'Learning Object Builder'}
+        canActivate: [AuthGuard]
       },
       { path: '**', redirectTo: 'dashboard' }
     ]


### PR DESCRIPTION
The purpose of this PR is to add the ability for our application to dynamically change the page title based on the location of the user within the application. The following is the list of titles for each page: 

Home: **Home | CLARK**
Browse: **Browse Learning Objects | CLARK**
Details: **{{ LO Name }} | CLARK**
Collection Pages: **{{ Collection Name }} | CLARK**
Dashboard: **Your Dashboard | CLARK**
Builder with new LO: **New Learning Object | CLARK**
Builder after name has been added: **{{ LO Name }} | CLARK**
Library: **Your Library | CLARK**
Login: **Login | CLARK**
Register: **Register | CLARK**
Forgot Password: **Change Password | CLARK**
User profiles: **{{ username }} | CLARK** ****This is also for the personal profile
Not Found: **Not Found | CLARK**
Unsupported: **Unsupported | CLARK**
Organization List: **{{ organization name }} | CLARK**

Collection Dashboard
Learning Objects: **Collection Dashboard Learning Objects | CLARK**
Users: **Collection Dashboard Users | CLARK**