### PR TITLE
Change attribution to be generic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.12.4",
+  "version": "4.12.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.12.4",
+      "version": "4.12.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.12.4",
+  "version": "4.12.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -35,15 +35,11 @@
     <div class="cc-attribution">
       <div class="cc-attribution__text-content">
         <div tabindex="0" class="cc-attribution__title"></div>
-        <div tabindex="0" class="cc-attribution__attribution" #objectAttributionElement id="objectAttribution"> 
-          <a attr.aria-label="Clickable link to {{ learningObject.name | titlecase }}" href='https://clark.center/details/{{learningObject.author.username}}/{{learningObject.cuid}}'>"{{ learningObject.name }}"</a>
-          is licensed under <a attr.aria-label="Clickable link to Creative Commons License" href='https://creativecommons.org/licenses/by-nc-sa/4.0/'>CC BY-NC-SA 4.0</a>
+        <div class="attribution__attribution">
+          This learning-object is licensed under 
+          <a attr.aria-label="Creative Commons License" href='https://creativecommons.org/licenses/by-nc-sa/4.0/'>CC BY-NC-SA 4.0</a>.<br>
+          Attribution format can be found <a attr.aria-label="Creative Commons Best Practices for Attribution" href="https://wiki.creativecommons.org/wiki/Best_practices_for_attribution">here.</a>
         </div>
-      </div>
-      <div class="cc-attribution__button">
-        <button aria-label="Clickable Copy CC Attribution button" class="button icon-only green" (activate)="copyAttribution()" id="copyAttribution">
-          <i class="fas fa-clipboard"></i>
-        </button>
       </div>
     </div>
     <div class="details-share">

--- a/src/app/cube/details/components/action-panel/action-panel.component.scss
+++ b/src/app/cube/details/components/action-panel/action-panel.component.scss
@@ -135,8 +135,8 @@
   }
 
   .attribution__attribution {
-    padding-top: 20px;
-    width: 80%;
+    color: $dark-grey;
+    width: 90%;
     display: inline-block;
   }
 


### PR DESCRIPTION
This PR changes the attribution from being specific to a learning-object to being more generic. 

Closes: https://app.clubhouse.io/clarkcan/story/3986/remove-specific-cc-attribution-information-and-replace-with-generic-info 


![Screen Shot 2021-04-22 at 3 21 30 PM](https://user-images.githubusercontent.com/43140629/115774182-3f1d7000-a37f-11eb-8737-5fe580574215.png)
