### PR TITLE
Ignore build-and-test workflow when merging into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,11 +80,20 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build
-      - test
+      - build:
+          filters:
+            branches:
+              ignore: /master/
+      - test:
+          filters:
+            branches:
+              ignore: /master/
       - publish-image:
           requires:
             - build
+          filters:
+            branches:
+              ignore: /master/
   build-test-and-deploy:
     jobs:
       - build:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.1",
+  "version": "2.46.1-1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
***Purpose***
This PR is in response to story https://app.clubhouse.io/clarkcan/story/842/only-run-non-deployment-pipeline-on-branches-that-aren-t-master

***Implementation***
Uses the ignore option for the master branch

Circle CI branch filtering docs: https://circleci.com/docs/2.0/configuration-reference/#filters-1