### PR TITLE
Fix guidelines in builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -512,7 +512,7 @@ export class BuilderStore {
         id:
           (<Partial<LearningOutcome> & { serviceId?: string }>outcome)
             .serviceId || outcome.id,
-        deleteMapping: standardOutcome.id
+        mappings: mappedOutcomes.map(x => x.id)
       },
       true
     );
@@ -914,7 +914,6 @@ export class BuilderStore {
         this.createLearningOutcome(newValue);
       } else {
         // this is an existing outcome, modify it
-        console.log(newValue);
         this.updateLearningOutcome(newValue);
       }
 

--- a/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.ts
+++ b/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.ts
@@ -110,6 +110,7 @@ export class StandardOutcomesComponent implements OnChanges, OnDestroy {
   }
 
   toggleStandardOutcome(standardOutcome: StandardOutcome, value: boolean) {
+    standardOutcome = new StandardOutcome(standardOutcome);
     this.toggleMapping.emit({ standardOutcome, value });
   }
 

--- a/src/app/onion/learning-object-builder/pages/outcome-page/outcome-page.component.ts
+++ b/src/app/onion/learning-object-builder/pages/outcome-page/outcome-page.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { LearningOutcome } from '@entity';
+import { LearningOutcome, StandardOutcome } from '@entity';
 import {
   BuilderStore,
   BUILDER_ACTIONS as actions
@@ -138,7 +138,7 @@ export class OutcomePageComponent implements OnInit, OnDestroy {
   }
 
   toggleStandardOutcome(data: {
-    standardOutcome: LearningOutcome;
+    standardOutcome: StandardOutcome;
     value: boolean;
   }) {
     this.store.execute(

--- a/src/entity/standard-outcome/standard-outcome.ts
+++ b/src/entity/standard-outcome/standard-outcome.ts
@@ -122,8 +122,8 @@ export class StandardOutcome implements Outcome {
    * @memberof StandardOutcome
    */
   private copyOutcome(outcome: any): void {
-    if (outcome._id) {
-      this.id = outcome._id;
+    if (outcome.id) {
+      this.id = outcome.id;
     }
     if (outcome.author) {
       this.author = outcome.author;


### PR DESCRIPTION
The builder was not parsing a StandardOutcome correctly after a learning object had been submitted to a collection and then pulled back from the waiting state. 