### PR TITLE
3538/deploy-team-page-at-the-same-time-as-card-deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.11.1",
+  "version": "4.11.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -17,7 +17,7 @@
       <div>
         <h3>General Information</h3>
         <a aria-label= "Clickable About Us link" href="http://clark.center/about" >{{copy.ABOUT}}</a>
-        <a aria-label="Clickable Meet the Team link" href="http://about.clark.center" target="_blank">{{ copy.TEAM }}</a>
+        <a aria-label="Clickable Meet the Team link" href="http://secured.team/" target="_blank">{{ copy.TEAM }}</a>
         <a [routerLink]="['/press']" aria-label="Press and Media link" target="_blank">{{ copy.PRESS }}</a>
         
       </div>


### PR DESCRIPTION
This updates the footer to have the new team page link on it. Completes story [3538/deploy-team-page-at-the-same-time-as-card-deployment](https://app.clubhouse.io/clarkcan/story/3538/deploy-team-page-at-the-same-time-as-card-deployment).