### PR TITLE
Fix Status Filter on Admin Dashboard is Not Filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.3",
+  "version": "2.46.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -63,8 +63,8 @@
   (close)="toggleFilterMenu(undefined)"
 >
   <div #contextMenu class="filter-status__container">
-    <ul *ngFor="let status of statuses">
-      <li [ngClass]="status" (click)="toggleStatusFilter(status)">
+    <ul>
+      <li *ngFor="let status of statuses" [ngClass]="status" (click)="toggleStatusFilter(status)">
         <div *ngIf="filters.has(status)" class="indicator"></div>
         <i [ngClass]="getStatusIcon(status)"></i> {{ status | titlecase }}
       </li>

--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -64,9 +64,12 @@
 >
   <div #contextMenu class="filter-status__container">
     <ul>
-      <li *ngFor="let status of statuses" [ngClass]="status" (click)="toggleStatusFilter(status)">
-        <div *ngIf="filters.has(status)" class="indicator"></div>
-        <i [ngClass]="getStatusIcon(status)"></i> {{ status | titlecase }}
+      <li 
+        *ngFor="let status of statuses"
+        [ngClass]="status"
+        (click)="toggleStatusFilter(status)">
+          <div *ngIf="filters.has(status)" class="indicator"></div>
+          <i [ngClass]="getStatusIcon(status)"></i> {{ status | titlecase }}
       </li>
     </ul>
   </div>


### PR DESCRIPTION
This PR moves the ngFor directive onto the list items themselves, instead of creating multiple lists. Click events were not behaving as expected when the context menu contained multiple lists.