### PR TITLE
2944 - Create NCyTE Collection in Mongo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.9.9",
+  "version": "4.9.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2998,7 +2998,8 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.9.9",
+  "version": "4.9.10",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/collection-details/collection-details.component.scss
+++ b/src/app/cube/collection-details/collection-details.component.scss
@@ -77,7 +77,6 @@
   .header {
       color: $light-blue;
       font-size: $largest;
-      text-transform: uppercase;
       font-weight: bold;
       padding: 0;
       margin-top: 10px;


### PR DESCRIPTION
Removes the text transformation property so 'NCYTE' can become 'NCyTE'.  Note, this also changes the capitalization of our other collections too, so 'SECURITY INJECTIONS' becomes 'Security Injections'.  Completes story [2944 - Create NCyTE Collection in Mongo](https://app.clubhouse.io/clarkcan/story/2944/create-ncyte-collection-in-mongo).