### PR TITLE
Add skip link to details and browse page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.52.1",
+  "version": "2.52.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,8 +1,8 @@
 <clark-message></clark-message>
-<button class="skip-link" (activate)="goToContent('pageContent')">Skip directly to site content</button>
-<button class="skip-link" *ngIf="!loggedin" (activate)="goToContent('clark-sign-in')">Skip directly to Login</button>
-<button class="skip-link" *ngIf="loggedin" (activate)="goToContent('clark-user-dropdown')">Skip directly to your User profile</button>
-<button class="skip-link" (activate)="goToContent('clark-search-input')">Skip directly to Search for Learning Objects</button>
+<clark-skip-link title="Skip directly to site content" skipLocation="pageContent"></clark-skip-link>
+<clark-skip-link *ngIf="!loggedin" title="Skip directly to Login" skipLocation="clark-sign-in"></clark-skip-link>
+<clark-skip-link *ngIf="loggedin" title="Skip directly to your User Profile" skipLocation="clark-user-dropdown"></clark-skip-link>
+<clark-skip-link title="Skip directly to Search for Learning Objects" skipLocation="clark-search-input"></clark-skip-link>
 <div role="navigation" *ngIf="nav.visible">
   <div class="topbar" [ngClass]="{'version': version, 'mobile': isMobile}">
     <div class="inner flex h left-right">

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -1,5 +1,6 @@
-<div tabindex="0" id="pageContent" class="container">
+<div class="container">
   <div class="browse-columns">
+    <clark-skip-link identity="pageContent" title="Skip Directly to Learning Objects" skipLocation="results"></clark-skip-link>
     <div *ngIf="filters" class="sidebar-wrapper" [ngClass]="{'active': filtersDownMobile}">
       <div class="column-title">
         {{ copy.FILTERS }}
@@ -12,10 +13,10 @@
         <button (activate)="closeFilters();" class="button neutral">Cancel</button>
       </div>
     </div>
-    <div *ngIf="learningObjects" class="content" id="content">
+    <div *ngIf="learningObjects" class="content" id="pageContent" tabindex="0">
       <div class="column-title" id="column-title">
-        <span>{{ copy.RESULTS }} ({{this.totalLearningObjects}})
-          <span class="clear-search" id="clear-search" (activate)="clearSearch()" *ngIf="query?.text !== '' || query.standardOutcomes.length">{{ copy.CLEARSEARCH }} </span>
+        <span tabindex="0" id="results">{{ copy.RESULTS }} ({{this.totalLearningObjects}})
+          <a class="clear-search" id="clear-search" (activate)="clearSearch()" *ngIf="query?.text !== '' || query.standardOutcomes.length">{{ copy.CLEARSEARCH }} </a>
           <span class="loading" *ngIf="loading"><i class="far fa-spinner-third fa-spin"></i></span>
         </span>
         <div class="results-options" id="results-options">

--- a/src/app/cube/details/components/splash/details-splash.component.html
+++ b/src/app/cube/details/components/splash/details-splash.component.html
@@ -1,11 +1,11 @@
 <div class="splash">
   <div class="inner">
-    <div class="header">    
-      <div class="name" tabindex="0" id="pageContent">{{ learningObject.name }}</div>
+    <div class="header">
+      <div class="name">{{ learningObject.name }}</div>
       <div class="author">
         <span tabindex="0">Created by </span>
-        <a tabindex="0" [routerLink]="['/users', learningObject.author.username]" class="link" id="author-link" attr.aria-label="Clickable link {{ learningObject.author.name }}">{{learningObject.author.name | titlecase}}</a> - 
-        <a tabindex="-0" [routerLink]="['/organization', learningObject.author.organization]" class="link"  attr.aria-label="Clickable link {{ learningObject.author.organization }}">{{learningObject.author.organization | titlecase}}</a>
+        <a [routerLink]="['/users', learningObject.author.username]" class="link" id="author-link" attr.aria-label="Clickable link {{ learningObject.author.name }}">{{learningObject.author.name | titlecase}}</a> - 
+        <a [routerLink]="['/organization', learningObject.author.organization]" class="link"  attr.aria-label="Clickable link {{ learningObject.author.organization }}">{{learningObject.author.organization | titlecase}}</a>
         <div class="updated" tabindex="0">Updated {{ learningObject.date | date:'shortDate' }}
           <a *ngIf="canViewChangelogs" id="view-changelog" (activate)="openViewAllChangelogsModal()" attr.aria-label="View the changelog for {{ learningObject.name }}" tabindex="0">View the changelog</a>
         </div>

