### PR TITLE
Implement the description section into the new details page and adjust spacing

### DIFF
--- a/src/app/core/history.service.ts
+++ b/src/app/core/history.service.ts
@@ -9,7 +9,7 @@ export interface HistorySnapshot {
    * @readonly
    * @memberof HistorySnapshot
    */
-  rewind(): void;
+  rewind(defaultUrl: string): void;
 }
 
 @Injectable({
@@ -91,7 +91,7 @@ export class HistoryService {
   snapshot(): HistorySnapshot {
     const index = this.history.length - 1;
     return {
-       rewind: () => { this.back(index); }
+       rewind: (defaultUrl: string = '/home') => { this.back(index); }
     };
   }
 }

--- a/src/app/cube/details/_global-details.scss
+++ b/src/app/cube/details/_global-details.scss
@@ -27,5 +27,5 @@ h2 {
 .details-columns {
   display: grid;
   grid-gap: 40px;
-  grid-template-columns: 2fr minmax(200px, 300px)
+  grid-template-columns: 2fr minmax(250px, 300px)
 }

--- a/src/app/cube/details/_global-details.scss
+++ b/src/app/cube/details/_global-details.scss
@@ -27,5 +27,5 @@ h2 {
 .details-columns {
   display: grid;
   grid-gap: 40px;
-  grid-template-columns: 2fr minmax(250px, 300px)
+  grid-template-columns: 1fr minmax(300px, 320px)
 }

--- a/src/app/cube/details/components/description/description.component.html
+++ b/src/app/cube/details/components/description/description.component.html
@@ -1,0 +1,1 @@
+<slot class="description" [innerHtml]="description"></slot>

--- a/src/app/cube/details/components/description/description.component.scss
+++ b/src/app/cube/details/components/description/description.component.scss
@@ -1,0 +1,9 @@
+@import '~_vars.scss';
+
+slot {
+  color: $dark-grey;
+
+  strong {
+    font-weight: 600 !important;
+  }
+}

--- a/src/app/cube/details/components/description/description.component.spec.ts
+++ b/src/app/cube/details/components/description/description.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DescriptionComponent } from './description.component';
+
+describe('DescriptionComponent', () => {
+  let component: DescriptionComponent;
+  let fixture: ComponentFixture<DescriptionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DescriptionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DescriptionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cube/details/components/description/description.component.ts
+++ b/src/app/cube/details/components/description/description.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'clark-details-description',
+  templateUrl: './description.component.html',
+  styleUrls: ['./description.component.scss'],
+  encapsulation: ViewEncapsulation.ShadowDom
+})
+export class DescriptionComponent implements OnInit {
+  @Input() description: string;
+
+}

--- a/src/app/cube/details/components/splash/grid.ts
+++ b/src/app/cube/details/components/splash/grid.ts
@@ -91,9 +91,9 @@ function setDimensions(wrapperElement: HTMLElement) {
   canvas.setAttribute('width', window.innerWidth.toString());
 
 
-  // take the height of the wrapper element, add 80 for padding, divide by 100 to get a decimal value, round up,
+  // take the height of the wrapper element, add 120 for padding, divide by 100 to get a decimal value, round up,
   // then multiply by 100 to get the lowest value that will show a) all of the content and b) no partial squares vertically
-  const newCanvasHeight = Math.max(300, Math.ceil((wrapperElement.offsetHeight + 80) / 100) * 100);
+  const newCanvasHeight = Math.max(300, Math.ceil((wrapperElement.offsetHeight + 120) / 100) * 100);
   canvas.setAttribute('height', newCanvasHeight + 'px');
 
   // show at most 20, and at lest 5, accent squares. Count is dependent on the width of the canvas (smaller canvases get fewer accents)

--- a/src/app/cube/details/components/splash/splash.component.html
+++ b/src/app/cube/details/components/splash/splash.component.html
@@ -8,7 +8,7 @@
       <div class="details-columns">
         <div class="columns_col1">
           <div #splashWrapper class="splash__content">
-            <span class="content__collection">
+            <span *ngIf="learningObject.collection" class="content__collection">
               <i class="far fa-cubes"></i>
               Part of the <a [routerLink]="['/c', learningObject.collection]"><u>{{ (learningObject.collection | collection) | async }}</u></a> collection
             </span> 

--- a/src/app/cube/details/components/splash/splash.component.html
+++ b/src/app/cube/details/components/splash/splash.component.html
@@ -10,11 +10,11 @@
           <div #splashWrapper class="splash__content">
             <span class="content__collection">
               <i class="far fa-cubes"></i>
-              Part of the <a routerLink="/c/nccp"><u>{{ ('nccp' | collection) | async }}</u></a> collection
+              Part of the <a [routerLink]="['/c', learningObject.collection]"><u>{{ (learningObject.collection | collection) | async }}</u></a> collection
             </span> 
-            <h1>Legal Foundations of Modern Cyber Law and Policy</h1>
-            <span class="content__date">Last updated April 11, 2019</span>
-            <clark-details-splash-length length="module"></clark-details-splash-length>
+            <h1>{{ learningObject.name }}</h1>
+            <span class="content__date">Last updated {{ learningObject.date | date:'longDate' }}</span>
+            <clark-details-splash-length [length]="learningObject.length"></clark-details-splash-length>
           </div>
         </div>
       </div>

--- a/src/app/cube/details/components/splash/splash.component.scss
+++ b/src/app/cube/details/components/splash/splash.component.scss
@@ -24,7 +24,6 @@
 }
 
 .splash-wrapper {
-  padding: 40px 0;
   position: absolute;
   top: 0;
   left: 0;
@@ -48,7 +47,7 @@
   .content__collection {
     color: $light-blue;
     margin-bottom: 15px;
-    margin-top: -20px;
+    margin-top: -10px;
     display: flex;
     align-items: center;
     white-space: pre;

--- a/src/app/cube/details/components/splash/splash.component.ts
+++ b/src/app/cube/details/components/splash/splash.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, AfterViewInit, ViewChild, ElementRef } from '@angular/core';
 import { LearningObject } from '@entity';
 import { Grid } from './grid';
 
@@ -7,7 +7,7 @@ import { Grid } from './grid';
   templateUrl: './splash.component.html',
   styleUrls: ['./splash.component.scss']
 })
-export class SplashComponent implements OnInit {
+export class SplashComponent implements AfterViewInit {
   @Input() learningObject: LearningObject;
 
   @Input() col1 = 1100;
@@ -17,7 +17,7 @@ export class SplashComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     Grid.init(this.splashWrapperElement.nativeElement);
   }
 

--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -1,27 +1,27 @@
 <main id="pageContent" class="details">
-  <section class="details__back details-wrapper">
-    <button class="back__target">
-      <i class="far fa-long-arrow-left"></i> Back to browse
-    </button>
-  </section>
   <section class="details__splash">
     <clark-details-splash [learningObject]="learningObject"></clark-details-splash>
   </section>
   <div class="details-wrapper">
-    <section class="details__description">
-      <h2 class="section-title">Description</h2>
-    </section>
-    <section class="details__outcomes">
-      <h2 class="section-title">Learning Outcomes</h2>
-    </section>
-    <section class="details__levels">
-      <h2 class="section-title">Academic Levels</h2>
-    </section>
-    <section class="details__hierarchy">
-      <h2 class="section-title">Hierarchy</h2>
-    </section>
-    <section class="details__materials">
-      <h2 class="section-title">Materials</h2>
-    </section>
+    <div class="details-columns">
+      <div class="columns__col1">
+        <section class="details__description">
+          <h2 class="section-title">Description</h2>
+          <clark-details-description [description]="learningObject.description"></clark-details-description>
+        </section>
+        <section class="details__outcomes">
+          <h2 class="section-title">Learning Outcomes</h2>
+        </section>
+        <section class="details__levels">
+          <h2 class="section-title">Academic Levels</h2>
+        </section>
+        <section class="details__hierarchy">
+          <h2 class="section-title">Hierarchy</h2>
+        </section>
+        <section class="details__materials">
+          <h2 class="section-title">Materials</h2>
+        </section>
+      </div>
+    </div>
   </div>
 </main>

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -6,5 +6,5 @@
 }
 
 section:not(.details__splash) {
-  margin-top: 90px;
+  margin-top: 70px;
 }

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -5,25 +5,6 @@
   background: white
 }
 
-.details__back {
-
-  .svg-inline--fa,
-  .icon {
-    margin-right: 10px;
-  }
-
-  .back__target {
-    color: $dark-grey;
-    appearance: none;
-    background: 0;
-    border: 0;
-    cursor: pointer;
-    padding-top: 20px;
-    padding-bottom: 20px;
-    font-size: $small;
-  }
-}
-
-section:not(.details__back):not(.details__splash) {
+section:not(.details__splash) {
   margin-top: 90px;
 }

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -11,10 +11,12 @@ import { LearningObjectService } from 'app/cube/learning-object.service';
 export class DetailsComponent implements OnInit {
   learningObject: LearningObject;
 
+  historySnapshot: HistorySnapshot;
+
   // flags
   loading: boolean;
 
-  constructor(private route: ActivatedRoute, private learningObjectService: LearningObjectService) { }
+  constructor(private route: ActivatedRoute, private learningObjectService: LearningObjectService,) { }
 
   ngOnInit() {
     this.route.params.subscribe(({ username, learningObjectName }: { username: string, learningObjectName: string }) => {

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { LearningObject } from '@entity';
+import { ActivatedRoute } from '@angular/router';
+import { LearningObjectService } from 'app/cube/learning-object.service';
 
 @Component({
   selector: 'clark-details',
@@ -9,9 +11,21 @@ import { LearningObject } from '@entity';
 export class DetailsComponent implements OnInit {
   learningObject: LearningObject;
 
-  constructor() { }
+  // flags
+  loading: boolean;
+
+  constructor(private route: ActivatedRoute, private learningObjectService: LearningObjectService) { }
 
   ngOnInit() {
+    this.route.params.subscribe(({ username, learningObjectName }: { username: string, learningObjectName: string }) => {
+      this.getLearningObject(username, learningObjectName)
+    });
+  }
+
+  async getLearningObject(username: string, learningObjectName: string) {
+    this.loading = true;
+    this.learningObject = await this.learningObjectService.getLearningObject(username, learningObjectName)
+    this.loading = false;
   }
 
 }

--- a/src/app/cube/details/details.module.ts
+++ b/src/app/cube/details/details.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { SplashComponent } from './components/splash/splash.component';
 import { LengthComponent } from './components/splash/length/length.component';
 import { SharedPipesModule } from 'app/shared/pipes/shared-pipes.module';
+import { DescriptionComponent } from './components/description/description.component';
 
 @NgModule({
   imports: [
@@ -18,7 +19,8 @@ import { SharedPipesModule } from 'app/shared/pipes/shared-pipes.module';
     DetailsComponent,
     // page components
     SplashComponent,
-    LengthComponent
+    LengthComponent,
+    DescriptionComponent
   ],
   providers: []
 })

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -1,5 +1,5 @@
 // font
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700');
+@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,600,700&display=swap');
 @import '~_vars.scss';
 
 .dummy-input {


### PR DESCRIPTION
This PR introduces the description section into the new details page. It also adjusts some spacing issues with the page as a whole and removes the back button from the page.

<img width="1292" alt="Screen Shot 2019-08-22 at 12 01 14 PM" src="https://user-images.githubusercontent.com/7431390/63530480-8bdae480-c4d4-11e9-9f33-9b61cae33795.png">