### PR TITLE
Invalidate CloudFront cache after deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,12 +70,13 @@ jobs:
     steps:
       - attach_workspace : 
           at: ~/clark-client/dist
-      - run: 
-          name: Invalidate index.html in CloudFront
-          command: aws cloudfront create-invalidation --distribution-id ${cloudfront_id} --paths /index.html
       - run:
           name: Deploy to S3 
           command: aws s3 sync ${source} s3://${s3_bucket} --region ${s3_region}
+      - run: 
+          name: Invalidate index.html in CloudFront
+          command: aws cloudfront create-invalidation --distribution-id ${cloudfront_id} --paths /index.html
+      
 workflows:
   version: 2
   build-and-test:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.1-2",
+  "version": "2.46.1-3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
**Purpose of this PR**
Addresses issue documented in this story https://app.clubhouse.io/clarkcan/story/844/invalidate-cache-after-client-deployment

**Changes in this PR**
- Swap order of operations to invalidate cache after deployment to S3.