### PR TITLE
Davidns/ch2141/implement frontend mocks for change learning object author

### DIFF
--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -17,6 +17,8 @@ import { PrivilegesListComponent } from './components/user-privileges/privileges
 import { CoreModule } from './core/core.module';
 import { LearningObjectListItemComponent } from './components/learning-object-list-item/learning-object-list-item.component';
 import { VirtualScrollerModule } from 'ngx-virtual-scroller';
+import { ChangeAuthorComponent } from './components/change-author/change-author.component';
+import { ChangeAuthorUserDropdownComponent } from './components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component';
 
 
 @NgModule({
@@ -33,6 +35,8 @@ import { VirtualScrollerModule } from 'ngx-virtual-scroller';
     UserPrivilegesComponent,
     PrivilegesListComponent,
     LearningObjectListItemComponent,
+    ChangeAuthorComponent,
+    ChangeAuthorUserDropdownComponent,
   ],
   imports: [
     CoreModule.forRoot(),

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -39,9 +39,9 @@
     <clark-change-author-user-dropdown (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
 
       <div class="btn-group center">
-        <button class="button good" (click)="toggleState(true)">Continue</button>
+        <button class="button good" aria-label="Change author" (click)="toggleState(true)">Continue</button>
 
-        <button class="button neutral" (activate)="close.emit()">Cancel</button>
+        <button class="button neutral" aria-label="Cancel" (activate)="close.emit()">Cancel</button>
       </div>
 </div>
 </ng-template>
@@ -61,13 +61,13 @@
 
 </div>
 <div class="change-author-confirmation">
-  <input (change)="toggleConsent($event)" name='change-author-checkbox' id='change-author-checkbox' type="checkbox">
+  <input (change)="toggleConsent($event)" aria-label="Change author confirmation checkbox" name='change-author-checkbox' id='change-author-checkbox' type="checkbox">
   <label for='change-author-checkbox' class="description xs">I have checked that the user I want to change authorship to is the correct user</label>
 </div>
 <div class="btn-group center">
 
-  <button class="button good">Change Author</button>
-  <button class="button neutral" (click)="toggleState(false)">Back</button>
+  <button class="button good" aria-label="Change author button">Change Author</button>
+  <button class="button neutral" aria-label="Back" (click)="toggleState(false)">Back</button>
 
 </div>
 </ng-template>

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -51,12 +51,16 @@
     <p class="banner-sub">Please confirm this change</p>
 </div>
 <div class="change-author-content">
-  <div>Are you sure you want to change this learning object's author?</div>
-  <div>Change the learning object author of "{{highlightedLearningObject.name}}" from {{highlightedLearningObject.author.name}} ({{highlightedLearningObject.author.organization}}) to {{selectedAuthor._username}} ({{selectedAuthor._organization}})). </div>
-  <div>Please Check to ensure that the new author is the correct user that you would like to change authorship of. Note that 
+  <div class="content-header padding-extra">Are you sure you want to change this learning object's author?</div>
+  <div class="description sm padding-indent">Change the learning object author of "{{highlightedLearningObject.name | titlecase}}" from {{highlightedLearningObject.author.name | titlecase}} ({{highlightedLearningObject.author.organization | titlecase}}) to {{selectedAuthor._name | titlecase}} ({{selectedAuthor._organization | titlecase}})). </div>
+  <div class="description sm padding-indent">Please Check to ensure that the new author is the correct user that you would like to change authorship of. Note that 
     changing the author will add the previous author onto the list of contributors for the object. 
   </div>
 
+</div>
+<div class="change-author-confirmation">
+  <input (change)="toggleConsent($event)" name='change-author-checkbox' id='change-author-checkbox' type="checkbox">
+  <label for='change-author-checkbox' class="description xs">I have checked that the user I want to change authorship to is the correct user</label>
 </div>
 <div class="btn-group center">
 

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngTemplateOutlet="finalStage ? confirmation : chooseAuthor"></ng-container>
 
 <ng-template #chooseAuthor>
-  <div class="change-author-banner">
+  <div class="change-author-banner" >
     <h3 class="banner-title">Change Learning Object Author </h3>
     <p class="banner-sub">The previous author will be added to the list of contributors</p>
 </div>
@@ -35,11 +35,13 @@
       </div>
 </div>
 <div class="content-header"> New Author </div>
+<div aria-live="assertive" *ngIf='selectAuthorFailure && selectAuthorFailure.length > 0' class="error" ><i  class="fas fa-info-circle"></i> {{ selectAuthorFailure || '' }} </div>
     <clark-change-author-user-dropdown (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
+
       <div class="btn-group center">
         <button class="button good" (click)="toggleState(true)">Continue</button>
 
-        <button class="button neutral">Cancel</button>
+        <button class="button neutral" (activate)="close.emit()">Cancel</button>
       </div>
 </div>
 </ng-template>

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -35,7 +35,10 @@
       </div>
 </div>
 <div class="content-header"> New Author </div>
-<div aria-live="assertive" *ngIf='selectAuthorFailure && selectAuthorFailure.length > 0' class="error" ><i  class="fas fa-info-circle"></i> {{ selectAuthorFailure || '' }} </div>
+<div class="error-wrapper">
+  <div aria-live="assertive" *ngIf='selectAuthorFailure && selectAuthorFailure.length > 0' class="error" ><i  class="fas fa-info-circle"></i> {{ selectAuthorFailure || '' }} </div>
+
+</div>
     <clark-change-author-user-dropdown [currentAuthor]="selectedAuthor" (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
 
       <div class="btn-group center">

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -36,7 +36,7 @@
 </div>
 <div class="content-header"> New Author </div>
 <div aria-live="assertive" *ngIf='selectAuthorFailure && selectAuthorFailure.length > 0' class="error" ><i  class="fas fa-info-circle"></i> {{ selectAuthorFailure || '' }} </div>
-    <clark-change-author-user-dropdown (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
+    <clark-change-author-user-dropdown [currentAuthor]="selectedAuthor" (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
 
       <div class="btn-group center">
         <button class="button good" aria-label="Change author" (click)="toggleState(true)">Continue</button>

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -1,0 +1,69 @@
+<ng-container *ngTemplateOutlet="finalStage ? confirmation : chooseAuthor"></ng-container>
+
+<ng-template #chooseAuthor>
+  <div class="change-author-banner">
+    <h3 class="banner-title">Change Learning Object Author </h3>
+    <p class="banner-sub">The previous author will be added to the list of contributors</p>
+</div>
+<div class="change-author-content">
+<div class="content-header"> Learning Object </div>
+
+<div class="card-container">
+    <div class="row-item">
+        <div class="left">
+          <div tabindex="0" class="status" [attr.aria-label]="'Learning Object Status: ' + highlightedLearningObject.status + '. ' + statusDescription" [ngClass]="highlightedLearningObject.status" [tip]="statusDescription" [tipDisabled]="!statusDescription" tipPosition="top">
+            <span *ngIf="highlightedLearningObject.status === 'unreleased'"><i class="fas fa-eye-slash"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'waiting'"><i class="fas fa-hourglass"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'review'"><i class="fas fa-sync"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'proofing'"><i class="fas fa-shield"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'released'"><i class="fas fa-eye"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'rejected'"><i class="fas fa-ban"></i></span>
+          </div>
+          <div>
+            {{ highlightedLearningObject.name }}
+          </div>
+        </div>
+        <div class="right">
+            <div>
+                {{ highlightedLearningObject.author.name | titlecase }}
+              </div>
+              <div>{{ highlightedLearningObject.length | titlecase }}</div>
+              <div>{{ highlightedLearningObject.date | date:'longDate' }}</div>
+        </div>
+       
+
+      </div>
+</div>
+<div class="content-header"> New Author </div>
+    <clark-change-author-user-dropdown (newAuthor)="setSelectedAuthor($event)"></clark-change-author-user-dropdown>
+      <div class="btn-group center">
+        <button class="button good" (click)="toggleState(true)">Continue</button>
+
+        <button class="button neutral">Cancel</button>
+      </div>
+</div>
+</ng-template>
+
+<ng-template #confirmation>
+
+  <div class="change-author-banner">
+    <h3 class="banner-title">Change Author Confirmation </h3>
+    <p class="banner-sub">Please confirm this change</p>
+</div>
+<div class="change-author-content">
+  <div>Are you sure you want to change this learning object's author?</div>
+  <div>Change the learning object author of "{{highlightedLearningObject.name}}" from {{highlightedLearningObject.author.name}} ({{highlightedLearningObject.author.organization}}) to {{selectedAuthor._username}} ({{selectedAuthor._organization}})). </div>
+  <div>Please Check to ensure that the new author is the correct user that you would like to change authorship of. Note that 
+    changing the author will add the previous author onto the list of contributors for the object. 
+  </div>
+
+</div>
+<div class="btn-group center">
+
+  <button class="button good">Change Author</button>
+  <button class="button neutral" (click)="toggleState(false)">Back</button>
+
+</div>
+</ng-template>
+
+

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -143,3 +143,52 @@
       padding-top: 100%;
     }
   }
+
+  .change-author-confirmation { 
+    display: flex;
+    border: 1px solid #d1d1d1;
+    border-radius: 4px;
+    padding: 5px;
+    max-width: 300px;
+    margin: auto;
+    margin-bottom: 40px;
+    margin-top: 20px;
+    label{ 
+      padding: 5px 15px;
+    }
+  }
+
+  .padding-extra{ 
+    padding: 10px 0px;
+
+  }
+
+  .padding-indent{ 
+    padding: 10px 10px
+  }
+
+  .description{ 
+    color: #424242;
+    &.sm{
+      font-size: $small;
+    }
+    &.xs { 
+      font-size: $smaller;
+    }
+  }
+
+  .error{ 
+    color: $light-blue;
+    font-size: $small;
+    padding: 10px;
+    animation: fade-in-out .5s  ;
+  }
+
+  @keyframes fade-in-out {
+    0%{
+      opacity: 0;
+    }
+    100%{
+      opacity: 1;
+    }
+  }

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -176,10 +176,14 @@
     }
   }
 
