### PR TITLE
4299/add-option-in-learning-object-meatball-menu-on-admin-dashboard-to-unrelease-a-released-learning-object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.12.10",
+  "version": "4.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.12.10",
+      "version": "4.13.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.12.10",
+  "version": "4.13.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -42,7 +42,7 @@
 
 <clark-popup *ngIf="showUnreleaseConfirm" (closed)="toggleUnreleaseConfirm(false)">
   <div class="modal-container center" #popupInner>
-    <p>Are you sure you want to unrelease this learning object?</p>
+    <p>Are you sure you want to unrelease this learning object? This action will change the status to proofing.</p>
     <button (click)="closeUnreleaseModal(true)" class="button bad">Yes</button>
     <button (click)="closeUnreleaseModal(false)" class="button">No</button>
   </div>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -35,9 +35,18 @@
       <li [routerLink]="['/onion/learning-object-builder', learningObject.id]"><i class="far fa-pencil"></i>Edit</li>
       <li [routerLink]="['/details', learningObject.author.username, learningObject.cuid]"><i class="far fa-cube"></i>View details</li>
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
+      <li *ngIf="learningObject.status === 'released'" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
     </ul>
   </div>
 </clark-context-menu>
+
+<clark-popup *ngIf="showUnreleaseConfirm" (closed)="toggleUnreleaseConfirm(false)">
+  <div class="modal-container center" #popupInner>
+    <p>Are you sure you want to unrelease this learning object?</p>
+    <button (click)="closeUnreleaseModal(true)" class="button bad">Yes</button>
+    <button (click)="closeUnreleaseModal(false)" class="button">No</button>
+  </div>
+</clark-popup>
 
 <clark-popup *ngIf="showChangeAuthor" (closed)="toggleChangeAuthorModal(false)">
   <div class="modal-container" #popupInner>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
@@ -165,6 +165,10 @@
 /*Styles for change learning object author*/
 
 .modal-container{ 
-  width: 600px; 
+  width: 600px;
+
+  &.center {
+    text-align: center;
+  }
 }
 

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.spec.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.spec.ts
@@ -10,6 +10,7 @@ import { AuthService } from 'app/core/auth.service';
 import { User, LearningObject } from '@entity';
 import { CollectionService } from 'app/core/collection.service';
 import { SharedDirectivesModule } from 'app/shared/directives/shared-directives.module';
