### PR TITLE
Relevancy builder revision 1

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -42,7 +42,10 @@
       <li (click)="toggleAddEvaluatorModal(true)"><i class="fal fa-user-plus"></i>Assign Evaluators</li>
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
       <li *ngIf="learningObject.status === 'released'" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
-      <li [routerLink]="['/onion/relevancy-builder', learningObject.id]"><i class="far fa-puzzle-piece"></i>Map & Tag</li>
+      <li class="new" [routerLink]="['/onion/relevancy-builder', learningObject.id]">
+        <p class="title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
+        <p class="new_tag"><i class="fas fa-asterisk"></i>NEW</p>
+      </li>
     </ul>
   </div>
 </clark-context-menu>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -42,9 +42,9 @@
       <li (click)="toggleAddEvaluatorModal(true)"><i class="fal fa-user-plus"></i>Assign Evaluators</li>
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
       <li *ngIf="learningObject.status === 'released'" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
-      <li class="new" [routerLink]="['/onion/relevancy-builder', learningObject.id]">
-        <p class="title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
-        <p class="new_tag"><i class="fas fa-asterisk"></i>NEW</p>
+      <li class="new-feature_wrapper" [routerLink]="['/onion/relevancy-builder', learningObject.id]">
+        <p class="list-item_title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
+        <p class="new-item_element"><i class="fas fa-asterisk"></i>NEW</p>
       </li>
     </ul>
   </div>

--- a/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.html
+++ b/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.html
@@ -3,7 +3,7 @@
     class="top"
     [ngStyle]="{
       'margin-top': '0px',
-      'margin-bottom': '30px'
+      'margin-bottom': '15px'
     }"
   >
     <div class="top__left">
@@ -22,6 +22,36 @@
       </div>
     </div>
   </div>
+  <div class="builder-navbar-wrapper__bottom">
+    <div class="builder-navbar-wrapper__bottom-left-menu">
+      <!-- update routerLinkActive with class used to show that link is active -->
+      <ul>
+        <li>
+          <ng-container
+            id="firstTab"
+            aria-label="Learning Outcome Mappings Link"
+            [ngTemplateOutlet]="navItemTemplate"
+            [ngTemplateOutletContext]="{
+              disabled: false,
+              link: 'outcomes',
+              text: 'Guidelines'
+            }"
+          ></ng-container>
+        </li>
+        <li>
+          <ng-container
+            aria-label="Learning Object Topics Link"
+            [ngTemplateOutlet]="navItemTemplate"
+            [ngTemplateOutletContext]="{
+              disabled: false,
+              link: 'topics',
+              text: 'Topics'
+            }"
+          ></ng-container>
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>
 
 <clark-popup *ngIf="cancelConfirmationOpen" (closed)="cancelConfirmationOpen = false">
@@ -34,4 +64,18 @@
     </div>
   </div>
 </clark-popup>
+
+<ng-template
+  #navItemTemplate
+  let-link="link"
+  let-disabled="disabled"
+  let-text="text"
+>
+  <a
+    routerLink="{{ link }}"
+    routerLinkActive="active"
+    (activate)="triggerRouteClick(link)"
+    >{{ text }}</a
+  >
+</ng-template>
 

