### PR TITLE
Add link to Plan C page that automatically filters by video when directed to browse page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "3.8.6",
+  "version": "3.8.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -42,6 +42,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     orderBy: undefined,
     sortType: undefined,
     collection: '',
+    fileTypes: [],
   };
 
   tooltipText = {

--- a/src/app/cube/shared/featured/featured.component.html
+++ b/src/app/cube/shared/featured/featured.component.html
@@ -8,7 +8,11 @@
 </div>
 
 <ng-template #noObjectsTemplate>
-  <div class="no-objects">
+  <div *ngIf="collectionName !== 'plan c'" class="no-objects">
     There are no Learning Objects released for this collection. Click <a routerLink="/browse">here</a> to browse all.
+  </div>
+  <div *ngIf="collectionName === 'plan c'" class="no-objects">
+    Click <a [routerLink]="['/browse']" [queryParams]="{ fileTypes: 'video' }">here</a> to browse Learning Objects with video content.
+       
   </div>
 </ng-template>

--- a/src/app/cube/shared/featured/featured.component.html
+++ b/src/app/cube/shared/featured/featured.component.html
@@ -10,6 +10,7 @@
 <ng-template #noObjectsTemplate>
   <div *ngIf="collectionName !== 'plan c'" class="no-objects">
     Click <a routerLink="/browse">here</a> to browse all.
+  </div>
   <div *ngIf="collectionName === 'plan c'" class="no-objects">
     Click <a [routerLink]="['/browse']" [queryParams]="{ fileTypes: 'video' }">here</a> to browse Learning Objects with video content.
   </div>

--- a/src/app/cube/shared/featured/featured.component.html
+++ b/src/app/cube/shared/featured/featured.component.html
@@ -13,6 +13,5 @@
   </div>
   <div *ngIf="collectionName === 'plan c'" class="no-objects">
     Click <a [routerLink]="['/browse']" [queryParams]="{ fileTypes: 'video' }">here</a> to browse Learning Objects with video content.
-       
   </div>
 </ng-template>

--- a/src/app/cube/shared/featured/featured.component.ts
+++ b/src/app/cube/shared/featured/featured.component.ts
@@ -28,7 +28,6 @@ export class FeaturedComponent implements OnInit {
   }
 
   ngOnInit() {
-    console.log(this.collection);
     if (this.collection) {
       this.loading = true;
       this.collection.pipe(takeUntil(this.destroyed$)).subscribe({

--- a/src/app/cube/shared/featured/featured.component.ts
+++ b/src/app/cube/shared/featured/featured.component.ts
@@ -21,16 +21,19 @@ export class FeaturedComponent implements OnInit {
     status: [LearningObject.Status.RELEASED]
   };
   loading = false;
+  collectionName: string;
 
   constructor(private learningObjectService: LearningObjectService) {
     this.learningObjects = this.learningObjects.fill(new LearningObject());
   }
 
   ngOnInit() {
+    console.log(this.collection);
     if (this.collection) {
       this.loading = true;
       this.collection.pipe(takeUntil(this.destroyed$)).subscribe({
         next: collection => {
+          this.collectionName = collection;
           this.query.collection = collection;
           this.fetchLearningObjects();
         }

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -22,6 +22,7 @@ export interface Query {
     | { id: string; name: string; date: string; outcome: string }[];
   collection?: string;
   status?: string[];
+  fileTypes?: string[];
 }
 
 export interface MappingQuery extends Query {


### PR DESCRIPTION
Until we have objects in the Plan C collection we will be directing users to all other objects on our site that have video content. 
<img width="1406" alt="Screen Shot 2020-03-20 at 12 49 22 PM" src="https://user-images.githubusercontent.com/43140629/77186508-5e293e80-6aa9-11ea-9e0f-ff863387f2c6.png">
