### PR TITLE
Fix bug where unprivileged users are inexplicably granted access to the editor action pad in builder after submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.55.8",
+  "version": "2.55.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.55.8",
+  "version": "2.55.9",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
@@ -139,7 +139,7 @@
   *ngIf="showSubmission"
   [learningObject]="store.learningObject"
   [visible]="true"
-  (close)="showSubmission = false; ($event && triggerExitBuilder());"
+  (close)="showSubmission = false; ($event && historySnapshot.rewind('/dashboard'));"
 ></clark-submit>
 
 <ng-template

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.html
@@ -47,11 +47,12 @@
         [states]="states"
       ></clark-lo-status-indicator>
       <ng-container
-        *ngIf="!adminMode && ['unreleased', 'rejected'].includes(learningObject?.status); else adminModeTemplate "
+        *ngIf="!adminMode; else adminModeTemplate "
       >
         <button
           id="submit"
           class="button"
+          *ngIf="['unreleased', 'rejected'].includes(learningObject?.status)"
           [ngClass]="{
             good: !submissionError,
             bad: validator.submissionMode && submissionError,
@@ -138,7 +139,7 @@
   *ngIf="showSubmission"
   [learningObject]="store.learningObject"
   [visible]="true"
-  (close)="showSubmission = false; getCollectionName()"
+  (close)="showSubmission = false; ($event && triggerExitBuilder());"
 ></clark-submit>
 
 <ng-template

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
@@ -44,8 +44,6 @@ export class BuilderNavbarComponent implements OnDestroy {
 
   historySnapshot: HistorySnapshot;
 
-  @Output() closeBuilder: EventEmitter<void> = new EventEmitter();
-
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
@@ -282,10 +280,6 @@ export class BuilderNavbarComponent implements OnDestroy {
         this.collection = col;
         this.buildTooltip();
       });
