### PR TITLE
Fix password check error

### DIFF
--- a/src/app/auth/register/profile-info/profile-info.component.ts
+++ b/src/app/auth/register/profile-info/profile-info.component.ts
@@ -14,9 +14,9 @@ import { takeUntil, debounceTime, map } from 'rxjs/operators';
 export class ProfileInfoComponent implements OnInit, OnDestroy {
   @Input() group: FormGroup;
 
-  @ViewChild('usernameInput') usernameInput: ElementRef;
-  @ViewChild('passwordInput') passwordInput: ElementRef;
-  @ViewChild('passwordVerifyInput') passwordVerifyInput: ElementRef;
+  @ViewChild('usernameInput', {static: true}) usernameInput: ElementRef;
+  @ViewChild('passwordInput', {static: true}) passwordInput: ElementRef;
+  @ViewChild('passwordVerifyInput', {static: true}) passwordVerifyInput: ElementRef;
 
   result: boolean;
 
@@ -65,15 +65,15 @@ export class ProfileInfoComponent implements OnInit, OnDestroy {
       takeUntil(this.destroyed$)
     ).subscribe(val => {
         this.passwordError = !this.checkPassword(val);
-      })
-    
+      });
+
     fromEvent(this.passwordVerifyInput.nativeElement, 'input').pipe(
       map(x => x['currentTarget'].value),
       debounceTime(650),
       takeUntil(this.destroyed$)
     ).subscribe(val => {
         this.passwordVerifyError = !this.checkPasswordsIdentical(val);
-      })
+      });
   }
 
   /**


### PR DESCRIPTION
There is logic in the client to check for strong passwords, but due to an update from Angular 7 from early 2019 the ViewChild was returning undefined and the form was being allowed to pass without any validation being done on client. In order to get this to work I added { static: true } which resolves query results before change detection runs which now properly executes the validation.  