### PR TITLE
Add Plan C back to homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/components/collections/collections.component.scss
+++ b/src/app/cube/home/components/collections/collections.component.scss
@@ -21,21 +21,13 @@
 }
 
 .collections__grid {
-  max-width: 800px;
+  max-width: 1000px;
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
   margin: auto;
   margin-top: 40px;
-}
-
-.plan-c-blurb {
-  margin: 20px 0;
-  font-size: $small;
-  // font-weight: bold;
-  font-style: italic;
-  text-align: center;
 }
 
 .card-wrapper {

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -77,7 +77,7 @@ export class HomeComponent implements OnInit {
       .getCollections()
       .then(collections => {
         this.collections = collections.filter(
-          c => c.abvName === 'nccp' || c.abvName === 'c5'
+          c => c.abvName === 'nccp' || c.abvName === 'c5' || c.abvName === 'plan c'
         );
       })
       .catch(e => {

--- a/src/app/shared/components/collection-card/collection-card.component.html
+++ b/src/app/shared/components/collection-card/collection-card.component.html
@@ -1,7 +1,7 @@
 
 <button attr.aria-label="Navigate to {{ collection.name }} collection" class="collection-card" routerLink="/c/{{ collection.abvName }}">
   <img aria-hidden="true" *ngIf="pictureLocation; else genericLogoTemplate" class="card__image" src="{{ pictureLocation }}" alt="{{ collection.name }} logo">
-  <div aria-hidden="true" class="card__name">{{ collection.name }}<span *ngIf="collection.abvName === 'plan c' && homepage">*</span></div>
+  <div aria-hidden="true" class="card__name">{{ collection.name }}</div>
 </button>
 
 <ng-template #genericLogoTemplate>


### PR DESCRIPTION
This PR adds the Plan C collection card back to the homepage. 
![screencapture-localhost-4200-home-2020-09-18-10_11_47](https://user-images.githubusercontent.com/43140629/93607505-68b08c00-f997-11ea-81c0-8ec16db125d0.png)