+import { UnreleaseService } from 'app/admin/core/unrelease.service';
 
 describe('DashboardItemComponent', () => {
   let component: LearningObjectListItemComponent;
@@ -28,7 +29,8 @@ describe('DashboardItemComponent', () => {
       ],
       providers: [
         { provide: AuthService, useValue: { user: new User() } },
-        CollectionService
+        CollectionService,
+        { provide: UnreleaseService, useClass: {} },
       ]
     })
     .compileComponents();

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -16,6 +16,7 @@ import { environment } from '@env/environment';
 import { HttpHeaders, HttpClient } from '@angular/common/http';
 import { take, catchError } from 'rxjs/operators';
 import { of } from 'rxjs/internal/observable/of';
+import { UnreleaseService } from 'app/admin/core/unrelease.service';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -40,6 +41,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   statusDescription: string;
 
   showChangeAuthor: boolean;
+  showUnreleaseConfirm: boolean;
 
   // flags
   meatballOpen = false;
@@ -49,6 +51,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   private headers = new HttpHeaders();
   constructor(
     private auth: AuthService,
+    private unreleaseService: UnreleaseService,
     private statuses: StatusDescriptions,
     private cd: ChangeDetectorRef,
     private http: HttpClient,
@@ -79,9 +82,44 @@ export class LearningObjectListItemComponent implements OnChanges {
     this.meatballOpen = value;
   }
 
+  /**
+   * Toggles the change author modal from showing/hiding
+   *
+   * @param value True if showing, false otherwise
+   */
   toggleChangeAuthorModal(value: boolean) {
     this.showChangeAuthor = value;
   }
+
+  /**
+   * Toggles the unrelease confirm modal from showing/hiding
+   *
+   * @param value True if showing, false otherwise
+   */
+  toggleUnreleaseConfirm(value: boolean) {
+    this.showUnreleaseConfirm = value;
+  }
+
+  /**
+   * Closes the unrelease a object modal with a value for if the user
+   * confirmed they want to unrelease a object
+   *
+   * @param value True if wanting to unrelease, false otherwise
+   */
+  closeUnreleaseModal(value: boolean) {
+    this.toggleUnreleaseConfirm(false);
+    if (value) {
+      this.unreleaseLearningObject();
+    }
+  }
+
+  /**
+   * Reaches to a service to unrelease the object.
+   */
+  async unreleaseLearningObject() {
+    await this.unreleaseService.unreleaseLearningObject(this.learningObject.author.username, this.learningObject.cuid);
+  }
+
   /**
    * Check the logged in user's email verification status
    * @return {boolean} true if loggedin user has verified their email, false otherwise

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -17,6 +17,7 @@ import { HttpHeaders, HttpClient } from '@angular/common/http';
 import { take, catchError } from 'rxjs/operators';
 import { of } from 'rxjs/internal/observable/of';
 import { UnreleaseService } from 'app/admin/core/unrelease.service';
+import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -55,6 +56,7 @@ export class LearningObjectListItemComponent implements OnChanges {
     private statuses: StatusDescriptions,
     private cd: ChangeDetectorRef,
     private http: HttpClient,
+    private toaster: ToastrOvenService,
   ) {}
 
   async ngOnChanges(changes: SimpleChanges) {
@@ -116,8 +118,10 @@ export class LearningObjectListItemComponent implements OnChanges {
   /**
    * Reaches to a service to unrelease the object.
    */
-  async unreleaseLearningObject() {
-    await this.unreleaseService.unreleaseLearningObject(this.learningObject.author.username, this.learningObject.cuid);
+  unreleaseLearningObject() {
+    this.unreleaseService.unreleaseLearningObject(this.learningObject.author.username, this.learningObject.cuid)
+      .then(() => this.toaster.success('Success', 'Learning object was successfully unreleased'))
+      .catch(() => this.toaster.error('Error', 'There was an issue unreleasing this learning object, please try again later'));
   }
 
   /**

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -1,0 +1,53 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { LearningObject } from '@entity';
+import { ADMIN_ROUTES } from '@env/route';
+import { throwError } from 'rxjs';
+import { catchError, retry } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UnreleaseService {
+
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Unreleases a learning object, moving it back to a
+   * in review status (waiting, review, or proofing)
+   *
+   * @param username The username of the author
+   * @param cuid The cuid of the learning object
+   * @returns A promise of the request
+   */
+  unreleaseLearningObject(username: string, cuid: string) {
+    return this.http
+      .post(
+        ADMIN_ROUTES.UNRELEASE_OBJECT(username, cuid),
+        { status: LearningObject.Status.UNRELEASED },
+        { withCredentials: true, responseType: 'text'}
+      ).pipe(
+        retry(3),
+        catchError(this.handleError)
+      )
+      .toPromise();
+  }
+
+  /**
+   * Generic error-handling function for errors through from the HttpClient module
+   *
+   * @private
+   * @param {HttpErrorResponse} error
+   * @returns
+   * @memberof PrivilegeService
+   */
+   private handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      // Client-side or network returned error
+      return throwError(error.error.message);
+    } else {
+      // API returned error
+      return throwError(error);
+    }
+  }
+}

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -41,7 +41,7 @@ export class UnreleaseService {
    * @returns
    * @memberof PrivilegeService
    */
-   private handleError(error: HttpErrorResponse) {
+  private handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {
       // Client-side or network returned error
       return throwError(error.error.message);

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -23,7 +23,10 @@ export const ADMIN_ROUTES = {
   },
   CHANGE_AUTHOR(userId: string, id: string): string {
     return `${environment.apiURL}/users/${encodeURIComponent(userId)}/learning-objects/${id}/change-author`;
-  }
+  },
+  UNRELEASE_OBJECT(username: string, cuid: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${cuid}/status`;
+  },
 };
 
 export const CHANGELOG_ROUTES = {


### PR DESCRIPTION
Creates the initial UI for the unrelease of a learning object.  Is dependent on story [4297/write-logic-to-unrelease-a-learning-object](https://app.clubhouse.io/clarkcan/story/4297/write-logic-to-unrelease-a-learning-object), so has not been tested yet.  Completes story [4299/add-option-in-learning-object-meatball-menu-on-admin-dashboard-to-unrelease-a-released-learning-object](https://app.clubhouse.io/clarkcan/story/4299/add-option-in-learning-object-meatball-menu-on-admin-dashboard-to-unrelease-a-released-learning-object).

Modal:
<img width="656" alt="Screen Shot 2021-06-14 at 3 57 43 PM" src="https://user-images.githubusercontent.com/32078831/121952639-85150580-cd2a-11eb-9a51-ea2fbdb16883.png">

Meatball menu - in review object
<img width="975" alt="Screen Shot 2021-06-14 at 3 58 01 PM" src="https://user-images.githubusercontent.com/32078831/121952689-9827d580-cd2a-11eb-8a9d-2f481ad50b64.png">

Meatball menu - released object
<img width="975" alt="Screen Shot 2021-06-14 at 3 58 15 PM" src="https://user-images.githubusercontent.com/32078831/121952719-a0801080-cd2a-11eb-81dd-50018f1dafc4.png">