### PR TITLE
Add request for maintenance on load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.58.11",
+  "version": "2.58.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.58.11",
+  "version": "2.58.12",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -103,8 +103,10 @@ export class ClarkComponent implements OnInit {
   }
 
   ngOnInit(): void {
-
     if (environment.production) {
+      this.messages.getMaintenance().then(message => {
+        this.isUnderMaintenance = message;
+      });
       // Determine if the application is currently under maintenance
       setInterval(async () => {
         this.messages.getMaintenance().then(message => {


### PR DESCRIPTION
Currently the application does not make a request right away for the maintenance status. This means that if a client deployment goes in the maintenance page will not be shown for five minutes after the deployment. 