--- a/src/app/cube/details/components/splash/details-splash.component.scss
+++ b/src/app/cube/details/components/splash/details-splash.component.scss
@@ -74,7 +74,7 @@ $content-width: calc(#{$max-width} - #{$sidebar-width});
           font-weight: 400;
         }
 
-        .link:hover {
+        .link:hover, .link:focus {
           cursor: pointer;
           text-decoration: underline;
         }

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -1,4 +1,5 @@
 <ng-container *ngIf="!loading.length; else loadingTemplate">
+  <clark-skip-link identity="pageContent" title="Skip Directly to Download" skipLocation="download-button"></clark-skip-link>
   <div *ngIf="learningObject && !errorStatus && revisedLearningObject" class="details-wrapper" [ngClass]="learningObject.length">
     <cube-details-splash [canRate]="loggedin && auth.user.emailVerified && !isOwnObject" [canViewChangelogs]="loggedin && auth.user.emailVerified" [ratings]="ratings" [averageRating]="averageRatingValue" [learningObject]="learningObject" (showNewRating)="showAddRating = $event;" (openChangelogModal)="openViewAllChangelogsModal()"></cube-details-splash>
     <div class="flex">
@@ -84,7 +85,7 @@
 
 <ng-template #loadingTemplate>
   <div class="loading">
-    <i class="far fa-spinner-third fa-spin"></i>Loading "{{ learningObjectName }}"
+    <i class="far fa-spinner-third fa-spin" aria-live="assertive"></i>Loading "{{ learningObjectName }}"
 
   </div>
 </ng-template>

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -23,6 +23,7 @@ import { RatingStarsComponent } from './rating-stars/rating-stars.component';
 import { TextEditorComponent } from './text-editor/text-editor.component';
 import { ToggleSwitchComponent } from './toggle-switch/toggle-switch.component';
 import { UserCardComponent } from './user-card/user-card.component';
+import { SkipLinkComponent } from './skip-link/skip-link.component';
 
 
 @NgModule({
@@ -51,6 +52,7 @@ import { UserCardComponent } from './user-card/user-card.component';
     TextEditorComponent,
     ToggleSwitchComponent,
     UserCardComponent,
+    SkipLinkComponent,
   ],
   exports: [
     // components
@@ -65,6 +67,7 @@ import { UserCardComponent } from './user-card/user-card.component';
     TextEditorComponent,
     ToggleSwitchComponent,
     UserCardComponent,
+    SkipLinkComponent,
   ]
 })
 export class SharedComponents {}

--- a/src/app/shared/components/skip-link/skip-link.component.html
+++ b/src/app/shared/components/skip-link/skip-link.component.html
@@ -1,0 +1,1 @@
+<button attr.id="{{ identity }}" class="skip-link" (activate)="goToContent(skipLocation)">{{ title }}</button>

--- a/src/app/shared/components/skip-link/skip-link.component.scss
+++ b/src/app/shared/components/skip-link/skip-link.component.scss
@@ -1,0 +1,24 @@
+@import '../../../../vars';
+
+.skip-link {
+    left: -100px;
+    position: absolute;
+    top: auto;
+    width: 0;
+    height: 0;
+    z-index: -1;
+  }
+  
+  .skip-link:focus, .skip-link:active {
+    color: #fff;
+    background-color:$light-blue;
+    left: auto;
+    width: auto;
+    height: auto;
+    overflow:auto;
+    margin: 10px;
+    padding:5px;
+    text-align:center;
+    font-size:$normal;
+    z-index:999;
+  }

--- a/src/app/shared/components/skip-link/skip-link.component.spec.ts
+++ b/src/app/shared/components/skip-link/skip-link.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkipLinkComponent } from './skip-link.component';
+
+describe('SkipLinkComponent', () => {
+  let component: SkipLinkComponent;
+  let fixture: ComponentFixture<SkipLinkComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SkipLinkComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SkipLinkComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/skip-link/skip-link.component.ts
+++ b/src/app/shared/components/skip-link/skip-link.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit, Input } from '@angular/core';
+
+@Component({
+  selector: 'clark-skip-link',
+  templateUrl: './skip-link.component.html',
+  styleUrls: ['./skip-link.component.scss']
+})
+export class SkipLinkComponent implements OnInit {
+
+  @Input() title: string;
+  @Input() skipLocation: string;
+  @Input() identity: string;
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+  goToContent(value: string) {
+    document.getElementById(value).focus();
+  }
+
+}


### PR DESCRIPTION
The purpose of this PR is to: 

1. Add a skip link to results on browse page so a user does not have to tab through all the filters before reaching results.
2. Add a skip link to download button on details page.
3. Change wording of download button to tell a user that is not signed in that they need to sign in in order to download the object. 