+  .error-wrapper{
+    min-height: 12px;
+  }
+
   .error{ 
     color: $light-blue;
     font-size: $small;
-    padding: 10px;
+    padding: 5px;
     animation: fade-in-out .5s  ;
   }
 

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -1,0 +1,145 @@
+@import '~_vars.scss';
+
+.change-author-banner{
+    top: 0;
+    left: 0;
+    right: 0;
+    box-sizing: border-box;
+    padding: 20px;
+    position: absolute;
+    background: linear-gradient(45deg, darken($light-blue, 5), lighten($light-blue, 5));
+    &:after {
+        content: '';
+        background: white;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        opacity: 0.04;
+        mask: $cube-pattern repeat;
+      }
+
+      .banner-title {
+        color: white;
+        font-size: $larger;
+        font-weight: normal;
+        padding: 0px;
+        margin: 0px;
+      }
+      .banner-sub {
+        color: white;
+        opacity: 0.85;
+        font-size: $normal;
+        padding: 0px;
+        margin: 0px;
+      }
+}
+.change-author-content{
+    padding-top: 90px;
+
+}
+.content-header{
+    font-size: $large;
+    color: $dark-grey;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-bottom: .5em;
+    height: 40px;
+}
+
+.status {
+    width: 32px;
+    height: 32px;
+    color: white;
+    font-size: $normal;
+    border-radius: 50%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: $status_unreleased;
+    transition: all 0.2s ease;
+    box-shadow: none;
+  
+    &.waiting {
+      background: $status_waiting;
+    }
+  
+    &.review {
+      background: $status_review;
+    }
+  
+    &.proofing {
+      background: $status_proofing;
+    }
+  
+    &.released {
+      background: $status_released;
+    }
+  
+    &.denied {
+      background: $status_rejected;
+    }
+  
+    &:hover {
+      box-shadow: 0 0 20px 2px rgba(0, 0, 0, 0.08);
+    }
+  }
+.card-container{ 
+    transition: background 0.1s ease;
+    font-size: $small;
+    color: $darker-grey;
+    margin-bottom: 3em;
+}
+.row-item {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    .left { 
+        display: flex;
+        align-items: center;
+        width: 45%;
+        flex-direction: row;
+        justify-content: space-around;
+    }
+    .right { 
+        display: flex;
+        align-items: center;
+        width: 45%;
+        flex-direction: row;
+        justify-content: space-around;    }
+  }
+
+
+
+  .name {
+    font-size: $small;
+
+    .hierarchy-parents,
+    .hierarchy-children {
+      color: $light-blue;
+      font-size: $small;
+      margin-left: 10px;
+      font-style: bold;
+    }
+
+  }
+
+  .dashboard-item__revision-badge {
+    background: $light-blue;
+    width: 10px;
+    position: absolute;
+    top: -5px;
+    right: -5px;
+    border-radius: 50%;
+    border: 3px solid white;
+    box-shadow: 0 0 3px 1px rgba(0, 0, 0, 0.1);
+
+    &:after {
+      content: '';
+      display: block;
+      padding-top: 100%;
+    }
+  }

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -145,7 +145,7 @@
 
   .change-author-confirmation { 
     display: flex;
-    border: 1px solid #d1d1d1;
+    border: 1px solid $light-grey;
     border-radius: 4px;
     padding: 5px;
     max-width: 300px;

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -61,6 +61,7 @@
     background: $status_unreleased;
     transition: all 0.2s ease;
     box-shadow: none;
+    margin: 0px 10px;
   
     &.waiting {
       background: $status_waiting;
@@ -100,9 +101,7 @@
     .left { 
         display: flex;
         align-items: center;
-        width: 45%;
         flex-direction: row;
-        justify-content: space-around;
     }
     .right { 
         display: flex;

--- a/src/app/admin/components/change-author/change-author.component.spec.ts
+++ b/src/app/admin/components/change-author/change-author.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeAuthorComponent } from './change-author.component';
+
+describe('ChangeAuthorComponent', () => {
+  let component: ChangeAuthorComponent;
+  let fixture: ComponentFixture<ChangeAuthorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChangeAuthorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeAuthorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/components/change-author/change-author.component.ts
+++ b/src/app/admin/components/change-author/change-author.component.ts
@@ -1,0 +1,32 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { LearningObject, User } from '@entity';
+
+@Component({
+  selector: 'clark-change-author',
+  templateUrl: './change-author.component.html',
+  styleUrls: ['./change-author.component.scss']
+})
+export class ChangeAuthorComponent implements OnInit {
+
+  finalStage: boolean = false;
+
+  constructor() { }
+  @Input() highlightedLearningObject: LearningObject;
+  @Input() statusDescription;
+
+  selectedAuthor: User;
+  ngOnInit(): void {
+  }
+
+  toggleState(renderFinalStage: boolean){
+    this.finalStage = renderFinalStage;
+  }
+
+  setSelectedAuthor(author){
+    if(author){
+      console.log('author exists ', author);
+
+      this.selectedAuthor = author;
+    }
+  }
+}

--- a/src/app/admin/components/change-author/change-author.component.ts
+++ b/src/app/admin/components/change-author/change-author.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
 import { LearningObject, User } from '@entity';
 
 @Component({
@@ -8,25 +8,47 @@ import { LearningObject, User } from '@entity';
 })
 export class ChangeAuthorComponent implements OnInit {
 
-  finalStage: boolean = false;
-
+  finalStage = false;
+  selectAuthorFailure: string;
+  consentGiven = false;
+  failureTimer;
   constructor() { }
   @Input() highlightedLearningObject: LearningObject;
   @Input() statusDescription;
+  @Output() close: EventEmitter<void> = new EventEmitter();
 
   selectedAuthor: User;
   ngOnInit(): void {
   }
 
-  toggleState(renderFinalStage: boolean){
-    this.finalStage = renderFinalStage;
+  toggleState(renderFinalStage: boolean) {
+    if (this.selectedAuthor && this.selectedAuthor.username) {
+      this.finalStage = renderFinalStage;
+    } else {
+      this.renderError();
+    }
   }
 
-  setSelectedAuthor(author){
-    if(author){
-      console.log('author exists ', author);
-
+  setSelectedAuthor(author) {
+    if (author) {
+      this.selectAuthorFailure = undefined;
       this.selectedAuthor = author;
     }
+  }
+
+  toggleConsent(event) {
+    if (event.target.checked) {
+      this.consentGiven = true;
+    } else {
+      this.consentGiven = false;
+    }
+  }
+
+  renderError() {
+    this.selectAuthorFailure = 'Please select an author before continuing';
+
+    this.failureTimer = setTimeout(() => {
+      this.selectAuthorFailure = undefined;
+    }, 4000);
   }
 }

--- a/src/app/admin/components/change-author/change-author.component.ts
+++ b/src/app/admin/components/change-author/change-author.component.ts
@@ -12,12 +12,14 @@ export class ChangeAuthorComponent implements OnInit {
   selectAuthorFailure: string;
   consentGiven = false;
   failureTimer;
-  constructor() { }
+  selectedAuthor: User;
   @Input() highlightedLearningObject: LearningObject;
   @Input() statusDescription;
   @Output() close: EventEmitter<void> = new EventEmitter();
 
-  selectedAuthor: User;
+  constructor() { }
+
+
   ngOnInit(): void {
   }
 

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.html
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.html
@@ -1,0 +1,44 @@
+<div class="user-dropdown">
+  <div class="input-container">
+    <i class="fas fa-search"></i> 
+    <input type="text" aria-label="Find users by their name, username, or email address." class="user-dropdown__search-input" placeholder="Search for authors" [(ngModel)]="query" (input)="userSearchInput$.next($event.currentTarget.value)">
+  </div>
+    <ul *ngIf="showDropdown" class="user-dropdown__list">
+        <ng-container *ngTemplateOutlet="loading ? loadingTemplate : resultsTemplate"></ng-container>
+    </ul>
+
+    <div *ngIf="selectedAuthor && selectedAuthor.username" class="author-details-container">
+      <div class="left">
+        <span class="user-dropdown__navbar-gravatar image" [ngStyle]="{'background-image': 'url(' + userService.getGravatarImage(selectedAuthor.email, 200) + ')'}"></span>
+        <span class="details">
+              <p>{{selectedAuthor.username}}</p>
+              <p>{{selectedAuthor.organization}} - {{selectedAuthor.email}}</p>
+        </span>
+      </div>
+      <div (click)="toggleAuthor()" class="right"><i class="fas fa-times"></i></div>
+  </div>
+  </div>
+
+  <ng-template #resultsTemplate>
+    <ng-container *ngIf="searchResults && searchResults.length; else noResultsTemplate">
+      <virtual-scroller #searchResultsScroller [items]="searchResults">
+        <li class="user-dropdown__list-item" *ngFor="let user of searchResultsScroller.viewPortItems" (activate)="toggleAuthor(user)">
+         
+          <span class="user-dropdown__navbar-gravatar" [ngStyle]="{'background-image': 'url(' + userService.getGravatarImage(user.email, 200) + ')'}"></span>
+          {{ user.username }} - {{ user.name | titlecase }} from {{ user.organization | titlecase }}
+        </li>
+      </virtual-scroller>
+    </ng-container>
+  </ng-template>
+  
+  <ng-template #loadingTemplate>
+    <span class="user-dropdown__message">
+      <i class="far fa-spinner-third fa-spin"></i>
+    </span>
+  </ng-template>
+  
+  <ng-template #noResultsTemplate>
+    <span class="user-dropdown__message">
+      No results!
+    </span>
+  </ng-template>

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.html
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.html
@@ -15,7 +15,7 @@
               <p>{{selectedAuthor.organization}} - {{selectedAuthor.email}}</p>
         </span>
       </div>
-      <div (click)="toggleAuthor()" class="right"><i class="fas fa-times"></i></div>
+      <button (click)="toggleAuthor()" class="right button"><i class="fas fa-times"></i></button>
   </div>
   </div>
 

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
@@ -19,6 +19,10 @@
     }
     .right{ 
 
+      &.button { 
+        border: none; 
+        background-color: transparent;
+      }
     }
 }
 .details{ 
@@ -39,7 +43,7 @@
     min-height: 150px;
   }
   .input-container{
-    background-color: #F1F1F1;
+    background-color: $light-grey;
     position: relative;
     padding: 8px 10px;
     border-radius: 5px;
@@ -52,12 +56,11 @@
   .user-dropdown__search-input {
     appearance: none;
     font-size: $small;
-   
     border: none;   
     color: $medium-grey;
     background-color: inherit;
     outline: 0;
-    max-width: 500px;
+    max-width: 550px;
     width: 100%;
     box-sizing: border-box;
     padding: 0px 15px;
@@ -73,13 +76,12 @@
     padding: 0;
     margin: 0;
     position: absolute;
-    max-width: 500px;
     width: 100%;
     background: white;
     border-radius: 2px;
     box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.2);
     z-index: 3;
-  
+    
     virtual-scroller {
       max-height: 300px;
       min-height: 100px;

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
@@ -1,0 +1,154 @@
+@import '~_vars.scss';
+
+.author-details-container{
+    padding: 10px;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    .left{
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        .image{
+            width: 70px;
+            height: 70px;
+            margin: 5px;
+            border-radius: 100px;
+        }
+    }
+    .right{ 
+
+    }
+}
+.details{ 
+  margin-left: 10px;
+
+}
+.details p{
+    padding: 0px;
+    margin: 0px;
+    list-style: none;
+    list-style-type:none ;
+    font-size: $small;
+    color: $medium-grey
+}
+
+.user-dropdown {
+    position: relative;
+    min-height: 150px;
+  }
+  .input-container{
+    background-color: #F1F1F1;
+    position: relative;
+    padding: 8px 10px;
+    border-radius: 5px;
+    i{
+      position: absolute; 
+      padding: 10px;
+    }
+  }
+  
+  .user-dropdown__search-input {
+    appearance: none;
+    font-size: $small;
+   
+    border: none;   
+    color: $medium-grey;
+    background-color: inherit;
+    outline: 0;
+    max-width: 500px;
+    width: 100%;
+    box-sizing: border-box;
+  
+    &:focus {
+      border-color: $light-blue;
+    }
+  }
+
+
+.user-dropdown__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    position: absolute;
+    max-width: 500px;
+    width: 100%;
+    background: white;
+    border-radius: 2px;
+    box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.2);
+    z-index: 3;
+  
+    virtual-scroller {
+      max-height: 300px;
+      min-height: 100px;
+    }
+  }
+  
+  .user-dropdown__list-item {
+    height: 40px;
+    background: white;
+    color: $dark-grey;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    cursor: pointer;
+    padding-left: 10px;
+    transition: background 0.2s ease;
+  
+    &:hover, &:focus {
+      background: $light-grey;
+  
+      .user-dropdown__action {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+  }
+
+
+.user-dropdown__action {
+    border-radius: 3px;
+    color: white;
+    height: 28px;
+    width: 28px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: $light-blue-gradient;
+    transform: scale(0.9);
+    opacity: 0;
+    transition: all 0.2s ease;
+  
+    &.user-dropdown__action--reversed {
+      background: $error-red;
+    }
+  
+    &.user-dropdown__action--visible {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+  
+  .user-dropdown__navbar-gravatar {
+    display: inline-block;
+    margin-left: 8px;
+    margin-right: 8px;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    box-shadow: 0 1px 6px 2px rgba(0, 0, 0, 0.05);
+  }
+  
+  .user-dropdown__message {
+    padding: 10px;
+    text-align: center;
+    color: $dark-grey;
+    width: 100%;
+    box-sizing: border-box;
+    display: block;
+  }
+  

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.scss
@@ -60,6 +60,7 @@
     max-width: 500px;
     width: 100%;
     box-sizing: border-box;
+    padding: 0px 15px;
   
     &:focus {
       border-color: $light-blue;

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.spec.ts
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeAuthorUserDropdownComponent } from './change-author-user-dropdown.component';
+
+describe('ChangeAuthorUserDropdownComponent', () => {
+  let component: ChangeAuthorUserDropdownComponent;
+  let fixture: ComponentFixture<ChangeAuthorUserDropdownComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChangeAuthorUserDropdownComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeAuthorUserDropdownComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
@@ -5,6 +5,7 @@ import {
   IterableDiffer,
   EventEmitter,
   Output,
+  OnDestroy,
 } from '@angular/core';
 import { User } from '@entity';
 import { UserService } from 'app/core/user.service';
@@ -17,7 +18,7 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
   templateUrl: './change-author-user-dropdown.component.html',
   styleUrls: ['./change-author-user-dropdown.component.scss'],
 })
-export class ChangeAuthorUserDropdownComponent implements OnInit {
+export class ChangeAuthorUserDropdownComponent implements OnInit, OnDestroy {
   // array of usernames representing all selected users
   selectedAuthor: User;
 
@@ -71,6 +72,11 @@ export class ChangeAuthorUserDropdownComponent implements OnInit {
           this.loading = false;
         }
       });
+  }
+
+  ngOnDestroy() {
+    this.destroyed$.next();
+    this.destroyed$.unsubscribe();
   }
 
   /**

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
@@ -1,0 +1,122 @@
+import {
+  Component,
+  OnInit,
+  IterableDiffers,
+  IterableDiffer,
+  EventEmitter,
+  Output,
+} from '@angular/core';
+import { User } from '@entity';
+import { UserService } from 'app/core/user.service';
+import { AuthService } from 'app/core/auth.service';
+import { Subject } from 'rxjs';
+import { debounceTime, takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'clark-change-author-user-dropdown',
+  templateUrl: './change-author-user-dropdown.component.html',
+  styleUrls: ['./change-author-user-dropdown.component.scss'],
+})
+export class ChangeAuthorUserDropdownComponent implements OnInit {
+  // array of usernames representing all selected users
+  selectedAuthor: User;
+
+  searchResults: User[] = [];
+
+  // search query string, modeled to the search
+  query: string;
+
+  differ: IterableDiffer<User>;
+  // fires every time an input event occurs on the search input element
+  userSearchInput$: Subject<string> = new Subject();
+  // fires when this component is destroyed
+  destroyed$: Subject<void> = new Subject();
+  // true if dropdown results should be shown, false if they should be hidden
+  showDropdown: boolean;
+  // true if the component is actively querying the services, false otherwise
+  loading: boolean;
+
+
+  // fired when an author is selected
+  @Output() newAuthor: EventEmitter<User> = new EventEmitter();
+
+  constructor(
+    private userService: UserService,
+    private authService: AuthService,
+    private differs: IterableDiffers
+  ) {
+    this.differ = this.differs.find([]).create(null);
+  }
+
+  ngOnInit() {
+    // subscribe to the search input and fire search after debounce
+    this.userSearchInput$
+      .pipe(debounceTime(650), takeUntil(this.destroyed$))
+      .subscribe((val: string) => {
+        this.findUser(val.trim());
+      });
+
+    // TODO is there a better way to do this?
+    // I want two events to occur when this event fires. 1) after a debounce, perform search
+    // 2) immediately (without debounce) show the popup
+    this.userSearchInput$
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((val: string) => {
+        if (val && val !== '') {
+          this.showDropdown = true;
+          this.loading = true;
+        } else {
+          this.clearSearch();
+          this.showDropdown = false;
+          this.loading = false;
+        }
+      });
+  }
+
+  /**
+   * Queries the UserService with query text and sets the searchResults variable
+   *
+   * @memberof UserDropdownComponent
+   */
+  findUser(query: string) {
+    if (query && query !== '') {
+      this.userService.searchUsers({ text: query }).then((results: User[]) => {
+        // remove current user from results
+        for (let i = 0; i < results.length; i++) {
+          if (this.authService.username === results[i].username) {
+            results.splice(i, 1);
+          }
+        }
+
+        this.searchResults = results;
+        console.log(results);
+        this.loading = false;
+      });
+    }
+  }
+
+  /**
+   * Clear's the current search text and results
+   *
+   * @memberof UserDropdownComponent
+   */
+  clearSearch() {
+    this.query = '';
+    this.searchResults = [];
+    this.loading = false;
+    this.showDropdown = false;
+  }
+
+  toggleAuthor(user?: User) {
+    if (user) {
+      this.selectedAuthor = user;
+      this.clearSearch();
+      console.log(this.selectedAuthor);
+      this.newAuthor.emit(user);
+    } else {
+      this.selectedAuthor = null;
+    }
+  }
+
+
+}

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
@@ -6,6 +6,7 @@ import {
   EventEmitter,
   Output,
   OnDestroy,
+  Input,
 } from '@angular/core';
 import { User } from '@entity';
 import { UserService } from 'app/core/user.service';
@@ -39,7 +40,8 @@ export class ChangeAuthorUserDropdownComponent implements OnInit, OnDestroy {
 
 
   // fired when an author is selected
-  @Output() newAuthor: EventEmitter<User> = new EventEmitter();
+  @Input() currentAuthor: User;
+  @Output() newAuthor: EventEmitter<any> = new EventEmitter();
 
   constructor(
     private userService: UserService,
@@ -50,6 +52,10 @@ export class ChangeAuthorUserDropdownComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    // If there's still an active selected author, set that user as the selected author
+    if (this.currentAuthor) {
+      this.selectedAuthor = this.currentAuthor;
+    }
     // subscribe to the search input and fire search after debounce
     this.userSearchInput$
       .pipe(debounceTime(650), takeUntil(this.destroyed$))
@@ -93,7 +99,6 @@ export class ChangeAuthorUserDropdownComponent implements OnInit, OnDestroy {
             results.splice(i, 1);
           }
         }
-
         this.searchResults = results;
         this.loading = false;
       });
@@ -119,6 +124,7 @@ export class ChangeAuthorUserDropdownComponent implements OnInit, OnDestroy {
       this.newAuthor.emit(user);
     } else {
       this.selectedAuthor = null;
+      this.newAuthor.emit({});
     }
   }
 

--- a/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
+++ b/src/app/admin/components/change-author/components/change-author-user-dropdown/change-author-user-dropdown.component.ts
@@ -11,7 +11,7 @@ import { UserService } from 'app/core/user.service';
 import { AuthService } from 'app/core/auth.service';
 import { Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-
+ 
 @Component({
   selector: 'clark-change-author-user-dropdown',
   templateUrl: './change-author-user-dropdown.component.html',
@@ -89,7 +89,6 @@ export class ChangeAuthorUserDropdownComponent implements OnInit {
         }
 
         this.searchResults = results;
-        console.log(results);
         this.loading = false;
       });
     }
@@ -111,7 +110,6 @@ export class ChangeAuthorUserDropdownComponent implements OnInit {
     if (user) {
       this.selectedAuthor = user;
       this.clearSearch();
-      console.log(this.selectedAuthor);
       this.newAuthor.emit(user);
     } else {
       this.selectedAuthor = null;

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -34,6 +34,15 @@
     <ul (activate)="toggleContextMenu($event)">
       <li [routerLink]="['/onion/learning-object-builder', learningObject.id]"><i class="far fa-pencil"></i>Edit</li>
       <li [routerLink]="['/details', learningObject.author.username, learningObject.cuid]"><i class="far fa-cube"></i>View details</li>
+      <li (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
     </ul>
   </div>
 </clark-context-menu>
+
+<clark-popup *ngIf="showChangeAuthor" (closed)="toggleChangeAuthorModal(false)">
+  <div class="modal-container" #popupInner>
+<clark-change-author [highlightedLearningObject]="learningObject" [statusDescription]="statusDescription"></clark-change-author>
+  
+    </div>
+    
+</clark-popup> 

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -41,7 +41,7 @@
 
 <clark-popup *ngIf="showChangeAuthor" (closed)="toggleChangeAuthorModal(false)">
   <div class="modal-container" #popupInner>
-<clark-change-author [highlightedLearningObject]="learningObject" [statusDescription]="statusDescription"></clark-change-author>
+<clark-change-author (close)="toggleChangeAuthorModal(false)" [highlightedLearningObject]="learningObject" [statusDescription]="statusDescription"></clark-change-author>
   
     </div>
     

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -34,7 +34,7 @@
     <ul (activate)="toggleContextMenu($event)">
       <li [routerLink]="['/onion/learning-object-builder', learningObject.id]"><i class="far fa-pencil"></i>Edit</li>
       <li [routerLink]="['/details', learningObject.author.username, learningObject.cuid]"><i class="far fa-cube"></i>View details</li>
-      <li (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
+      <li *ngIf="experimental" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
     </ul>
   </div>
 </clark-context-menu>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
@@ -160,3 +160,11 @@
     opacity: 0.5;
   }
 }
+
+
+/*Styles for change learning object author*/
+
+.modal-container{ 
+  width: 600px; 
+}
+

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -12,6 +12,7 @@ import {
 import { StatusDescriptions } from 'environments/status-descriptions';
 import { AuthService } from 'app/core/auth.service';
 import { LearningObject } from '@entity';
+import { Subject } from 'rxjs';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -34,6 +35,8 @@ export class LearningObjectListItemComponent implements OnChanges {
   changeStatus: EventEmitter<LearningObject> = new EventEmitter();
 
   statusDescription: string;
+
+  showChangeAuthor: boolean;
 
   // flags
   meatballOpen = false;
@@ -68,6 +71,10 @@ export class LearningObjectListItemComponent implements OnChanges {
     this.meatballOpen = value;
   }
 
+  toggleChangeAuthorModal(value: boolean){
+    this.showChangeAuthor = value;
+    console.log(this.learningObject);
+  }
   /**
    * Check the logged in user's email verification status
    * @return {boolean} true if loggedin user has verified their email, false otherwise

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -12,7 +12,7 @@ import {
 import { StatusDescriptions } from 'environments/status-descriptions';
 import { AuthService } from 'app/core/auth.service';
 import { LearningObject } from '@entity';
-import { Subject } from 'rxjs';
+import { environment } from '@env/environment';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -37,6 +37,8 @@ export class LearningObjectListItemComponent implements OnChanges {
   statusDescription: string;
 
   showChangeAuthor: boolean;
+
+  experimental = environment.experimental;
 
   // flags
   meatballOpen = false;

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -73,7 +73,6 @@ export class LearningObjectListItemComponent implements OnChanges {
 
   toggleChangeAuthorModal(value: boolean){
     this.showChangeAuthor = value;
-    console.log(this.learningObject);
   }
   /**
    * Check the logged in user's email verification status

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -26,6 +26,7 @@ import { UserCardComponent } from './user-card/user-card.component';
 import { SkipLinkComponent } from './skip-link/skip-link.component';
 
 
+
 @NgModule({
   imports: [
     // angular modules
@@ -53,6 +54,7 @@ import { SkipLinkComponent } from './skip-link/skip-link.component';
     ToggleSwitchComponent,
     UserCardComponent,
     SkipLinkComponent,
+  
   ],
   exports: [
     // components

--- a/src/app/shared/components/shared-components.module.ts
+++ b/src/app/shared/components/shared-components.module.ts
@@ -54,7 +54,6 @@ import { SkipLinkComponent } from './skip-link/skip-link.component';
     ToggleSwitchComponent,
     UserCardComponent,
     SkipLinkComponent,
-  
   ],
   exports: [
     // components


### PR DESCRIPTION
This story covers implementing the provided mocks client side for change author functionality. 

The user dropdown component from the builder was reused and modified to fit the needs of this new component. A completely separate dropdown component was created in the process.
![Screen Shot 2020-06-11 at 5 30 48 PM](https://user-images.githubusercontent.com/39136153/84441445-d23b3480-ac09-11ea-9359-084ff8fbc59f.png) 
![Screen Shot 2020-06-11 at 5 30 59 PM](https://user-images.githubusercontent.com/39136153/84441443-d10a0780-ac09-11ea-960d-7f56977a34eb.png)
![Screen Shot 2020-06-11 at 5 31 22 PM](https://user-images.githubusercontent.com/39136153/84441439-cfd8da80-ac09-11ea-9829-c26cb21f4874.png)
![Screen Shot 2020-06-11 at 5 31 33 PM](https://user-images.githubusercontent.com/39136153/84441434-cea7ad80-ac09-11ea-99b6-429b74657d6d.png)


