### PR TITLE
2861 - Delete file context menu not working on edit screens for admins/editors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.7",
+  "version": "4.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.7",
+  "version": "4.9.8",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -150,7 +150,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   solutionUpload = false;
 
   showDeletePopup = false;
-  handleDeleteGenerator: Iterator<void>;
+  handleDeleteGenerator: Iterator<void, any, boolean>;
 
   dragAndDropSupported = false;
 
@@ -239,7 +239,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
     fromEvent(document.getElementsByTagName('body')[0], 'dragleave')
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((event: any) => {
-        if (event.target.classList.contains('uploader')) {
+        if (event.target && event.target.classList.contains('uploader')) {
           this.toggleDrag(false);
         }
       });
@@ -759,7 +759,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    * @memberof UploadComponent
    */
   confirmDeletion() {
-    this.handleDeleteGenerator.next();
+    console.log(this.handleDeleteGenerator.next(true));
     this.hideDeleteConfirmation();
   }
 
@@ -769,7 +769,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    * @memberof UploadComponent
    */
   cancelDeletion() {
-    this.handleDeleteGenerator.next();
+    this.handleDeleteGenerator.next(false);
     this.hideDeleteConfirmation();
   }
 

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -759,7 +759,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    * @memberof UploadComponent
    */
   confirmDeletion() {
-    console.log(this.handleDeleteGenerator.next(true));
+    this.handleDeleteGenerator.next(true);
     this.hideDeleteConfirmation();
   }
 


### PR DESCRIPTION
This is a small PR that updates the iterator for deleting files to pass a true/false value if the file is supposed to be deleted (after confirming from a popup).  Completes story [2861 - Delete file context menu not working on edit screens for admins/editors](https://app.clubhouse.io/clarkcan/story/2861/delete-file-context-menu-not-working-on-edit-screens-for-admins-editors).

[see an example of a generator being passed a value](https://gist.github.com/ericelliott/890c20d18bcc4362048dba2dca8e67ac)