### PR TITLE
Remove bootstrap from Error Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.46.7-1",
+  "version": "2.46.8",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/error-status/error-status.component.html
+++ b/src/app/cube/details/error-status/error-status.component.html
@@ -1,21 +1,17 @@
 <div class="not-found-top">
-  <div class="container">
-      <img src="../assets/images/logo.png" class="not-found-logo" alt="CLARK logo">
-      <div class="row justify-content-center">
-          <div class="col-md-12 text-center">
-            <div *ngIf="statusCode">
-              <strong><h1 class="huge" tabindex="0" attr.aria-label="Error status: {{ statusCode }}">{{ statusCode }}</h1></strong>
-              <div tabindex="0" class="message">This Learning Object is currently under review.</div>
-              <div *ngIf="!auth.user; else unauthorized">
-                <div tabindex="0" class="message">Try logging in to see if you have access.</div>
-                <button class="auth-button" (click)="login()" aria-label="Clickable Login button">LOGIN</button>
-              </div>
-              <ng-template #unauthorized>
-                <div tabindex="0" class="message">You do not have access to this Learning Object.</div>
-              </ng-template>
-              <a routerLink='' class="btn btn-link" aria-label="Clickable back to homepage link">Back to Home</a>
-            </div>
-          </div>
+    <img src="../assets/images/logo.png" class="not-found-logo" alt="CLARK logo">
+    <div *ngIf="statusCode">
+      <strong><h1 class="huge" tabindex="0" attr.aria-label="Error status: {{ statusCode }}">{{ statusCode }}</h1></strong>
+      <div tabindex="0" class="message">This Learning Object is currently under review.</div>
+      <div *ngIf="!auth.user; else unauthorized">
+        <div tabindex="0" class="message">Try logging in to see if you have access.</div><br>
+        <div class="btn-group center">
+          <button class="button good" (click)="login()" aria-label="Clickable Login button">LOGIN</button>
+        </div>
       </div>
-  </div>
+      <ng-template #unauthorized>
+        <div tabindex="0" class="message">You do not have access to this Learning Object.</div>
+      </ng-template>
+      <a routerLink='' class="message" aria-label="Clickable back to homepage link">Back to Home</a>
+    </div>
 </div>

--- a/src/app/cube/details/error-status/error-status.component.scss
+++ b/src/app/cube/details/error-status/error-status.component.scss
@@ -2,43 +2,31 @@
 @import '~_vars.scss';
 @import "../../../../globals.scss";
 
-.huge {
-  font-size: $largest;
-}
+.not-found-top {
+  padding: 50px;
+  justify-content: center;
 
-.not-found-logo {
-  width: 180px;
-  display: block;
-  margin: 0 auto;
-}
-.not-found.top {
-  padding-top: 500px;
-}
-
-.message {
-  font-size: $large;
-  margin-bottom: 10px;
-}
-
-.auth-button {
-  -moz-transition-duration: .2s;
-  transition-duration: .2s;
-  overflow: hidden;
-  text-align: center;
-  font-size: $normal;
-  margin-bottom: 10px;
-  position: relative;
-  background-color: $blue-accent;
-  color: white;
-  border: none;
-  padding: 10px;
-  width: 400px;
-  border-radius: 4px;
-
-  &:hover {
-    -moz-transition-duration: .2s;
-    transition-duration: .2s;
-    opacity: .9;
+  .not-found-logo {
+    height: 180px;
+    display: block;
+    margin: auto;
+  }
+  .huge {
+    font-size: $largest;
+    max-width: 100px;
+    display: block;
+    margin: auto;
+    text-align: center;
+  }
+  .message {
+    padding-top: 20px;
+    max-width: 400px;
+    font-size: $large;
+    display: block;
+    margin: auto;
+    text-align: center;
   }
 }
+
+
 


### PR DESCRIPTION
The purpose of this PR is to address the issues that killing bootstrap caused for our error page. 
<img width="1073" alt="Screen Shot 2019-07-26 at 2 48 06 PM" src="https://user-images.githubusercontent.com/43140629/61974393-6a113f00-afb4-11e9-8540-d7af32b729d7.png">

![Screen Shot 2019-07-26 at 2 44 37 PM](https://user-images.githubusercontent.com/43140629/61974336-4b12ad00-afb4-11e9-9b02-c0eb5d47a4ed.png)
