### PR TITLE
Clear search button fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.22.0",
+  "version": "4.22.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/clark.module.ts
+++ b/src/app/clark.module.ts
@@ -19,6 +19,7 @@ import { MessageComponent } from './components/navbar/components/message/message
 import { SearchComponent } from './components/navbar/components/search/search.component';
 import { MaintenancePageComponent } from './maintenance-page/maintenance-page.component';
 import { UnauthorizedComponent } from './unauthorized.component';
+import { FormsModule } from '@angular/forms';
 @NgModule({
   imports: [
     BrowserModule,
@@ -27,6 +28,7 @@ import { UnauthorizedComponent } from './unauthorized.component';
     CoreModule.forRoot(),
     BrowserAnimationsModule,
     ScrollingModule,
+    FormsModule
   ],
   declarations: [
     ClarkComponent,

--- a/src/app/components/navbar/components/search/search.component.html
+++ b/src/app/components/navbar/components/search/search.component.html
@@ -4,11 +4,13 @@
       <div class="input">
         <input
           #searchInput
+          name="searchInput"
           id="clark-search-input"
           type="search"
           placeholder="Search..."
+          (ngModelChange)="togglePlaceholder()"
           aria-label="Search"
-          [value]="searchValue"
+          [(ngModel)]="searchValue"
         />
         <button
           aria-label="Search"

--- a/src/app/components/navbar/components/search/search.component.ts
+++ b/src/app/components/navbar/components/search/search.component.ts
@@ -9,6 +9,7 @@ import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { Subject } from 'rxjs';
 import { COPY } from './search.copy';
 import { takeUntil, filter } from 'rxjs/operators';
+import { NavbarService } from 'app/core/navbar.service';
 
 @Component({
   selector: 'clark-search',
@@ -23,6 +24,7 @@ export class SearchComponent implements OnInit, OnDestroy {
   @ViewChild('optionTwoSwitch') optionTwoSwitch: ElementRef;
 
   searchValue = '';
+  textQuery: boolean;
 
   // flags
   selected = 1;
@@ -39,7 +41,7 @@ export class SearchComponent implements OnInit, OnDestroy {
     'Search for learning objects by organization, user, or keyword/phrase.' :
     'Search for learning objects by mapped guidelines';
 
-  constructor(private router: Router, private route: ActivatedRoute) { }
+  constructor(private router: Router, private route: ActivatedRoute, private navService: NavbarService) { }
 
   ngOnInit() {
     // force search bar to reflect current search on browse page when navigating by url query parameters
@@ -58,6 +60,19 @@ export class SearchComponent implements OnInit, OnDestroy {
         }
       }
     });
+
+    this.navService.query.subscribe((change: boolean) => {
+      if (change) {
+        this.searchValue = '';
+        this.navService.query.next(false);
+      }
+    });
+  }
+
+  togglePlaceholder() {
+    if (this.searchValue.length === 0) {
+      (<HTMLInputElement>document.getElementById('clark-search-input')).placeholder = 'Search...';
+    }
   }
 
   /**

--- a/src/app/core/navbar.service.ts
+++ b/src/app/core/navbar.service.ts
@@ -3,12 +3,22 @@
    */
 
 import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NavbarService {
   visible: boolean;
+  _query$ = new BehaviorSubject<boolean>(false);
+
+  get query(): BehaviorSubject<boolean> {
+    return this._query$;
+  }
+
+  set query(val: BehaviorSubject<boolean>) {
+    this._query$ = val;
+  }
 
   // hide navbar
   hide() {

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -64,8 +64,6 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
   unsubscribe: Subject<void> = new Subject();
 
-  clearQuery: Observable<string>;
-
   shouldResetPage = false;
 
   sortMenuDown: boolean;

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -11,6 +11,7 @@ import {
 import { Observable, Subject } from 'rxjs';
 import { OrderBy, Query, SortType } from '../../interfaces/query';
 import { LearningObjectService } from '../learning-object.service';
+import { NavbarService } from 'app/core/navbar.service';
 
 @Component({
   selector: 'cube-browse',
@@ -63,6 +64,8 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
   unsubscribe: Subject<void> = new Subject();
 
+  clearQuery: Observable<string>;
+
   shouldResetPage = false;
 
   sortMenuDown: boolean;
@@ -81,6 +84,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     private router: Router,
     public mappingService: SuggestionService,
     private cd: ChangeDetectorRef,
+    private navService: NavbarService
   ) {
     this.windowWidth = window.innerWidth;
     this.cd.detach();
@@ -169,6 +173,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
   }
 
   clearSearch() {
+    this.navService.query.next(true);
     this.query.text = '';
     this.query.standardOutcomes = [];
     this.query.currPage = 1;

--- a/src/app/cube/shared/learning-object/learning-object.component.ts
+++ b/src/app/cube/shared/learning-object/learning-object.component.ts
@@ -56,12 +56,6 @@ export class LearningObjectListingComponent implements OnInit, OnChanges, OnDest
   }
 
   ngOnInit() {
-    this.auth.isLoggedIn.subscribe(() => {
-      this.auth.userCanDownload(this.learningObject).then(isAuthorized => {
-        this.canDownload = isAuthorized === DOWNLOAD_STATUS.CAN_DOWNLOAD;
-      });
-    });
-
     this.collectionService.getCollections().then(collections => {
       this.collections = new Map(
         collections.map(c => [c.abvName, c.name] as [string, string])
@@ -138,35 +132,12 @@ export class LearningObjectListingComponent implements OnInit, OnChanges, OnDest
    * @returns string unformated or title cased
    */
      organizationFormat(organization: string) {
-      if ( organization.charAt(1) === organization.charAt(1).toUpperCase() ) {
+      if ( organization && (organization.charAt(1) === organization.charAt(1).toUpperCase()) ) {
         return organization;
-      } else {
+      } else if (organization) {
         return titleCase(organization);
       }
     }
-
-  download(e) {
-    // Stop the event propagation so that the routerLink of the parent doesn't trigger
-    e.stopPropagation();
-    this.library
-      .downloadLearningObject(
-        this.learningObject.author.username,
-        this.learningObject.cuid,
-        this.learningObject.version
-      )
-      .pipe(take(1));
-
-    this.toggleDownloadModal(true);
-  }
-
-  toggleDownloadModal(val?: boolean) {
-    if (!val) {
-      this.showDownloadModal = val;
-    } else if (!localStorage.getItem('downloadWarning')) {
-      this.showDownloadModal = val;
-      localStorage.setItem('downloadWarning', 'true');
-    }
-  }
 
   onResize(event) {
     this.collection = this.collections.get(this.learningObject.collection);

--- a/src/app/cube/user-profile/user-information/user-information.component.ts
+++ b/src/app/cube/user-profile/user-information/user-information.component.ts
@@ -12,12 +12,12 @@ import { titleCase } from 'title-case';
   templateUrl: './user-information.component.html',
   styleUrls: ['./user-information.component.scss']
 })
-export class UserInformationComponent implements OnInit, OnChanges {
+export class UserInformationComponent implements OnChanges {
   copy = COPY;
   // User Information
   @Input() user: User;
   @Input() self = false;
-  objects: LearningObject[];
+  objects: LearningObject[] = Array(5).fill(new LearningObject());
   loading = false;
 
   constructor(
@@ -27,10 +27,8 @@ export class UserInformationComponent implements OnInit, OnChanges {
     private notifications: ToastrOvenService
   ) {}
 
-  ngOnInit() {}
-
-  ngOnChanges() {
-    this.getUsersLearningObjects();
+  async ngOnChanges() {
+    await this.getUsersLearningObjects();
   }
 
   navigateToOrganizationPage() {

--- a/src/app/cube/user-profile/user-information/user-information.component.ts
+++ b/src/app/cube/user-profile/user-information/user-information.component.ts
@@ -17,7 +17,7 @@ export class UserInformationComponent implements OnInit, OnChanges {
   // User Information
   @Input() user: User;
   @Input() self = false;
-  objects: LearningObject[] = Array(5).fill(new LearningObject());
+  objects: LearningObject[];
   loading = false;
 
   constructor(


### PR DESCRIPTION
Update: This PR now also fixes an issue where the user's LO's would not display on their profile page. The solution was to not initialize the size of the LO array for that user
shortcut: https://app.shortcut.com/clarkcan/story/5771/learning-object-cards-not-populating-on-user-profile-and-generic-collections-pages

This PR adds an observable that now connects the browse page with the navbar. The problem was that there was not a variable to track text query, so then when a search was cleared on the browse page, the text query would remain in the search bar. The solution was to toggle the placeholder of the search bar by waiting for the clear search event from the browse page.

Shortcut story: https://app.shortcut.com/clarkcan/story/5746/text-search-does-not-clear-properly