### PR TITLE
5768/back-button-on-admin-dashboard-does-not-return-to-previous-page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.22.1",
+  "version": "4.22.2",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/components/sidebar/sidebar.component.html
+++ b/src/app/admin/components/sidebar/sidebar.component.html
@@ -1,6 +1,6 @@
 <div class="admin__sidebar">
   <div class="sidebar__top">
-    <a (activate)="historySnapshot.rewind()">
+    <a (activate)="goBack()">
       <i class="far fa-arrow-left"></i> Back
     </a>
   </div>

--- a/src/app/admin/components/sidebar/sidebar.component.ts
+++ b/src/app/admin/components/sidebar/sidebar.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subject } from 'rxjs';
 import { Collection } from 'app/core/collection.service';
-import { HistoryService, HistorySnapshot } from 'app/core/history.service';
 import { sidebarAnimations } from './sidebar.component.animation';
 import { AuthService } from 'app/core/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'clark-admin-sidebar',
@@ -20,11 +20,12 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   @Input() initialized = false;
 
-  historySnapshot: HistorySnapshot;
-  constructor(private history: HistoryService, private authService: AuthService) { }
+  constructor(private authService: AuthService, private router: Router) { }
 
-  ngOnInit() {
-    this.historySnapshot = this.history.snapshot();
+  ngOnInit() { }
+
+  goBack() {
+    this.router.navigate(['']);
   }
 
   isAdminOrEditor(): boolean {


### PR DESCRIPTION
This PR makes the back button on the admin page go back to the homepage.  Completes story [5768/back-button-on-admin-dashboard-does-not-return-to-previous-page](https://app.shortcut.com/clarkcan/story/5768/back-button-on-admin-dashboard-does-not-return-to-previous-page).