### PR TITLE
2743 mobile stats page broken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.3",
+  "version": "4.9.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/usage-stats/counter-block/counter-block.component.scss
+++ b/src/app/cube/usage-stats/counter-block/counter-block.component.scss
@@ -63,6 +63,12 @@
   }
 }
 
+@media screen and (max-width: 600px) {
+  .counter-wrapper {
+    margin: 0 auto;
+  }
+}
+
 @media print {
   .counter-wrapper {
     padding: 0;

--- a/src/app/cube/usage-stats/distribution-chart/distribution-chart.component.scss
+++ b/src/app/cube/usage-stats/distribution-chart/distribution-chart.component.scss
@@ -36,6 +36,12 @@
   }
 }
 
+@media screen and (max-width: 600px) {
+  .chart-wrapper {
+    padding: 20px 0;
+  }
+}
+
 @media print {
   .chart-wrapper {
     padding: 0;

--- a/src/app/cube/usage-stats/distribution-chart/distribution-chart.component.scss
+++ b/src/app/cube/usage-stats/distribution-chart/distribution-chart.component.scss
@@ -4,6 +4,8 @@
   background: white;
   padding: 20px;
   border-radius: 2px;
+  max-width: 100%;
+  overflow-x: scroll;
 }
 
 .loading {
@@ -29,6 +31,8 @@
 
   canvas {
     margin-bottom: 15px;
+    width: auto;
+    max-height: 300px;
   }
 }
 

--- a/src/app/cube/usage-stats/heat-map/heat-map.component.scss
+++ b/src/app/cube/usage-stats/heat-map/heat-map.component.scss
@@ -41,7 +41,6 @@
   .heat-map-wrapper {
     .title {
       top: 10px;
-      font-size: $normal;
     }
   }
 }
@@ -59,14 +58,18 @@
 @media screen and (max-width: 600px) {
   .heat-map-wrapper {
     max-height: none;
+    padding: 20px 0;
   }
 
   .graph-wrapper {
     display: block;
+    max-width: 100%;
+    overflow-x: scroll;
   }
 
   .iframe-wrapper {
     margin-bottom: 15px;
     min-height: 250px;
+    height: auto;
   }
 }

--- a/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
+++ b/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
@@ -19,9 +19,14 @@ $row-gap: 25px;
       width: 80%;
       
       .name {
-        color: $darker-grey;
+        color: $light-blue;
         display: inline-block;
         margin-bottom: 10px;
+        cursor: pointer;
+
+        &:hover {
+          text-decoration: underline;
+        }
       }
   
       .count {
@@ -33,5 +38,17 @@ $row-gap: 25px;
   .loading {
     padding-top: 100px;
     text-align: center;
+  }
+}
+
+@media only screen and (max-width: 450px) {
+  .downloads-container {
+    padding: 0;
+    width: auto;
+
+    .count {
+      float: none;
+      margin-bottom: 20px;
+    }
   }
 }

--- a/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
+++ b/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
@@ -41,6 +41,12 @@ $row-gap: 25px;
   }
 }
 
+@media screen and (max-width: 600px) {
+  .top-downloads {
+    padding: 20px 0;
+  }
+}
+
 @media only screen and (max-width: 450px) {
   .downloads-container {
     padding: 0;

--- a/src/app/cube/usage-stats/usage-stats.component.scss
+++ b/src/app/cube/usage-stats/usage-stats.component.scss
@@ -71,6 +71,12 @@ $row-gap: 25px;
   border: 0;
 }
 
+@media only screen and (max-width: 450px) {
+  .charts {
+    grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
+  }
+}
+
 
 @media print {
   .container {

--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -167,6 +167,7 @@ export class UsageStatsComponent implements OnInit {
       legend: true,
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         legend: {
           position: 'bottom'
         },
@@ -228,6 +229,7 @@ export class UsageStatsComponent implements OnInit {
       legend: true,
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         legend: {
           position: 'bottom'
         },
@@ -291,6 +293,7 @@ export class UsageStatsComponent implements OnInit {
       legend: true,
       options: {
         responsive: true,
+        maintainAspectRatio: false,
         legend: {
           position: 'bottom'
         },


### PR DESCRIPTION
This PR fixes the mobile stats page.  Completes story [2743 - Mobile view for statistics page is broken](https://app.clubhouse.io/clarkcan/story/2743/mobile-view-for-statistics-page-is-broken).

<img width="377" alt="Screen Shot 2020-10-01 at 11 48 04 AM" src="https://user-images.githubusercontent.com/32078831/94832511-fcdd1300-03db-11eb-8f1c-40fc09dfea10.png">

<img width="377" alt="Screen Shot 2020-10-01 at 11 47 54 AM" src="https://user-images.githubusercontent.com/32078831/94832521-ff3f6d00-03db-11eb-8844-2e0f961bf88e.png">

<img width="377" alt="Screen Shot 2020-10-01 at 11 47 43 AM" src="https://user-images.githubusercontent.com/32078831/94832527-02d2f400-03dc-11eb-8ad6-23ddf4fc833b.png">

<img width="377" alt="Screen Shot 2020-10-01 at 11 47 28 AM" src="https://user-images.githubusercontent.com/32078831/94832536-05cde480-03dc-11eb-8f25-37596be11161.png">