### PR TITLE
Send correct query string on submission download request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.55.6",
+  "version": "2.55.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.55.6",
+  "version": "2.55.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/old-details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/old-details/components/action-panel/action-panel.component.ts
@@ -139,8 +139,9 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
   download(author: string, learningObjectName: string) {
     this.downloading = true;
+    const revision = this.revisedVersion || (!this.isReleased && !this.revisedVersion);
     const loaded = this.cartService
-      .downloadLearningObject(author, learningObjectName, this.revisedVersion).pipe(
+      .downloadLearningObject(author, learningObjectName, revision).pipe(
       takeUntil(this.destroyed$));
 
     this.toggleDownloadModal(true);

--- a/src/app/cube/old-details/details.component.ts
+++ b/src/app/cube/old-details/details.component.ts
@@ -167,6 +167,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
         author,
         name
       );
+
       // FIXME: This filter should be removed when service logic is updated
       this.releasedChildren = this.releasedLearningObject.children.filter(
         child => {

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -230,7 +230,7 @@ export const USER_ROUTES = {
   DOWNLOAD_REVISED_OBJECT(author, learningObjectName) {
     return `${environment.apiURL}/users/${encodeURIComponent(
       author
-    )}/learning-objects/${learningObjectName}/bundle?revision`;
+    )}/learning-objects/${learningObjectName}/bundle?revision=true`;
   },
   GET_SAME_ORGANIZATION(organization) {
     return `${

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -230,7 +230,7 @@ export const USER_ROUTES = {
   DOWNLOAD_REVISED_OBJECT(author, learningObjectName) {
     return `${environment.apiURL}/users/${encodeURIComponent(
       author
-    )}/learning-objects/${learningObjectName}/bundle?revision=true`;
+    )}/learning-objects/${learningObjectName}/bundle?revision`;
   },
   GET_SAME_ORGANIZATION(organization) {
     return `${


### PR DESCRIPTION
***Purpose***
This PR updates the action panel component to send the `revision=true` query param on download requests for Learning Object submissions