### PR TITLE
4795/upgrade-elasticbeanstalk-instances-to-non-deprecated-platforms

### DIFF
--- a/src/app/components/navbar/components/message/message.component.html
+++ b/src/app/components/navbar/components/message/message.component.html
@@ -1,6 +1,6 @@
 <div class="wrapper warning" *ngIf="showBanner">
   <div class="inner-wrapper">
-    <div aria-live="assertive">{{ message.message }} </div>
+    <div aria-live="assertive">{{ message.message }}</div>
     <!-- <a *ngIf="!downtime" class="status-link" [routerLink]="['/onion/learning-object-builder/info']" aria-label="Create a learning object" target="_blank"> Create a Learning Object</a> -->
     <a *ngIf="downtime" class="status-link" [routerLink]="['/system/status']" aria-label="Clickable System Outages link" target="_blank"> View Status</a>
   </div>

--- a/src/app/components/navbar/components/message/message.component.ts
+++ b/src/app/components/navbar/components/message/message.component.ts
@@ -24,7 +24,7 @@ export class MessageComponent implements OnInit {
   getMessage() {
     this.messages.getStatus().then(message => {
       this.message = message;
-      this.showBanner = false;
+      this.showBanner = true;
     })
     .catch ( _ => {
       /** Suppress the error because it is being handled in Gateway.

--- a/src/app/core/messages.service.ts
+++ b/src/app/core/messages.service.ts
@@ -9,7 +9,7 @@ export class Message {
 }
 @Injectable()
 export class MessagesService {
-  private _message: Message;
+  private _message: Message = { isUnderMaintenance: false, message: 'CLARK will be taking downtime October 19th between 7 and 8 am EST.' };
 
   get message() {
     return this._message;


### PR DESCRIPTION
This PR adds a notice for the downtime we are taking for the elastic beanstalk upgrades on 19 Oct 2021, 7-8am EST.  Completes story [4795/upgrade-elasticbeanstalk-instances-to-non-deprecated-platforms](https://app.shortcut.com/clarkcan/story/4795/upgrade-elasticbeanstalk-instances-to-non-deprecated-platforms).