### PR TITLE
Update change authorship

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.5",
+  "version": "4.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.5",
+  "version": "4.9.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -57,12 +57,12 @@
   <div class="change-author-content">
     <div class="content-header padding-extra">Are you sure you want to change this learning object's author?</div>
     <div class="description sm padding-indent">Change the learning object author of "{{highlightedLearningObject.name | titlecase}}" from {{highlightedLearningObject.author.name | titlecase}} ({{highlightedLearningObject.author.organization | titlecase}}) to {{selectedAuthor._name | titlecase}} ({{selectedAuthor._organization | titlecase}})). </div>
-    <div class="description sm padding-indent">Please Check to ensure that the new author is the correct user that you would like to change authorship of. Note that 
-      changing the author will add the previous author onto the list of contributors for the object. </div>
+    <div class="description sm padding-indent">Please Check to ensure that the new author is the correct user that you would like to change authorship of. Any revisions of the learning object will also have their authorship changed. Note that 
+      changing the author will add the previous author onto the list of contributors for the object.</div>
   </div>
   <div *ngIf="hasChildren">
     <div class="content-header padding-extra">This learning object has {{ children.length }} children</div>
-    <div class="description sm padding-indent">By changing the author of "{{ highlightedLearningObject.name | titlecase }}" you will also be changing the authorship of its {{ children.length }} children.</div>
+    <div class="description sm padding-indent">By changing the author of "{{ highlightedLearningObject.name | titlecase }}" you will also be changing the authorship of its {{ children.length }} children and their revisions.</div>
   </div>
   <div class="change-author-confirmation">
     <input (change)="toggleConsent($event)" aria-label="Change author confirmation checkbox" name='change-author-checkbox' id='change-author-checkbox' type="checkbox">

--- a/src/app/admin/core/authorship.service.ts
+++ b/src/app/admin/core/authorship.service.ts
@@ -16,11 +16,9 @@ export class AuthorshipService {
 
   async changeAuthorship(oldAuthor: User, id: string, newAuthor: string) {
     return this.http
-    .post(ADMIN_ROUTES.CHANGE_AUTHOR(oldAuthor.username, id),
+    .post(ADMIN_ROUTES.CHANGE_AUTHOR(oldAuthor.id, id),
     {
-      'fromUserID': oldAuthor.id,
-      'toUserID': newAuthor,
-      'objectID': id,
+      'author': newAuthor,
     },
     { withCredentials: true, responseType: 'text'}
     )

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -21,8 +21,8 @@ export const ADMIN_ROUTES = {
   REMOVE_MAPPER(userId: string): string {
     return `${environment.apiURL}/guidelines/members/${encodeURIComponent(userId)}`;
   },
-  CHANGE_AUTHOR(userId: string, cuid: string): string {
-    return `${environment.apiURL}/admin/users/${encodeURIComponent(userId)}/learning-objects/${cuid}/change-author`;
+  CHANGE_AUTHOR(userId: string, id: string): string {
+    return `${environment.apiURL}/users/${encodeURIComponent(userId)}/learning-objects/${id}/change-author`;
   }
 };
 


### PR DESCRIPTION
This PR updates the route and service call to reflect the adjustment made to the backend. It also updates the message to the user to include a notice of revisions of the object and revisions of its children having their author changed. 
![Screen Shot 2020-11-03 at 1 25 43 PM](https://user-images.githubusercontent.com/43140629/98025856-3dafb980-1dd8-11eb-84a5-f04298392cba.png)
