### PR TITLE
3898/icon-in-footer-overlaps-with-text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,5 @@ FROM nginx:alpine as serve
 # Copy the build folder from the build stage into the nginx folder
 # and expose the port
 COPY --from=build /build/dist /usr/share/nginx/html
+COPY /nginx-custom.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80

--- a/nginx-custom.conf
+++ b/nginx-custom.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name  localhost;
+    location / {
+        root   /usr/share/nginx/html/;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.12.2",
+      "version": "4.12.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.12.3",
+  "version": "4.12.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/shared/footer/footer.component.scss
+++ b/src/app/cube/shared/footer/footer.component.scss
@@ -100,6 +100,18 @@ footer {
   }
 }
 
+@media(max-width: 1575px) {
+  .grants {
+    .images {
+      flex-wrap: wrap;
+
+      img {
+        margin: 10px !important;
+      }
+    }
+  }
+}
+
 
 @media(max-width: 800px) {
   .footer-info {


### PR DESCRIPTION
This fixes the footer issue between switching from desktop to mobile where the logos would appear off-screen or overlap text.  Also includes a small quality of life dockerfile upgrade so if you are running the client docker container you can go directly to links instead of having to go to the homepage first and work your way to the link.  Completes story [3898/icon-in-footer-overlaps-with-text](https://app.clubhouse.io/clarkcan/story/3898/icon-in-footer-overlaps-with-text).