### PR TITLE
5995/bug-saving-outcomes-in-database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.23.2",
+  "version": "4.23.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.23.2",
+  "version": "4.23.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/onion/learning-object-builder/pages/outcome-page/outcome-page.component.ts
+++ b/src/app/onion/learning-object-builder/pages/outcome-page/outcome-page.component.ts
@@ -92,6 +92,13 @@ export class OutcomePageComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Gets the active outcome from the outcomes map
+   */
+  get activeOutcomeObject() {
+    return this._outcomes.get(this.activeOutcome);
+  }
+
   setActiveOutcome(id: string) {
     if (id !== this.activeOutcome) {
       this.store.sendOutcomeCache();
@@ -112,8 +119,9 @@ export class OutcomePageComponent implements OnInit, OnDestroy {
       const outcome = this.store.outcomeEvent.getValue().get(id);
       this.validator.validateLearningOutcome(outcome);
       this.validateNewOutcome();
-      setTimeout(() => {
+      setTimeout(async () => {
         this.activeOutcome = id;
+        await this.store.execute(actions.MUTATE_OUTCOME, { id, params: this.activeOutcomeObject });
       }, 100);
     });
   }


### PR DESCRIPTION
This PR makes it so the outcome will automatically update after creating an outcome.  This fixes the bug where if you type an outcome and it doesn't save twice then the outcome saves as an empty outcome.  Completes story [5995/bug-saving-outcomes-in-database](https://app.shortcut.com/clarkcan/story/5995/bug-saving-outcomes-in-database).