### PR TITLE
Cube backwards compat

### DIFF
--- a/src/app/cube/core/route-backwards-compat.guard.spec.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { RouteBackwardsCompatGuard } from './route-backwards-compat.guard';
+
+describe('RouteBackwardsCompatGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [RouteBackwardsCompatGuard]
+    });
+  });
+
+  it('should ...', inject([RouteBackwardsCompatGuard], (guard: RouteBackwardsCompatGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/cube/core/route-backwards-compat.guard.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import { router } from 'app/onion/learning-object-builder/components/content-upload/app/content-upload.routes';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '@env/environment';
 

--- a/src/app/cube/core/route-backwards-compat.guard.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RouteBackwardsCompatGuard implements CanActivate {
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return true;
+  }
+  
+}

--- a/src/app/cube/core/route-backwards-compat.guard.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.ts
@@ -9,7 +9,13 @@ export class RouteBackwardsCompatGuard implements CanActivate {
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
-    return true;
+      const cuidRegex = /([a-z0-9]){8}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){12}/;
+      console.log(next.params.learningObjectName.search(cuidRegex));
+      if (next.params.learningObjectName.search(cuidRegex) === 0) {
+        return true;
+      } else {
+        return false;
+      }
   }
   
 }

--- a/src/app/cube/core/route-backwards-compat.guard.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.ts
@@ -1,11 +1,15 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable } from 'rxjs';
+import { router } from 'app/onion/learning-object-builder/components/content-upload/app/content-upload.routes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RouteBackwardsCompatGuard implements CanActivate {
+
+  constructor(private router: Router) {}
+
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
@@ -14,7 +18,8 @@ export class RouteBackwardsCompatGuard implements CanActivate {
       if (next.params.learningObjectName.search(cuidRegex) === 0) {
         return true;
       } else {
-        return false;
+        // Route home first, change to found cuid later
+        return this.router.createUrlTree(['']);
       }
   }
   

--- a/src/app/cube/core/route-backwards-compat.guard.ts
+++ b/src/app/cube/core/route-backwards-compat.guard.ts
@@ -2,24 +2,31 @@ import { Injectable } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { router } from 'app/onion/learning-object-builder/components/content-upload/app/content-upload.routes';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '@env/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RouteBackwardsCompatGuard implements CanActivate {
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private http: HttpClient) {}
 
   canActivate(
     next: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
       const cuidRegex = /([a-z0-9]){8}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){12}/;
-      console.log(next.params.learningObjectName.search(cuidRegex));
       if (next.params.learningObjectName.search(cuidRegex) === 0) {
         return true;
       } else {
-        // Route home first, change to found cuid later
-        return this.router.createUrlTree(['']);
+        // http://localhost:4200/details/kkuczynski/Principles%20of%20Cyber%20Law%20and%20Policy
+        return this.http.get(`${environment.apiURL}}/learning-objects/${next.params.username}/${next.params.learningObjectName}`, { withCredentials: false }).toPromise().then(cuid => {
+          return this.router.createUrlTree([`/details/${next.params.username}/${cuid}`]);
+        }).catch(err => {
+          console.error(err);
+          // TODO: Route to Not Found page instead of home
+          return this.router.createUrlTree(['']);
+        });
       }
   }
   

--- a/src/app/cube/details/details.module.ts
+++ b/src/app/cube/details/details.module.ts
@@ -30,10 +30,11 @@ import { EditorialActionPadModule } from './components/action-panel/editorial-ac
 import { ReviewerPanelComponent } from './components/reviewer-panel/reviewer-panel.component';
 import { CubePatternComponent } from './components/cube-pattern/cube-pattern.component';
 import { ActionPadComponent } from './components/action-pad/action-pad.component';
+import { RouteBackwardsCompatGuard } from '../core/route-backwards-compat.guard';
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule.forChild([ { path: ':username/:learningObjectName', component: DetailsComponent } ]),
+    RouterModule.forChild([ { path: ':username/:learningObjectName', component: DetailsComponent, canActivate: [ RouteBackwardsCompatGuard ]} ]),
     SharedPipesModule,
     FileBrowserModule,
     FormsModule,


### PR DESCRIPTION
Adds route backwards compatibility to the client so old links to content on clark are still valid.  Needs to go in after the gateway PR is merged.

Test URL in development: http://localhost:4200/details/kkuczynski/Principles%20of%20Cyber%20Law%20and%20Policy