-  }
-
-  triggerExitBuilder() {
-    this.closeBuilder.emit();
   }
 
   ngOnDestroy() {

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
@@ -1,10 +1,10 @@
-import { Component, OnDestroy, Input } from '@angular/core';
+import { Component, OnDestroy, Input, Output, EventEmitter } from '@angular/core';
 import { BuilderStore } from '../../builder-store.service';
 import { AuthService } from 'app/core/auth.service';
 import { LearningObjectValidator } from '../../validators/learning-object.validator';
 import { filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 import { ToasterService } from 'app/shared/modules/toaster';
 import { CollectionService, Collection } from 'app/core/collection.service';
 import { LearningObject } from '@entity';
@@ -43,6 +43,8 @@ export class BuilderNavbarComponent implements OnDestroy {
   @Input() adminMode = false;
 
   historySnapshot: HistorySnapshot;
+
+  @Output() closeBuilder: EventEmitter<void> = new EventEmitter();
 
   constructor(
     private router: Router,
@@ -280,6 +282,10 @@ export class BuilderNavbarComponent implements OnDestroy {
         this.collection = col;
         this.buildTooltip();
       });
+  }
+
+  triggerExitBuilder() {
+    this.closeBuilder.emit();
   }
 
   ngOnDestroy() {

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.html
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.html
@@ -38,7 +38,7 @@
     <div class="modal-text">We are currently unable to save your work due to a network related issue. Please check back
       later and try again.</div>
     <div class="btn-group center">
-      <button class="button good" (activate)="routeToDashboard()">Back to Dashboard</button>
+      <button class="button good" (activate)="exitBuilder()">Back to Dashboard</button>
     </div>
   </div>
 </clark-popup>

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.html
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.html
@@ -1,7 +1,7 @@
 <clark-toaster [content]="noteService.content"></clark-toaster>
 <div class="learning-object-builder-wrapper" [@builderTransition]="getState(o)">
   <!-- The ngIf directive on onion-builder-navbar forces the :enter event to fire for router animations and should NOT be removed -->
-  <onion-builder-navbar *ngIf="true" [adminMode]="adminMode"></onion-builder-navbar>
+  <onion-builder-navbar (closeBuilder)="routeToDashboard()" *ngIf="true" [adminMode]="adminMode"></onion-builder-navbar>
   <router-outlet #o="outlet"></router-outlet>
 </div>
 

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.html
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.html
@@ -1,7 +1,7 @@
 <clark-toaster [content]="noteService.content"></clark-toaster>
 <div class="learning-object-builder-wrapper" [@builderTransition]="getState(o)">
   <!-- The ngIf directive on onion-builder-navbar forces the :enter event to fire for router animations and should NOT be removed -->
-  <onion-builder-navbar (closeBuilder)="routeToDashboard()" *ngIf="true" [adminMode]="adminMode"></onion-builder-navbar>
+  <onion-builder-navbar *ngIf="true" [adminMode]="adminMode"></onion-builder-navbar>
   <router-outlet #o="outlet"></router-outlet>
 </div>
 

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -22,6 +22,7 @@ import { AuthService } from 'app/core/auth.service';
 import { LearningObject } from '@entity';
 import { environment } from '@env/environment.prod';
 import { LearningObjectService } from '../core/learning-object.service';
+import { HistorySnapshot, HistoryService } from 'app/core/history.service';
 
 export const builderTransitions = trigger('builderTransition', [
   transition('* => *', [
@@ -105,7 +106,8 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
   isRevision: boolean;
 
   showServiceFailureModal = false;
-  adminDashboardURL = environment.adminAppUrl;
+
+  historySnapshot: HistorySnapshot;
 
   // tslint:disable-next-line:max-line-length
   constructor(
@@ -117,10 +119,13 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
     private validator: LearningObjectValidator,
     public noteService: ToasterService,
     private authService: AuthService,
-    private learningObjectService: LearningObjectService
+    private learningObjectService: LearningObjectService,
+    private history: HistoryService
   ) { }
 
   ngOnInit() {
+    this.historySnapshot = this.history.snapshot();
+
     // listen for route change and grab name parameter if it's there
     this.route.paramMap
       .pipe(takeUntil(this.destroyed$))
@@ -296,12 +301,12 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
    *
    * @memberof LearningObjectBuilderComponent
    */
-  routeToDashboard() {
+  exitBuilder() {
     this.showServiceFailureModal = false;
     if (!this.adminMode) {
-      this.router.navigate(['/onion/dashboard']);
+      this.historySnapshot.rewind('/onion/dashboard');
     } else {
-      window.location.href = this.adminDashboardURL;
+      this.historySnapshot.rewind('/home');
     }
   }
 

--- a/src/app/onion/shared/submit/submit.component.html
+++ b/src/app/onion/shared/submit/submit.component.html
@@ -35,5 +35,8 @@
         </div>
       </ng-template>
     </clark-carousel>
+    <div *ngIf="loading.length" class="submit__loading">
+      <i class="far fa-spinner-third fa-spin"></i>
+    </div>
   </div>
 </clark-popup>

--- a/src/app/onion/shared/submit/submit.component.scss
+++ b/src/app/onion/shared/submit/submit.component.scss
@@ -73,3 +73,18 @@
 .submit-btn {
   margin-top: 30px;
 }
+
+.submit__loading {
+  position: absolute;
+  z-index: 999999;
+  background: rgba(255, 255, 255, 0.8);
+  color: $light-blue;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 40px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -174,7 +174,6 @@ export class SubmitComponent implements OnInit {
    * @memberof SubmitComponent
    */
   closeModal(submitted?: boolean) {
-    console.log(submitted)
     this.close.emit(submitted || false);
   }
 }

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -26,7 +26,9 @@ export class SubmitComponent implements OnInit {
   licenseAccepted: boolean;
   needsChangelog: boolean;
 
-  @Output() close: EventEmitter<void> = new EventEmitter();
+  loading: boolean[] = [];
+
+  @Output() close: EventEmitter<boolean> = new EventEmitter();
 
   constructor(
     private changelogService: ChangelogService,
@@ -48,6 +50,7 @@ export class SubmitComponent implements OnInit {
    */
   createChangelog() {
     if (this.changelog) {
+      this.loading.push(true);
       this.changelogService
         .createChangelog(
           this.learningObject.author.id,
@@ -56,10 +59,11 @@ export class SubmitComponent implements OnInit {
         )
         .then(() => {
           this.changelogComplete$.next(true);
+          this.loading.pop();
         })
         .catch(e => {
-          this.closeModal();
           this.changelogComplete$.next(false);
+          this.loading.pop();
 
           if (e.status === 401) {
             // user isn't logged in, redirect to login page
@@ -75,7 +79,6 @@ export class SubmitComponent implements OnInit {
         });
     } else {
       this.changelogComplete$.next(true);
-      this.closeModal();
     }
   }
 
@@ -112,6 +115,7 @@ export class SubmitComponent implements OnInit {
     }
 
     if (proceed) {
+      this.loading.push(true);
       this.collectionService
       .submit({
         learningObjectId: this.learningObject.id,
@@ -127,7 +131,8 @@ export class SubmitComponent implements OnInit {
           'good',
           'far fa-check'
         );
-        this.closeModal();
+        this.loading.pop();
+        this.closeModal(true);
         return true;
       })
       .catch(e => {
@@ -142,6 +147,7 @@ export class SubmitComponent implements OnInit {
             'far fa-times'
           );
         }
+        this.loading.pop();
         this.closeModal();
         return false;
       });
@@ -167,7 +173,8 @@ export class SubmitComponent implements OnInit {
    *
    * @memberof SubmitComponent
    */
-  closeModal() {
-    this.close.emit();
+  closeModal(submitted?: boolean) {
+    console.log(submitted)
+    this.close.emit(submitted || false);
   }
 }


### PR DESCRIPTION
This PR fixes a serious bug in the client where users are granted access to the editor action pad immediately following submission, even if the users are not privileged. This granted them the ability to partially bypass our submission process. The user can attempt to release any of their Learning Objects, and while they will show as released in the user's dashboard, the object is never made visible to the public. This presents a worrying loophole wherein the users object is marked as released to the user **and** the collection curators, but invisible any public user, hence putting it in some sort of immutable limbo.