### PR TITLE
3157/move-c5-objects-to-ncyte-collection

### DIFF
--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -77,7 +77,7 @@ export class HomeComponent implements OnInit {
       .getCollections()
       .then(collections => {
         this.collections = collections.filter(
-          c => c.abvName === 'nccp' || c.abvName === 'c5' || c.abvName === 'plan c'
+          c => c.abvName === 'nccp' || c.abvName === 'ncyte' || c.abvName === 'plan c'
         );
       })
       .catch(e => {


### PR DESCRIPTION
This PR removes the c5 collection from the homepage, replacing it with NCyTE.  This should be merged in after the backend script is run.  Completes story [3157 - Move C5 objects to ncyte collection](https://app.clubhouse.io/clarkcan/story/3157/move-c5-objects-to-ncyte-collection).