### PR TITLE
Handle bad request errors from service when adding file metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.45.1",
+  "version": "2.45.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -336,7 +336,7 @@ export class LearningObjectService {
     const completed$: Subject<boolean> = new Subject<boolean>();
     const sendNextBatch$: Subject<void> = new Subject<void>();
 
-    const response = new Promise(resolve => {
+    const response = new Promise((resolve, reject) => {
       sendNextBatch$.pipe(takeUntil(completed$)).subscribe(async () => {
         const batch = files.splice(0, MAX_PER_REQUEST);
         if (batch.length) {
@@ -345,7 +345,7 @@ export class LearningObjectService {
           const fileIds = await this.handleFileMetaRequestQueueCompletion(
             completed$,
             responses$
-          );
+          ).catch(reject);
           resolve(fileIds);
         }
       });

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -302,7 +302,7 @@ export class LearningObjectService {
    * @param {string} authorUsername [The Learning Object's author's username]
    * @param {string} objectId [The Id of the Learning Object]
    * @param {FileUploadMeta[]} files [List of file meta to be added]
-   * @returns {Promise<any>}
+   * @returns {Promise<string[]>}
    * @memberof LearningObjectService
    */
   addFileMeta({
@@ -313,7 +313,7 @@ export class LearningObjectService {
     username: string;
     objectId: string;
     files: FileUploadMeta[];
-  }): Promise<any> {
+  }): Promise<string[]> {
     const route = USER_ROUTES.ADD_FILE_META(username, objectId);
     return this.handleFileMetaRequests(files, route);
   }
@@ -330,23 +330,24 @@ export class LearningObjectService {
    * @returns
    * @memberof LearningObjectService
    */
-  private handleFileMetaRequests(files: FileUploadMeta[], route: string) {
+  private handleFileMetaRequests(
+    files: FileUploadMeta[],
+    route: string
+  ): Promise<string[]> {
     const MAX_PER_REQUEST = 100;
     const responses$: Promise<string[]>[] = [];
     const completed$: Subject<boolean> = new Subject<boolean>();
     const sendNextBatch$: Subject<void> = new Subject<void>();
 
-    const response = new Promise((resolve, reject) => {
-      sendNextBatch$.pipe(takeUntil(completed$)).subscribe(async () => {
+    const response = new Promise<string[]>((resolve, reject) => {
+      sendNextBatch$.pipe(takeUntil(completed$)).subscribe(() => {
         const batch = files.splice(0, MAX_PER_REQUEST);
         if (batch.length) {
           this.handleFileMetaBatch(route, batch, responses$, sendNextBatch$);
         } else {
-          const fileIds = await this.handleFileMetaRequestQueueCompletion(
-            completed$,
-            responses$
-          ).catch(reject);
-          resolve(fileIds);
+          this.handleFileMetaRequestQueueCompletion(completed$, responses$)
+            .then(resolve)
+            .catch(reject);
         }
       });
     });
@@ -393,7 +394,7 @@ export class LearningObjectService {
   private async handleFileMetaRequestQueueCompletion(
     completed$: Subject<boolean>,
     responses$: Promise<string[]>[]
-  ) {
+  ): Promise<string[]> {
     completed$.next(true);
     completed$.unsubscribe();
     const fileIdsArrays = await Promise.all(responses$);

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -55,6 +55,7 @@ export enum BUILDER_ERRORS {
   SUBMIT_REVIEW,
   CANCEL_SUBMISSION,
   DELETE_OUTCOME,
+  ADD_FILE_META,
   SERVICE_FAILURE
 }
 
@@ -548,12 +549,18 @@ export class BuilderStore {
    */
   private async addFileMeta(files: FileUploadMeta[]): Promise<any> {
     this.serviceInteraction$.next(true);
-    await this.learningObjectService.addFileMeta({
+    await this.learningObjectService
+      .addFileMeta({
       files,
       username: this.learningObject.author.username,
       objectId: this.learningObject.id
+      })
+      .then(() => {
+         this.fetchMaterials();
+      })
+      .catch(e => {
+        this.handleServiceError(e, BUILDER_ERRORS.ADD_FILE_META);
     });
-    await this.fetchMaterials();
     this.serviceInteraction$.next(false);
   }
   /**

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -267,7 +267,7 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
       case BUILDER_ERRORS.ADD_FILE_META:
         this.noteService.notify(
           toasterTitle,
-          'Unable to add file',
+          'Unable to add file(s)',
           toasterClass,
           toasterIcon
         );

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -264,6 +264,14 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
           toasterIcon
         );
         break;
+      case BUILDER_ERRORS.ADD_FILE_META:
+        this.noteService.notify(
+          toasterTitle,
+          'Unable to add file',
+          toasterClass,
+          toasterIcon
+        );
+        break;
       default:
         break;
     }


### PR DESCRIPTION
**Purpose of this PR**
This patch is in relation to the issue documented in this story https://app.clubhouse.io/clarkcan/story/823/drag-and-drop-function-for-uploading-material-files-not-working-editorial-mode. Files were being uploaded successfully, but when adding the metadata, the service would not insert because of a Bad Request caused by missing parameters.

**Changes in this PR**
Handle service errors when adding file metadata and display feedback to the user.