### PR TITLE
Make Modals Accessible Again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.50.10",
+  "version": "2.51.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.html
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.html
@@ -39,9 +39,9 @@
             <div #contextMenu>
               <ul (activate)="toggleContextMenu($event)">
           
-                <li *ngIf="actionPermissions('edit')" [routerLink]="['/onion/learning-object-builder', learningObject.id]"><i class="far fa-pencil"></i>Edit</li>
+                <li *ngIf="actionPermissions('edit')" [routerLink]="['/onion/learning-object-builder', learningObject.id]" activate><i class="far fa-pencil"></i>Edit</li>
                 <li *ngIf="actionPermissions('infoPanel')" (activate)="viewSidePanel.emit()"><i class="fas fa-info-circle"></i>Info</li>
-                <li *ngIf="actionPermissions('manageMaterials')" [routerLink]="['/onion/learning-object-builder', learningObject.id, 'materials']"><i class="far fa-upload"></i>Manage Materials</li>
+                <li *ngIf="actionPermissions('manageMaterials')" [routerLink]="['/onion/learning-object-builder', learningObject.id, 'materials']" activate><i class="far fa-upload"></i>Manage Materials</li>
                 <li *ngIf="actionPermissions('submit')" (activate)="submit.emit()"><i class="far fa-eye"></i>Submit for Review</li>
                 <li (activate)="viewAllChangelogs.emit(learningObject.id)"><i class="far fa-comment-alt-lines"></i>View Changelogs</li>
                 <li *ngIf="actionPermissions('view')" [routerLink]="['/details', learningObject.author.username, learningObject.name]"><i class="far fa-cube"></i>Learning Object Details</li>

--- a/src/app/shared/directives/shared-directives.module.ts
+++ b/src/app/shared/directives/shared-directives.module.ts
@@ -6,19 +6,22 @@ import { ActivateDirective } from './activate.directive';
 import { AutofocusDirective } from './autofocus.directive';
 import { LearningObjectCardDirective } from './learning-object-card.directive';
 import { TipDirective } from './tip.directive';
+import { TrapFocusDirective } from './trap-focus.directive';
 
 @NgModule({
   declarations: [
     ActivateDirective,
     AutofocusDirective,
     LearningObjectCardDirective,
-    TipDirective
+    TipDirective,
+    TrapFocusDirective,
   ],
   exports: [
     ActivateDirective,
     AutofocusDirective,
     LearningObjectCardDirective,
-    TipDirective
+    TipDirective,
+    TrapFocusDirective,
   ]
 })
 export class SharedDirectivesModule {}

--- a/src/app/shared/directives/trap-focus.directive.ts
+++ b/src/app/shared/directives/trap-focus.directive.ts
@@ -1,0 +1,48 @@
+import { Directive, ElementRef, OnDestroy } from '@angular/core';
+
+@Directive({
+  selector: '[trapFocus]'
+})
+export class TrapFocusDirective implements OnDestroy {
+
+  constructor(private host: ElementRef<HTMLElement>) {
+    this.host.nativeElement.classList.add('focus--trapped');
+
+    this.focusFirstElement();
+
+    setTimeout(() => {
+      document.querySelectorAll('.focus--trapped *').forEach((el: HTMLElement) => {
+        el.classList.add('focus--trapped');
+
+        el.addEventListener('blur', (event) => {
+          if (!(event.relatedTarget as HTMLElement).classList.contains('focus--trapped')) {
+            // if we've left the focus-trapped region, refocus the first element in the focus-trapped region
+            this.focusFirstElement();
+          }
+        });
+      });
+    });
+  }
+
+/**
+ * Focus the first element in the focus-trapped region
+ *
+ * @memberof TrapFocusDirective
+ */
+  focusFirstElement() {
+    setTimeout(() => {
+      try {
+        (document.querySelector('.focus--trapped') as HTMLElement).focus();
+      } catch (_) {
+        // do nothing since this error is expected if the element has been removed from the DOM
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    // remove any remaining focus--trapped classes from the DOM
+    document.querySelectorAll('.focus--trapped').forEach((el: HTMLElement) => {
+      el.classList.remove('focus--trapped');
+    });
+  }
+}

--- a/src/app/shared/modules/contextmenu/context-menu/context-menu.component.scss
+++ b/src/app/shared/modules/contextmenu/context-menu/context-menu.component.scss
@@ -1,10 +1,3 @@
 :host {
   display: none !important;
 }
-
-::ng-deep #contextMenuDummyInput {
-  position: fixed;
-  width: 50px;
-  opacity: 0;
-  left: -100px;
-}

--- a/src/app/shared/modules/contextmenu/context-menu/context-menu.component.ts
+++ b/src/app/shared/modules/contextmenu/context-menu/context-menu.component.ts
@@ -126,6 +126,7 @@ export class ContextMenuComponent implements AfterViewInit, OnDestroy {
       const dummyNode = document.createElement('input');
       // hide the input immediately on render
       dummyNode.setAttribute('id', 'contextMenuDummyInput');
+      dummyNode.setAttribute('class', 'dummy-input');
       document.body.appendChild(dummyNode);
 
       // focus the first element in the context menu for accessibility
@@ -142,6 +143,9 @@ export class ContextMenuComponent implements AfterViewInit, OnDestroy {
           }
         });
       });
+
+      // mark the anchor element has the last focused element, since the menu will disappear whenever an element is selected
+      this.anchor.setAttribute('lastFocusedElement', 'true');
 
     } else {
       console.error(
@@ -160,6 +164,11 @@ export class ContextMenuComponent implements AfterViewInit, OnDestroy {
 
     // remove the dummy node from the DOM since we don't need it anymore
     document.getElementById('contextMenuDummyInput').remove();
+
+    setTimeout(() => {
+      // wait 1 second and remove the lastFocusedElement attribute from the anchor element
+      this.anchor.removeAttribute('lastFocusedElement');
+    }, 1000);
   }
 
   /**

--- a/src/app/shared/modules/popups/popup-viewer/popup-viewer.component.ts
+++ b/src/app/shared/modules/popups/popup-viewer/popup-viewer.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { Component, EventEmitter, Output, Input, AfterViewInit, OnDestroy } from '@angular/core';
 import {
   trigger,
   transition,
@@ -46,7 +46,7 @@ import {
     ])
   ],
   template: `
-    <div [@fade] class="overlay" [ngClass]="{'overlay--floating': floating}" (activate)="close.emit()">
+    <div trapFocus [@fade] class="overlay" [ngClass]="{'overlay--floating': floating}" (activate)="close.emit()">
       <div role="dialog" [@scale] (activate)="$event.stopPropagation()">
         <div class="popup-close" (activate)="close.emit()" type="button" aria-label="Close Navigation">
           <i class="far fa-times"></i>

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -2,6 +2,13 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700');
 @import '~_vars.scss';
 
+.dummy-input {
+  position: fixed;
+  width: 50px;
+  opacity: 0;
+  left: -100px;
+}
+
 body {
   font-family: 'Source Sans Pro', sans-serif;
   background: $wrapper-background !important;


### PR DESCRIPTION
Story details: https://app.clubhouse.io/clarkcan/story/640

This PR introduces a trapFocus directive and integrates it with the PopupsModule. Now, when a popup is opened, the user is "trapped" in the popup and cannot tab out of it until the popup is closed. When the popup is closed, the browser refocuses the originally-focused element.