### PR TITLE
5671/learning-outcome-builder-wipes-learning-outcome-data-upon-empty-string-deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.21.3",
+  "version": "4.21.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.21.3",
+  "version": "4.21.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
This PR adds a check for deleting empty outcomes in the builder by checking if the ID is a generated UUID.  Completes story [5671/learning-outcome-builder-wipes-learning-outcome-data-upon-empty-string-deletion](https://app.shortcut.com/clarkcan/story/5671/learning-outcome-builder-wipes-learning-outcome-data-upon-empty-string-deletion).