### PR TITLE
Remove adding +1 to year by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.17.0",
+      "version": "4.17.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^9.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/components/relevancy-date/relevancy-date.component.ts
+++ b/src/app/admin/components/relevancy-date/relevancy-date.component.ts
@@ -21,7 +21,6 @@ export class RelevancyDateComponent implements OnInit {
   ngOnInit(): void {
     // Set the current nextCheck
     this.selected = new Date(this.learningObject.nextCheck);
-    this.selected.setFullYear(this.selected.getFullYear() + 1);
 
     // Set min and maxes for calendar picks
     this.minDate = new Date();


### PR DESCRIPTION
This PR fixes a bug on the client where there was +1 being added to year of the nextCheck date.