### PR TITLE
Fix sizing issues on homepage

### DIFF
--- a/src/app/cube/home/components/collections/collections.component.scss
+++ b/src/app/cube/home/components/collections/collections.component.scss
@@ -31,8 +31,8 @@
 }
 
 .card-wrapper {
-  margin: 20px;
-  width: 240px;
+  margin: 10px;
+  width: 300px;
   text-align: center;
 
   &.center {


### PR DESCRIPTION
Quick hotfix.  Fixes css so the ncyte logo does not extend pass the card on the homepage.

Before
<img width="990" alt="Screen Shot 2021-01-26 at 1 35 40 PM" src="https://user-images.githubusercontent.com/32078831/105888839-80e68680-5fdb-11eb-84cd-12412b36fa4e.png">

After
<img width="990" alt="Screen Shot 2021-01-26 at 1 35 33 PM" src="https://user-images.githubusercontent.com/32078831/105888858-8512a400-5fdb-11eb-9d8f-b375f7fc77b4.png">