### PR TITLE
3963/change-all-help-links-to-secured-email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.12.5",
+      "version": "4.12.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.12.5",
+  "version": "4.12.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/press/components/splash/splash.component.html
+++ b/src/app/cube/press/components/splash/splash.component.html
@@ -5,6 +5,6 @@
       <button (activate)="this.viewPressKit.emit()" class="button">View Information Kit</button>
       <button (activate)="this.viewLogo.emit()" class="button">View Logo</button>
     </div>
-    <a class="contact-link" href="mailto:skaza@towson.edu?subject=CLARK Information">Contact Us</a>
+    <a class="contact-link" href="mailto:info@secured.team?subject=CLARK Information">Contact Us</a>
   </div>
 </div>

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -10,7 +10,7 @@
       </div>
       <div>
         <h3>Help</h3>
-        <a aria-label="Clickable Ask for Help link" href="mailto:skaza@towson.edu?subject=CLARK Help">{{ copy.HELP }}</a>
+        <a aria-label="Clickable Ask for Help link" href="mailto:info@secured.team?subject=CLARK Help">{{ copy.HELP }}</a>
         <a aria-label="Clickable Troubleshooting link" href="http://help.clark.center" target="_blank">Troubleshooting</a>
         <a aria-label="Clickable Tutorial link" href="http://about.clark.center/tutorial" target="_blank">{{ copy.TUTORIAL }}</a>
       </div>

--- a/src/app/maintenance-page/maintenance-page.component.html
+++ b/src/app/maintenance-page/maintenance-page.component.html
@@ -7,7 +7,7 @@
     We'll be back up and running shortly.<br />Please check back soon!
   </p>
   <span>
-    For questions, comments, or concerns, please <a href="mailto: skaza@towson.edu">reach out</a>.
+    For questions, comments, or concerns, please <a href="mailto:info@secured.team">reach out</a>.
   </span>
 </main>
 


### PR DESCRIPTION
This updates the emails to point to info@secured.team.  Completes story [3963/change-all-help-links-to-secured-email](https://github.com/Cyber4All/cards-client/pull/128).