### PR TITLE
Height of Images Revised

### DIFF
--- a/src/app/cube/about-us/components/diversity/diversity.component.scss
+++ b/src/app/cube/about-us/components/diversity/diversity.component.scss
@@ -18,7 +18,7 @@
             justify-content: space-around;
             .ts-img{
                 width: 200px;
-                height: auto;
+                height: 255.84px;
             }
         }
         .middle-section{
@@ -38,11 +38,11 @@
             justify-content: space-around;
             .bsl-img{
                 width: 200px;
-                height: auto;
+                height: 255.84px;
             }
             .bsr-img{
                 width: 200px;
-                height: auto;
+                height: 255.84px;
             }
         }
     }
@@ -72,11 +72,13 @@
     }
     img{
         width: 125px !important;
+        height: 159.89px !important;
     }
 }
 
 @media screen and (max-width: 500px){
     img{
         width: 115px !important;
+        height: 147.11px !important;
     }
 }

--- a/src/app/cube/about-us/components/mission/mission.component.scss
+++ b/src/app/cube/about-us/components/mission/mission.component.scss
@@ -48,8 +48,8 @@
         display: flex;
         justify-content: space-around;
         .mission-logo{
-            width: 85%;
-            height: auto;
+            width: 290px;
+            height: 320px;
             z-index: 2;
         }
     }
@@ -74,8 +74,8 @@
     .mission-container{
         .left-side{
             .mission-logo{
-                width: 60%;
-                height: auto;
+                width: 150px;
+                height: 167.84px;
             }
         }
         .right-side{


### PR DESCRIPTION
There was a bug in the about us page images for mission container and diversity container.  They appeared fine while using dev tools on a laptop and desktop. However when on a mobile device the images were distorted.

I changed height auto to the rigid heights in px that were proportionally accurate. 