--- a/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.scss
+++ b/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.scss
@@ -13,7 +13,6 @@
   box-sizing: border-box;
   
   .top {
-    margin-bottom: 30px;
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.ts
+++ b/src/app/onion/relevancy-builder/components/builder-navbar/builder-navbar.component.ts
@@ -15,6 +15,8 @@ export class BuilderNavbarComponent implements OnInit {
 
   historySnapshot: HistorySnapshot;
 
+  routesClicked: Set<string> = new Set();
+
   constructor(
     private history: HistoryService,
     public store: BuilderStore
@@ -23,6 +25,15 @@ export class BuilderNavbarComponent implements OnInit {
   }
 
   ngOnInit(): void { }
+
+  /**
+   * Add the passed route to the set of clicked routes
+   * @param {string} route
+   * @memberof BuilderNavbarComponent
+   */
+     triggerRouteClick(route: string) {
+      this.routesClicked.add(route);
+    }
 
   /**
    * Function to toggle the confirm cancel popup

--- a/src/app/onion/relevancy-builder/components/column-wrapper/column-wrapper.component.scss
+++ b/src/app/onion/relevancy-builder/components/column-wrapper/column-wrapper.component.scss
@@ -9,7 +9,7 @@ $right-column: minmax(290px, 340px);
   grid-gap: 5px;
   margin: 0 25px;
   position: absolute;
-  top: 120px;
+  top: 138px;
 
   &.no-left {
     grid-template-columns: $middle-column $right-column;

--- a/src/app/onion/relevancy-builder/components/outcome/outcome.component.html
+++ b/src/app/onion/relevancy-builder/components/outcome/outcome.component.html
@@ -4,7 +4,7 @@
       <div class="outcome-level" *ngFor="let l of outcomeLevels">
         <span *ngIf="l === 'remember and understand' && outcome?.bloom.toLowerCase() === l.toLowerCase()"><i class="fal fa-cloud"></i> Remember & Understand</span>
         <span *ngIf="l === 'apply and analyze' && outcome?.bloom.toLowerCase() === l.toLowerCase()"><i class="fal fa-bolt"></i> Apply & Analyze</span>
-        <span *ngIf="l === 'evaluate and synthesize' && outcome?.bloom.toLowerCase() === l.toLowerCase()"><i class="fal fa-balance-scale-right"> Evaluate & Synthesize</i></span>
+        <span *ngIf="l === 'evaluate and synthesize' && outcome?.bloom.toLowerCase() === l.toLowerCase()"><i class="fas fa-balance-scale-right"></i> Evaluate & Synthesize</span>
       </div>
       {{outcome.verb ? ( outcome.verb | titlecase ) + ' ' + outcome.text : 'Learning Outcome '
       + outcomeNumber }}

--- a/src/app/onion/relevancy-builder/components/scafold/scafold.component.scss
+++ b/src/app/onion/relevancy-builder/components/scafold/scafold.component.scss
@@ -30,6 +30,7 @@
   flex-direction: row;
   justify-content: flex-start;
   flex-wrap: wrap;
+  padding-bottom: 20px;
   margin: 5px 15px;
 }
 

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
@@ -1,7 +1,14 @@
 <onion-column-wrapper>
   <!-- Left Column -->
   <div left>
-    <clark-relevancy-scafold></clark-relevancy-scafold>
+    <div class="header">
+      <div class="g_title">
+        <p>Guideline Mappings</p>
+      </div>
+    </div>
+    <div>
+      <p>Info go brr</p>
+    </div>
   </div>
 
   <!-- Center Column -->

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
@@ -1,13 +1,13 @@
 <onion-column-wrapper>
   <!-- Left Column -->
-  <div left>
+  <div left *ngIf="store.outcomes && !activeOutcome">
     <div class="header">
       <div class="g_title">
         <p>Guideline Mappings</p>
       </div>
     </div>
-    <div>
-      <p>Info go brr</p>
+    <div class="blurb">
+      This feature provides the ability to map learning object outcomes to published curricular guidelines. Select an outcome to get started! 
     </div>
   </div>
 

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.html
@@ -1,13 +1,13 @@
 <onion-column-wrapper>
   <!-- Left Column -->
-  <div left *ngIf="store.outcomes && !activeOutcome">
+  <div left>
     <div class="header">
       <div class="g_title">
         <p>Guideline Mappings</p>
       </div>
     </div>
     <div class="blurb">
-      This feature provides the ability to map learning object outcomes to published curricular guidelines. Select an outcome to get started! 
+        Mapping learning outcomes to curricular guidelines allows for the alignment of the learning object to those guidelines to be searchable on CLARK.
     </div>
   </div>
 

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
@@ -11,10 +11,19 @@
   font-weight: 600;
 }
 
+.header {
+  display: flex;
+
+  .g_title {
+    font-size: $large;
+    font-weight: 600;
+    margin: 0px auto;
+  }
+}
+
 .top {
-  padding: 20px;
-  margin: 20px;
   .title {
+    margin: 20px auto 10px 30px;
     float: left;
   }
 }

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
@@ -17,7 +17,7 @@
   .g_title {
     font-size: $large;
     font-weight: 600;
-    margin: 0px auto;
+    margin-left: 15px;
   }
 }
 
@@ -30,7 +30,7 @@
 
 .blurb {
   padding: 0 15px 20px 15px;
-  text-align: center;
+  text-align: left;
 }
 
 .add-button {

--- a/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/outcome-page/outcome-page.component.scss
@@ -28,6 +28,11 @@
   }
 }
 
+.blurb {
+  padding: 0 15px 20px 15px;
+  text-align: center;
+}
+
 .add-button {
   display: flex;
   float: right;

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
@@ -9,17 +9,6 @@
        <div class="blurb">
             Topic tagging is a new feature that was developed to categorize learning objects by relevant topic areas in order to increase search-ability. Select the tag(s) that most appropriately describe
             the entire learning object.
-            <button class="blurb-tooltip"
-                [tip]
-                tip="Suggest a topic!
-                
-                Topics should accurately 'tag' a learning object. If you feel we are missing a topic or a current topic is no longer relevant, click the information icon below to send us an email.
-                "
-                (activate)="sendEmail()"
-                href="mailto:mfranz1@students.towson.edu?subject=CLARK Learning Object Topic Suggestion&body=yeet"
-            >
-                <i class="fas fa-info-circle"></i>
-            </button>
        </div>
     </div>
 

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
@@ -6,7 +6,10 @@
                 <p>Learning Object Topic Tags</p>
             </div>
         </div>
-        <p>Info go grr</p>
+       <div class="blurb">
+            Topic tagging is a new feature that was developed to categorize learning objects by relevant topic areas in order to increase search-ability. Select the tag(s) that most appropriately describe
+            the entire learning object.
+       </div>
     </div>
 
     <!-- Center Column -->

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
@@ -9,6 +9,17 @@
        <div class="blurb">
             Topic tagging is a new feature that was developed to categorize learning objects by relevant topic areas in order to increase search-ability. Select the tag(s) that most appropriately describe
             the entire learning object.
+            <button class="blurb-tooltip"
+                [tip]
+                tip="Suggest a topic!
+                
+                Topics should accurately 'tag' a learning object. If you feel we are missing a topic or a current topic is no longer relevant, click the information icon below to send us an email.
+                "
+                (activate)="sendEmail()"
+                href="mailto:mfranz1@students.towson.edu?subject=CLARK Learning Object Topic Suggestion&body=yeet"
+            >
+                <i class="fas fa-info-circle"></i>
+            </button>
        </div>
     </div>
 

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.html
@@ -1,0 +1,16 @@
+<onion-column-wrapper>
+    <!-- Left Column -->
+    <div left>
+        <div class="header">
+            <div class="title">
+                <p>Learning Object Topic Tags</p>
+            </div>
+        </div>
+        <p>Info go grr</p>
+    </div>
+
+    <!-- Center Column -->
+    <div main>
+        <clark-relevancy-scafold></clark-relevancy-scafold>
+    </div>
+</onion-column-wrapper>

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
@@ -1,0 +1,11 @@
+@import '~_vars.scss';
+
+.header {
+    display: flex;
+  
+    .title {
+      font-size: $large;
+      font-weight: 600;
+      margin: 0px auto;
+    }
+}

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
@@ -9,3 +9,8 @@
       margin: 0px auto;
     }
 }
+
+.blurb {
+  padding: 0 15px 20px 15px;
+  text-align: center;
+}

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
@@ -13,4 +13,10 @@
 .blurb {
   padding: 0 15px 20px 15px;
   text-align: left;
+
+  .blurb-tooltip {
+    color: $light-blue;
+    border: none;
+    background-color: white;
+  }
 }

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
@@ -6,11 +6,11 @@
     .title {
       font-size: $large;
       font-weight: 600;
-      margin: 0px auto;
+      margin-left: 15px;
     }
 }
 
 .blurb {
   padding: 0 15px 20px 15px;
-  text-align: center;
+  text-align: left;
 }

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.scss
@@ -13,10 +13,4 @@
 .blurb {
   padding: 0 15px 20px 15px;
   text-align: left;
-
-  .blurb-tooltip {
-    color: $light-blue;
-    border: none;
-    background-color: white;
-  }
 }

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.spec.ts
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TopicPageComponent } from './topic-page.component';
+
+describe('TopicPageComponent', () => {
+  let component: TopicPageComponent;
+  let fixture: ComponentFixture<TopicPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ TopicPageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopicPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.ts
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'clark-topic-page',
+  templateUrl: './topic-page.component.html',
+  styleUrls: ['./topic-page.component.scss']
+})
+export class TopicPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.ts
+++ b/src/app/onion/relevancy-builder/pages/topic-page/topic-page.component.ts
@@ -12,4 +12,13 @@ export class TopicPageComponent implements OnInit {
   ngOnInit(): void {
   }
 
+  /**
+   * Function to send email for topic tool tip
+   */
+  sendEmail() {
+    const mail = document.createElement('a');
+    mail.href = `mailto:info@secured.team?subject=CLARK Learning Object Topic Suggestion`;
+    mail.click();
+  }
+
 }

--- a/src/app/onion/relevancy-builder/relevancy-builder.module.ts
+++ b/src/app/onion/relevancy-builder/relevancy-builder.module.ts
@@ -18,6 +18,7 @@ import { OutcomePageComponent } from './pages/outcome-page/outcome-page.componen
 import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { OutcomeListItemComponent } from './components/standard-outcomes/outcome-list-item/outcome-list-item.component';
 import { CubeSharedModule } from 'app/cube/shared/cube-shared.module';
+import { TopicPageComponent } from './pages/topic-page/topic-page.component';
 
 @NgModule({
   declarations: [
@@ -29,6 +30,7 @@ import { CubeSharedModule } from 'app/cube/shared/cube-shared.module';
     StandardOutcomesComponent,
     OutcomePageComponent,
     OutcomeListItemComponent,
+    TopicPageComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/onion/relevancy-builder/relevancy-builder.routing.ts
+++ b/src/app/onion/relevancy-builder/relevancy-builder.routing.ts
@@ -2,12 +2,15 @@ import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { OutcomePageComponent } from './pages/outcome-page/outcome-page.component';
+import { TopicPageComponent } from './pages/topic-page/topic-page.component';
 import { RelevancyBuilderComponent } from './relevancy-builder.component';
 
 const builder_routes: Routes = [
     { path: '', component: RelevancyBuilderComponent,
     children: [
-      { path: '', component: OutcomePageComponent, data: { state: 'outcomes' }},
+      { path: '', redirectTo: 'outcomes', pathMatch: 'full'},
+      { path: 'outcomes', component: OutcomePageComponent, data: { state: 'outcomes' }},
+      { path: 'topics', component: TopicPageComponent }
     ]
   }
 ];

--- a/src/app/shared/modules/contextmenu/context-menu-viewer/context-menu-viewer.component.scss
+++ b/src/app/shared/modules/contextmenu/context-menu-viewer/context-menu-viewer.component.scss
@@ -38,6 +38,26 @@
         margin-right: 10px;
       }
 
+      p {
+        margin: 0;
+        display: inline;
+
+        &.title {
+          margin-right: 35px;
+        }
+
+        &.new_tag {
+          margin: 0;
+          color: $orange;
+
+          .svg-inline--fa{
+            margin-right: 2px;
+          }
+        }
+      }
+
+      
+
       .notifications {
         background-color: $error-red;
         border: 1px solid white;

--- a/src/app/shared/modules/contextmenu/context-menu-viewer/context-menu-viewer.component.scss
+++ b/src/app/shared/modules/contextmenu/context-menu-viewer/context-menu-viewer.component.scss
@@ -38,24 +38,26 @@
         margin-right: 10px;
       }
 
-      p {
-        margin: 0;
-        display: inline;
+      &.new-feature_wrapper {
 
-        &.title {
-          margin-right: 35px;
-        }
-
-        &.new_tag {
+        p {
           margin: 0;
-          color: $orange;
-
-          .svg-inline--fa{
-            margin-right: 2px;
+          display: inline;
+  
+          &.list-item_title {
+            margin-right: 35px;
+          }
+  
+          &.new-item_element {
+            margin: 0;
+            color: $orange;
+  
+            .svg-inline--fa{
+              margin-right: 2px;
+            }
           }
         }
       }
-
       
 
       .notifications {


### PR DESCRIPTION
This PR breaks out the outcomes and topic sections of the relevancy builder. Each now have their own respective page. A small badge was added to the admin dashboard to signify this is a new feature.

Story: https://app.shortcut.com/clarkcan/story/5769/separate-topics-from-guidelines-in-relevancy-builder

![image](https://user-images.githubusercontent.com/55514493/133805337-ed9eff1b-e027-4a05-a1b0-85134a48a311.png)
![image](https://user-images.githubusercontent.com/55514493/133805370-0c269224-e254-4ddf-b3de-fff5703ce60c.png)
![image](https://user-images.githubusercontent.com/55514493/133805402-e1b23b7d-9bda-4acc-a18e-f3be147d0d6f.png)
