### PR TITLE
Fix parents not showing on dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "3.8.4",
+  "version": "3.8.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -361,11 +361,11 @@ export class LearningObjectService {
   }
 
   /**
-   * Fetchs the parents of a learning object
-   * @param id of learing object
+   * Fetches the parents of a learning object
+   * @param id of learning object
    */
-  fetchParents(id: string) {
-    const route = PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id);
+  fetchParents(username: string, id: string) {
+    const route = PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(username, id);
     return this.http.get<LearningObject[]>(route, { withCredentials: true }).toPromise().then(parents => {
       return parents;
     });

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -203,7 +203,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
    */
   async parentNames() {
     const parents = [];
-    return this.learningObjectService.fetchParents(this.learningObject.id).then(returners => {
+    return this.learningObjectService.fetchParents(this.learningObject.author.username, this.learningObject.id).then(returners => {
       returners.forEach(parent => {
         parents.push(parent.name);
       });

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -379,8 +379,8 @@ export const PUBLIC_LEARNING_OBJECT_ROUTES = {
       username
     )}/learning-objects`;
   },
-  GET_LEARNING_OBJECT_PARENTS(id: string) {
-    return `${environment.apiURL}/learning-objects/${id}/parents`;
+  GET_LEARNING_OBJECT_PARENTS(username: string, id: string) {
+    return `${environment.apiURL}/users/${username}/learning-objects/${id}/parents`;
   },
   DOWNLOAD_FILE(params: {
     username: string;


### PR DESCRIPTION
I updated the parents route in Learning Object Service yesterday and forgot that we are using it on the dashboard. This updates the route for the new route structure so that the number of parents and children will show on the dashboard. 