### PR TITLE
Make login and map tag edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.22.2",
+  "version": "4.22.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.22.2",
+  "version": "4.22.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -72,7 +72,7 @@ export class LoginComponent implements OnInit {
   }
 
   error(text: string = 'An error occured', duration: number = 4000) {
-    this.loginFailure = text;
+    this.loginFailure = text + ', you have 5 login attempts per hour';
 
     this.loginFailureTimer = setTimeout(() => {
       this.loginFailure = undefined;

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -331,7 +331,6 @@ export class AuthService {
           }
         )
         .pipe(
-          retry(3),
           catchError(this.handleError)
         )
         .toPromise();
@@ -390,7 +389,6 @@ export class AuthService {
           }
         )
         .pipe(
-          retry(3),
           catchError(this.handleError)
         )
         .toPromise();

--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -94,4 +94,9 @@
       <i class="fal fa-spinner-third fa-spin"></i>
     </span>
   </button>
+  <button
+    *ngIf="mapAndTag"
+    class="button neutral"
+    aria-label="Map and Tag"
+    (activate)="mapAndTagObject()">Map and Tag</button>
 </ng-template>

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -15,6 +15,7 @@ import { LibraryService, iframeParentID } from 'app/core/library.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { takeUntil } from 'rxjs/operators';
 import { CollectionService } from 'app/core/collection.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'cube-details-action-panel',
@@ -73,6 +74,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     private toaster: ToastrOvenService,
     private changeDetectorRef: ChangeDetectorRef,
     private collectionService: CollectionService,
+    private router: Router,
   ) { }
 
   ngOnInit() {
@@ -88,6 +90,20 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     const userName = this.auth.username;
     this.userIsAuthor = (this.learningObject.author.username === userName);
     this.getCollection();
+  }
+
+  get mapAndTag() {
+    let canMapAndTag = false;
+    if (this.auth.user && this.auth.user.accessGroups) {
+      const privileges = ['admin', 'editor', 'mapper', 'curator', 'reviewer'];
+      for (let i = 0; i < privileges.length; i++) {
+        if (this.auth.user.accessGroups.includes(privileges[i]) ||
+          this.auth.user.accessGroups.some(res => res.includes(privileges[i]))) {
+            canMapAndTag = true;
+        }
+      }
+    }
+    return canMapAndTag;
   }
 
   get isReleased(): boolean {
@@ -310,6 +326,13 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
       attribution = 'List of Contributors';
     }
     return attribution;
+  }
+
+  /**
+   * Opens the relevancy builder
+   */
+  mapAndTagObject() {
+    this.router.navigate([`/onion/relevancy-builder/${this.learningObject.id}`]);
   }
 
   private capitalizeName(name) {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
@@ -22,22 +22,8 @@
   Edits and Revisions not Permitted
 </button>
 
-<button
-  *ngIf="makeRevision"
-  class="button neutral"
-  aria-label="Map and Tag"
-  (activate)="mapAndTagObject()">
-  Map and Tag
-</button>
-
 <clark-popup *ngIf="openRevisionModal" (closed)="closeRevisionModal()">
   <div #popupInner style="max-width: 600px;">
     <clark-revision-notice-popup (createRevision)="createRevision()" (close)="closeRevisionModal()"></clark-revision-notice-popup>
-  </div>
-</clark-popup>
-
-<clark-popup *ngIf="showAddEvaluator" (closed)="toggleAddEvaluatorModal(false)">
-  <div class="modal-container" #popupInner>
-    <clark-add-evaluator (close)="toggleAddEvaluatorModal(false)" [learningObject]="learningObject"></clark-add-evaluator>
   </div>
 </clark-popup>

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
@@ -23,11 +23,11 @@
 </button>
 
 <button
-  *ngIf="assignEvaluators"
+  *ngIf="makeRevision"
   class="button neutral"
-  aria-label="Assign Evaluators"
-  (activate)="toggleAddEvaluatorModal(true)">
-  Assign Evaluators
+  aria-label="Map and Tag"
+  (activate)="mapAndTagObject()">
+  Map and Tag
 </button>
 
 <clark-popup *ngIf="openRevisionModal" (closed)="closeRevisionModal()">

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -106,11 +106,9 @@ export class EditorialActionPadComponent implements OnInit {
     }
 
   /**
-   * Toggles the add evaluator modal from showing/hiding
-   *
-   * @param value True if showing, false otherwise
+   * Opens the relevancy builder
    */
-  toggleAddEvaluatorModal(value: boolean) {
-    this.showAddEvaluator = value;
+  mapAndTagObject() {
+    this.router.navigate([`/onion/relevancy-builder/${this.learningObject.id}`]);
   }
 }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -1,12 +1,9 @@
-import { Component, OnInit, Input, OnDestroy } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 import { LearningObject } from '@entity';
 import { LearningObjectService } from 'app/cube/learning-object.service';
 import { LearningObjectService as LOUri} from 'app/core/learning-object.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
-import { takeUntil, debounceTime } from 'rxjs/operators';
-import { Subject } from 'rxjs';
-import { AuthService } from 'app/core/auth.service';
 
 /**
  * EditorialActionPadComponent coordinates all editor functionality inside of the
@@ -25,9 +22,6 @@ export class EditorialActionPadComponent implements OnInit {
   openRevisionModal: boolean;
   showPopup = false;
 
-  showAddEvaluator: boolean;
-  addEvaluatorButton = false;
-
   @Input() revisedLearningObject: LearningObject;
 
   constructor(
@@ -35,20 +29,9 @@ export class EditorialActionPadComponent implements OnInit {
     private learningObjectService: LearningObjectService,
     private learningObjectServiceUri: LOUri,
     private toaster: ToastrOvenService,
-    private authService: AuthService
     ) { }
 
   async ngOnInit() {
-  }
-
-  get assignEvaluators() {
-    const addEvaluatorUserPrivileges = ['admin', 'editor'];
-    for (let i = 0; i < addEvaluatorUserPrivileges.length; i++) {
-      if (this.authService.user.accessGroups.includes(addEvaluatorUserPrivileges[i])) {
-        this.addEvaluatorButton = true;
-      }
-    }
-    return this.addEvaluatorButton;
   }
 
   // Determines if an editor can create a revision of a learning object
@@ -104,11 +87,4 @@ export class EditorialActionPadComponent implements OnInit {
         this.toaster.error('Error', e.error.message);
       });
     }
-
-  /**
-   * Opens the relevancy builder
-   */
-  mapAndTagObject() {
-    this.router.navigate([`/onion/relevancy-builder/${this.learningObject.id}`]);
-  }
 }


### PR DESCRIPTION
This PR combines two stories:
- Removes the retry attempts for login/register and updates the error message to include how many login attempts you are given
- Swaps out the assigned evaluators button for the map and tag button

Completes stories [5861/increase-number-of-bad-password-attempts-and-adjust-error-verbiage](https://app.shortcut.com/clarkcan/story/5861/increase-number-of-bad-password-attempts-and-adjust-error-verbiage) and [5861/increase-number-of-bad-password-attempts-and-adjust-error-verbiage](https://app.shortcut.com/clarkcan/story/5861/increase-number-of-bad-password-attempts-and-adjust-error-verbiage).