### PR TITLE
Import uri retriever service and use children retriever

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "2.58.10",
+  "version": "2.58.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "2.58.10",
+  "version": "2.58.11",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/uri-retriever.service.ts
+++ b/src/app/core/uri-retriever.service.ts
@@ -206,6 +206,18 @@ export class UriRetrieverService {
     );
   }
 
+  /**
+   * Fetches the resource of the uri that it was given
+   * @param uri the uri of the learning object resource
+   * @param callback
+   */
+  fetchUri(uri: string, callback?: Function) {
+    return this.http.get(uri).pipe(
+      take(1),
+      map(res => callback ? callback(res) : res)
+    );
+  }
+
   private handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {
       // Client-side or network returned error
@@ -220,18 +232,6 @@ export class UriRetrieverService {
   //////////////////////
   // HELPER FUNCTIONS///
   //////////////////////
-
-  /**
-   * Fetches the resource of the uri that it was given
-   * @param uri the uri of the learning object resource
-   * @param callback
-   */
-  private fetchUri(uri: string, callback?: Function) {
-    return this.http.get(uri).pipe(
-      take(1),
-      map(res => callback ? callback(res) : res)
-    );
-  }
 
   /**
    * Packages a full Learning Object with all the resources that were requested

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -360,16 +360,16 @@ export class LearningObjectService {
     );
   }
 
-/**
- * Fetchs the parents of a learning object
- * @param id of learing object
- */
-fetchParents(id: string) {
-  const route = PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id);
-  return this.http.get<LearningObject[]>(route, { withCredentials: true }).toPromise().then(parents => {
-    return parents;
-  });
-}
+  /**
+   * Fetchs the parents of a learning object
+   * @param id of learing object
+   */
+  fetchParents(id: string) {
+    const route = PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id);
+    return this.http.get<LearningObject[]>(route, { withCredentials: true }).toPromise().then(parents => {
+      return parents;
+    });
+  }
 
   /**
    * Adds file meta to a Learning Object's materials

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.html
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.html
@@ -15,7 +15,7 @@
     <div class="name" role="button" (activate)="actionPermissions('infoPanel')&&openInfoPanel()" [ngClass]="[actionPermissions('infoPanel') ? 'clickable' : 'notClickable']">
       {{ learningObject.name }}
       <span *ngIf="parents?.length" [tip]="parents.join(', ')" tipPosition="top" class="hierarchy-parents">{{ parents.length }} parent{{ parents.length !== 1 ? 's' : '' }}</span>
-      <span *ngIf="learningObject.children?.length" [tip]="objectChildrenNames(learningObject).join(', ')" tipPosition="top" class="hierarchy-children">{{ learningObject.children.length }} {{ learningObject.children.length !== 1 ? 'children' : 'child' }}</span>
+      <span *ngIf="children?.length" [tip]="children.join(', ')" tipPosition="top" class="hierarchy-children">{{ children.length }} {{ children.length !== 1 ? 'children' : 'child' }}</span>
     </div>
     <div *ngIf="hasAuthor">
       {{ learningObject.author.name | titlecase }}

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -14,6 +14,8 @@ import { StatusDescriptions } from 'environments/status-descriptions';
 import { AuthService } from 'app/core/auth.service';
 import { LearningObject } from 'entity/learning-object/learning-object';
 import { LearningObjectService } from 'app/onion/core/learning-object.service';
+import { UriRetrieverService } from 'app/core/uri-retriever.service';
+import { takeUntil } from 'rxjs/operators';
 
 
 @Component({
@@ -80,16 +82,19 @@ export class DashboardItemComponent implements OnInit, OnChanges {
 
   // parents
   parents: string[];
+  children: string[];
 
   constructor(
     private auth: AuthService,
     private statuses: StatusDescriptions,
     private cd: ChangeDetectorRef,
-    private learningObjectService: LearningObjectService
+    private learningObjectService: LearningObjectService,
+    private uriRetriever: UriRetrieverService
   ) {}
 
   async ngOnInit() {
     this.parents = await this.parentNames();
+    this.children = await this.objectChildrenNames();
     this.cd.detectChanges();
   }
 
@@ -174,15 +179,19 @@ export class DashboardItemComponent implements OnInit, OnChanges {
    * Takes a learning object and returns a list of it's children's names or an empty list
    * @return {string[]}
    */
-  objectChildrenNames(learningObject: LearningObject): string[] {
-    if (learningObject.children && learningObject.children.length) {
-      return (learningObject.children as LearningObject[]).map(
-        l => l.name
-      );
-    } else {
+  async objectChildrenNames() {
+    const result = [];
+    return this.uriRetriever.getLearningObjectChildren({uri: this.learningObject.resourceUris.children, unreleased: true}).toPromise().then(children => {
+      children.forEach(child => {
+        result.push(child.name);
+      });
+      return result;
+    }).catch(err => {
+      console.error(err);
       return [];
-    }
+    });
   }
+
   openInfoPanel() {
     if (!this.meatballOpen) {
       this.viewSidePanel.emit();

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -181,7 +181,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
    */
   async objectChildrenNames() {
     const result = [];
-    return this.uriRetriever.getLearningObjectChildren({uri: this.learningObject.resourceUris.children, unreleased: true}).toPromise().then(children => {
+    return this.uriRetriever.fetchUri(this.learningObject.resourceUris.children).toPromise().then((children: LearningObject[]) => {
       children.forEach(child => {
         result.push(child.name);
       });

--- a/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.ts
+++ b/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.ts
@@ -32,7 +32,6 @@ export class RevisionComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges) {
     this.hasRevision = false;
-    console.log(this.revision);
     if (this.revision) {
       this.hasRevision = true;
     }

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -310,6 +310,5 @@ export class DashboardComponent implements OnInit {
 
   async createRevision(object: LearningObject) {
     const revisionId = this.learningObjectService.createRevision(object.id, object.author.username);
-    console.log(revisionId);
   }
 }

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -221,7 +221,6 @@ export class BuilderStore {
     return retrieve()
       .then(object => {
         this.learningObject = object;
-        console.log(this.learningObject);
         // this learning object is submitted, ensure submission mode is on
         this.validator.submissionMode =
           this.learningObject.status &&


### PR DESCRIPTION
Since we are using resource uris now to retrieve children and parents, the dashboard in the builder needed to be updated to retrieve these children and get their names.

Story 1325