### PR TITLE
3540/fix-ncyte-collection-logo-on-mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/collection-details/collection-details.component.html
+++ b/src/app/cube/collection-details/collection-details.component.html
@@ -1,7 +1,7 @@
 <div class="background">
   <section class="hero">
       <div class="inner">
-        <div class="logos">
+        <div class="logos" [ngClass]="{'long': collection?.abvName === 'ncyte' || collection?.abvName === 'cae_community' || collection?.abvName === 'nice'}">
           <img *ngIf="pictureLocation" src="{{ pictureLocation }}" alt="collection logo">
           <div *ngIf="!pictureLocation" class="title__icon">
             <i class="far fa-cubes"></i>

--- a/src/app/cube/collection-details/collection-details.component.scss
+++ b/src/app/cube/collection-details/collection-details.component.scss
@@ -52,6 +52,10 @@
     img {
       width: 100%;
     }
+
+    &.long {
+      width: 200px;
+    }
   }
 
   .title__icon {

--- a/src/app/cube/collection-details/collection-details.component.scss
+++ b/src/app/cube/collection-details/collection-details.component.scss
@@ -51,6 +51,7 @@
 
     img {
       width: 100%;
+      height: 100%;
     }
 
     &.long {


### PR DESCRIPTION
This PR adds two small fixes to the collection page:

- Makes longer logos like NCyTE, CAE, and NICE have more width so they are easier to see.
- Fixes issue with Safari on phones where longer logos like these appear stretched out.

Completes story [3540/fix-ncyte-collection-logo-on-mobile](https://app.clubhouse.io/clarkcan/story/3540/fix-ncyte-collection-logo-on-mobile).

Easier to See Before/After:
<img width="330" alt="Screen Shot 2021-02-03 at 4 17 48 PM" src="https://user-images.githubusercontent.com/32078831/106812909-51b8c080-663e-11eb-8fef-f9736ea3faf5.png">
<img width="330" alt="Screen Shot 2021-02-03 at 4 17 57 PM" src="https://user-images.githubusercontent.com/32078831/106812916-53828400-663e-11eb-9a3f-b8f64002c775.png">

Safari Issues Before/After:
<img width="394" alt="Screen Shot 2021-02-03 at 4 39 41 PM" src="https://user-images.githubusercontent.com/32078831/106813032-7c0a7e00-663e-11eb-9d34-9192540971ed.png">
<img width="394" alt="Screen Shot 2021-02-03 at 4 40 03 PM" src="https://user-images.githubusercontent.com/32078831/106813041-7dd44180-663e-11eb-8f4b-cb27cf1917a8.png">