### PR TITLE
Changelog modal fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.44.0",
+  "version": "2.44.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.scss
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.scss
@@ -38,7 +38,7 @@
     opacity: .3;
   }
 
-  &:hover {
+  &:hover, &:focus {
     box-shadow: 0 0 5px $light-blue;
   }
 

--- a/src/app/onion/shared/edit-changelog/edit-changelog.component.scss
+++ b/src/app/onion/shared/edit-changelog/edit-changelog.component.scss
@@ -11,4 +11,5 @@
 
 .btn-group {
   margin-top: 45px;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
I was not able to recreate the issue that I found a few weeks ago, the modal seems to closing when a changelog is made and confirm is pressed and when no changelog is left. I did find a small issue that might have been bootstrap, when the modal is scrolled all the way to the bottom the buttons lined up with the bottom of the modal, and also added a focus for keyboard accessibility. 
<img width="768" alt="Screen Shot 2019-07-12 at 9 18 45 AM" src="https://user-images.githubusercontent.com/43140629/61131221-a1e19800-a486-11e9-8862-8f7038999653.png">
<img width="740" alt="Screen Shot 2019-07-12 at 9 19 15 AM" src="https://user-images.githubusercontent.com/43140629/61131256-b9208580-a486-11e9-9183-8a6685a87448.png">
<img width="820" alt="Screen Shot 2019-07-12 at 9 19 24 AM" src="https://user-images.githubusercontent.com/43140629/61131262-bc1b7600-a486-11e9-8725-7a9e3336df95.png">

