### PR TITLE
Change checkbox disabled appearance 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.11",
+  "version": "2.46.12",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/modals/checkbox/checkbox.component.scss
+++ b/src/app/shared/modals/checkbox/checkbox.component.scss
@@ -71,9 +71,21 @@
   }
 
   &.disabled {
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
+    border-color: $light-grey;
+
+    &:before {
+      background: $light-grey;
+    }
+  
+    &:after {
+      background: $light-grey;
+    }
+
+    &:after, .svg-inline--fa {
+      transform: scale(1);
+      opacity: 1;
+      visibility: visible;
+    }
   }
 }
 

--- a/src/app/shared/modals/checkbox/checkbox.component.scss
+++ b/src/app/shared/modals/checkbox/checkbox.component.scss
@@ -72,14 +72,7 @@
 
   &.disabled {
     border-color: $light-grey;
-
-    &:before {
-      background: $light-grey;
-    }
-  
-    &:after {
-      background: $light-grey;
-    }
+    cursor: default;
   }
 }
 

--- a/src/app/shared/modals/checkbox/checkbox.component.scss
+++ b/src/app/shared/modals/checkbox/checkbox.component.scss
@@ -80,12 +80,6 @@
     &:after {
       background: $light-grey;
     }
-
-    &:after, .svg-inline--fa {
-      transform: scale(1);
-      opacity: 1;
-      visibility: visible;
-    }
   }
 }
 

--- a/src/app/shared/modals/checkbox/checkbox.component.ts
+++ b/src/app/shared/modals/checkbox/checkbox.component.ts
@@ -16,7 +16,7 @@ import {
       id="checkbox"
       aria-label="Checkbox"
       tabindex="0"
-      (click)="(state = !state) && animate()"
+      (click)="!disabled ? (state = !state) && animate() : none"
       [ngClass]="{ 'active': state, 'disabled': disabled, 'animating': animating }"
     >
       <i class="fas fa-check"></i>
@@ -48,8 +48,8 @@ export class CheckBoxComponent implements OnChanges {
   }
 
   set state(value: boolean) {
-    this._state = value;
-    this.sendEvent();
+      this._state = value;
+      this.sendEvent();
   }
 
   get animating() {

--- a/src/app/shared/modals/checkbox/checkbox.component.ts
+++ b/src/app/shared/modals/checkbox/checkbox.component.ts
@@ -16,7 +16,7 @@ import {
       id="checkbox"
       aria-label="Checkbox"
       tabindex="0"
-      (click)="!disabled ? (state = !state) && animate() : none"
+      (click)="(state = !state) && animate()"
       [ngClass]="{ 'active': state, 'disabled': disabled, 'animating': animating }"
     >
       <i class="fas fa-check"></i>

--- a/src/app/shared/modals/checkbox/checkbox.component.ts
+++ b/src/app/shared/modals/checkbox/checkbox.component.ts
@@ -44,7 +44,9 @@ export class CheckBoxComponent implements OnChanges {
   }
 
   get state() {
-    return this._state;
+    if (!this.disabled) {
+      return this._state;
+    }
   }
 
   set state(value: boolean) {


### PR DESCRIPTION
The purpose of this PR is to change the way we handle disabled checkboxes in the UI. Instead of not showing it a grayed out pre-checked box is rendered. 

![Screen Shot 2019-07-29 at 12 07 06 PM](https://user-images.githubusercontent.com/43140629/62063704-68848880-b1f9-11e9-8685-a28a6643bce1.png)

***This should be okay for 508 because I tried to style it after the typical semantic HTML disabled checkbox using our grey. This also blocks emitting the state of the checkbox up and any pointer events*** 