### PR TITLE
Learning Objects Children can only be objects of original author

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.1-3",
+  "version": "2.46.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
@@ -41,7 +41,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
-      this.children = await this.getLearningObjects();
+    this.children = await this.getLearningObjects();
   }
 
   /**

--- a/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
@@ -41,7 +41,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
-    this.children = await this.getLearningObjects();
+      this.children = await this.getLearningObjects();
   }
 
   /**
@@ -52,7 +52,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
   async getLearningObjects(filters?: any, query?: string): Promise<LearningObject[]> {
     this.loading = true;
     return this.learningObjectService
-      .getLearningObjects(this.auth.username, filters, query)
+      .getLearningObjects(this.child.author.username, filters, query)
       .then((children: LearningObject[]) => {
         this.loading = false;
         const indx = this.lengths.indexOf(this.child.length);


### PR DESCRIPTION
The purpose of this PR is to fix a bug where if a learning object was opened in editor mode in the builder and editor or admin would be able to add their own objects as children. 