### PR TITLE
2856 - Move Clark by the numbers from the bottom of the homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.4",
+  "version": "4.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.4",
+  "version": "4.9.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/home.component.html
+++ b/src/app/cube/home/home.component.html
@@ -17,6 +17,9 @@
     </div>
     <cube-featured></cube-featured>
   </div>
+  <section class="usage">
+    <clark-usage [stats]="usageStats"></clark-usage>
+  </section>
   <section class="collections">
     <clark-collections [collections]="collections"></clark-collections>
   </section>
@@ -27,9 +30,6 @@
   </section>
   <section class="philosophy">
     <clark-philosophy></clark-philosophy>
-  </section>
-  <section class="usage">
-    <clark-usage [stats]="usageStats"></clark-usage>
   </section>
   <section class="cta">
     <div class="cta__content">


### PR DESCRIPTION
This PR moves the Clark by the numbers section to right below the featured objects section on the homepage.  Completes story [#2856 - Move Clark by the numbers from the bottom of the homepage](https://app.clubhouse.io/clarkcan/story/2856/move-clark-by-the-numbers-from-the-bottom-of-the-homepage).

<img width="605" alt="Screen Shot 2020-11-03 at 9 19 28 AM" src="https://user-images.githubusercontent.com/32078831/97996439-c406d400-1db5-11eb-8c7c-d33c28209581.png">