### PR TITLE
Fix count to only released

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.16.0",
+  "version": "4.16.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/components/splash/splash.component.ts
+++ b/src/app/cube/home/components/splash/splash.component.ts
@@ -20,7 +20,7 @@ export class SplashComponent implements OnInit {
   ) { }
 
   async ngOnInit() {
-    const objects = await this.learningObjectService.getLearningObjects();
+    const objects = await this.learningObjectService.getLearningObjects({status: ['released']});
     this.learningObjectCount = objects.total;
   }
 


### PR DESCRIPTION
This PR just added a query to the request to get the object count so it only returns the released ones for admins/editors. 