### PR TITLE
6020/changing-collection-frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2583,8 +2583,7 @@
         },
         "lodash": {
           "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "resolved": "",
           "dev": true
         },
         "ms": {
@@ -5057,8 +5056,7 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "autoprefixer": {
@@ -5538,8 +5536,7 @@
         },
         "ssri": {
           "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-7.1.0.tgz",
-          "integrity": "sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==",
+          "resolved": "",
           "dev": true,
           "requires": {
             "figgy-pudding": "^3.5.1",
@@ -7832,8 +7829,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ansi-styles": {
@@ -12884,8 +12880,7 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "resolved": ""
         },
         "cli-cursor": {
           "version": "3.1.0",
@@ -18126,9 +18121,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
+      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
       "dev": true
     },
     "private": {
@@ -19728,8 +19723,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "resolved": ""
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -21709,9 +21703,9 @@
       }
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-arraybuffer": {
@@ -21876,8 +21870,7 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "ansi-styles": {
@@ -24260,11 +24253,11 @@
       "dev": true
     },
     "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "widest-line": {
@@ -24278,8 +24271,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "resolved": "",
           "dev": true
         },
         "emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.25.3",
+  "version": "4.26.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.25.3",
+  "version": "4.26.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -35,6 +35,7 @@ import { AddEvaluatorComponent } from './components/add-evaluator/add-evaluator.
 import { ObjectDropdownComponent } from './components/add-evaluator/components/object-dropdown/object-dropdown.component';
 import { SelectedUserComponent } from './components/add-evaluator/components/selected-user/selected-user.component';
 import { LearningObjectService } from 'app/cube/learning-object.service';
+import { ChangeCollectionComponent } from './components/change-collection/change-collection.component';
 
 @NgModule({
   declarations: [
@@ -60,6 +61,7 @@ import { LearningObjectService } from 'app/cube/learning-object.service';
     AddEvaluatorComponent,
     ObjectDropdownComponent,
     SelectedUserComponent,
+    ChangeCollectionComponent,
   ],
   imports: [
     CoreModule.forRoot(),

--- a/src/app/admin/components/change-collection/change-collection.component.html
+++ b/src/app/admin/components/change-collection/change-collection.component.html
@@ -1,0 +1,14 @@
+<div class="banner">
+    <div class="banner__title">Select a Collection</div>
+    <div class="banner__sub">Select a collection to change the collection of the object.</div>
+</div>
+<div class="content">
+    <clark-collections-grid [currentCollection]="object.collection" (selected)="selectCollection($event)"></clark-collections-grid>
+    <div class="submit-btn btn-group center">
+        <button class="button good"
+            [ngClass]="{'disabled': !selectedCollection || selectedCollection === object.collection }"
+            [disabled]="!selectedCollection || selectedCollection === object.collection"
+            (activate)="confirm()" aria-label="Change object's submitted collection">Confirm</button>
+        <button class="button neutral" aria-label="Go back to the previous page" (activate)="close.emit()">Cancel</button>
+    </div>
+</div>

--- a/src/app/admin/components/change-collection/change-collection.component.scss
+++ b/src/app/admin/components/change-collection/change-collection.component.scss
@@ -1,0 +1,66 @@
+@import '~_vars.scss';
+
+.submit {
+  max-width: 800px;
+  min-height: 550px;
+  width: 90vw;
+  padding: 20px;
+}
+
+.banner {
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 20px;
+  box-sizing: border-box;
+  position: absolute;
+  background: $light-blue-gradient;
+  height: 96px;
+
+  &:after {
+    content: '';
+    background: white;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0.04;
+    mask: $cube-pattern repeat;
+  }
+
+  .banner__title {
+    color: white;
+    font-size: $larger;
+    font-weight: bold;
+  }
+
+  .banner__sub {
+    color: white;
+    opacity: 0.85;
+    font-size: $normal;
+  }
+}
+
+.submit-btn {
+  margin-top: 30px;
+}
+
+.submit__loading {
+  position: absolute;
+  z-index: 999999;
+  background: rgba(255, 255, 255, 0.8);
+  color: $light-blue;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 40px;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+.content {
+    margin-top: 80px;
+}

--- a/src/app/admin/components/change-collection/change-collection.component.spec.ts
+++ b/src/app/admin/components/change-collection/change-collection.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangeCollectionComponent } from './change-collection.component';
+
+describe('ChangeCollectionComponent', () => {
+  let component: ChangeCollectionComponent;
+  let fixture: ComponentFixture<ChangeCollectionComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ChangeCollectionComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangeCollectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/components/change-collection/change-collection.component.ts
+++ b/src/app/admin/components/change-collection/change-collection.component.ts
@@ -1,0 +1,48 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Collection, CollectionService } from 'app/core/collection.service';
+import { CollectionService as AdminCollectionService } from 'app/admin/core/collection.service';
+import { LearningObject } from '@entity';
+import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
+
+@Component({
+  selector: 'clark-change-collection',
+  templateUrl: './change-collection.component.html',
+  styleUrls: ['./change-collection.component.scss']
+})
+export class ChangeCollectionComponent implements OnInit {
+  collections: Collection[] = [];
+  selectedCollection: string;
+
+  @Input() object: LearningObject;
+
+  @Output() close: EventEmitter<void> = new EventEmitter();
+
+  constructor(
+    private collectionService: CollectionService,
+    private adminCollectionService: AdminCollectionService,
+    private toaster: ToastrOvenService
+  ) { }
+
+  async ngOnInit(): Promise<void> {
+    this.collections = await this.collectionService.getCollections();
+  }
+
+  /**
+   * Selects the new collection to move to
+   *
+   * @param collection The abv collection name
+   */
+  selectCollection(collection: string) {
+    this.selectedCollection = collection;
+  }
+
+  /**
+   * Confirms the object's new submitted collection
+   */
+  confirm() {
+    this.adminCollectionService.updateSubmittedCollection(this.object.author.username, this.object.cuid, this.selectedCollection)
+      .then(() => this.object.collection = this.selectedCollection)
+      .catch(() => this.toaster.error('Error', 'There was an error changing collections, please try again later.'))
+      .finally(() => this.close.emit());
+  }
+}

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -46,9 +46,16 @@
         <p class="list-item_title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
         <p class="new-item_element"><i class="fas fa-asterisk"></i>NEW</p>
       </li>
+      <li *ngIf="learningObject.status !== 'released'" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
     </ul>
   </div>
 </clark-context-menu>
+
+<clark-popup *ngIf="showChangeCollection" (closed)="toggleChangeCollectionModal(false)">
+  <div class="modal-container" #popupInner>
+    <clark-change-collection [object]="learningObject" (close)="toggleChangeCollectionModal(false)"></clark-change-collection>
+  </div>
+</clark-popup>
 
 <clark-popup *ngIf="showUnreleaseConfirm" (closed)="toggleUnreleaseConfirm(false)">
   <div class="modal-container center" #popupInner>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -46,7 +46,7 @@
         <p class="list-item_title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
         <p class="new-item_element"><i class="fas fa-asterisk"></i>NEW</p>
       </li>
-      <li *ngIf="learningObject.status !== 'released'" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
+      <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
     </ul>
   </div>
 </clark-context-menu>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -41,12 +41,12 @@
       <li (click)="toggleRelevancyDate(true)"><i class="fal fa-history"></i>Mark Next Check Date</li>
       <li (click)="toggleAddEvaluatorModal(true)"><i class="fal fa-user-plus"></i>Assign Evaluators</li>
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
+      <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
       <li *ngIf="learningObject.status === 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
       <li class="new-feature_wrapper" [routerLink]="['/onion/relevancy-builder', learningObject.id]">
         <p class="list-item_title"><i class="far fa-puzzle-piece"></i>Map & Tag</p>
         <p class="new-item_element"><i class="fas fa-asterisk"></i>NEW</p>
       </li>
-      <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
     </ul>
   </div>
 </clark-context-menu>

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -51,10 +51,10 @@ export class LearningObjectListItemComponent implements OnChanges {
   showChangeAuthor: boolean;
   showAddEvaluator: boolean;
   showUnreleaseConfirm: boolean;
-
   showRelevancyDate: boolean;
-
   showDeleteRevisionConfirmation: boolean;
+  showChangeCollection: boolean;
+
   // flags
   meatballOpen = false;
 
@@ -133,6 +133,16 @@ export class LearningObjectListItemComponent implements OnChanges {
     if (value) {
       this.unreleaseLearningObject();
     }
+  }
+
+  /**
+   * Opens or closes the change collection modal based
+   * on the passed value
+   *
+   * @param value true (if open), false otherwise
+   */
+  toggleChangeCollectionModal(value: boolean) {
+    this.showChangeCollection = value;
   }
 
   /**

--- a/src/app/admin/core/collection.service.spec.ts
+++ b/src/app/admin/core/collection.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CollectionService } from './collection.service';
+
+describe('CollectionService', () => {
+  let service: CollectionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CollectionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/admin/core/collection.service.ts
+++ b/src/app/admin/core/collection.service.ts
@@ -1,0 +1,25 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { ADMIN_ROUTES } from '@env/route';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CollectionService {
+
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Changes the collection of an in review object
+   *
+   * @param username The username of the object's author
+   * @param cuid The cuid of the object
+   * @param collection The collection changing to
+   */
+  async updateSubmittedCollection(username: string, cuid: string, collection: string) {
+    await this.http.patch(
+      ADMIN_ROUTES.UPDATE_OBJECT_SUBMITTED_COLLECTION(username, cuid),
+      { collection }, { withCredentials: true,  responseType: 'text' }
+    ).toPromise();
+  }
+}

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -30,6 +30,9 @@ export const ADMIN_ROUTES = {
   DELETE_REVISION(username: string, cuid: string, version: number) {
     return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${cuid}/versions/${version}`;
   },
+  UPDATE_OBJECT_SUBMITTED_COLLECTION(username: string, cuid: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${encodeURIComponent(cuid)}/collection`;
+  },
 };
 
 export const CHANGELOG_ROUTES = {


### PR DESCRIPTION
This PR adds a new modal to the admin dashboard that will allow editors and admins to change the collection of in review, waiting, or proofing learning objects.  Completes story [6020/changing-collection-frontend](https://app.shortcut.com/clarkcan/story/6020/changing-collection-frontend).

Screenshots
<img width="256" alt="Screen Shot 2021-11-10 at 11 15 16 AM" src="https://user-images.githubusercontent.com/32078831/141151126-c647ff51-4d17-4162-9da0-b982ec9bab97.png">

<img width="667" alt="Screen Shot 2021-11-10 at 11 15 28 AM" src="https://user-images.githubusercontent.com/32078831/141151152-b6883074-7d35-4c7b-8cd9-88ef0a762767.png">

<img width="667" alt="Screen Shot 2021-11-10 at 11 15 33 AM" src="https://user-images.githubusercontent.com/32078831/141151175-1a5c5df3-eb01-4dcc-a336-4ceaea3214c3.png">

<img width="1652" alt="Screen Shot 2021-11-10 at 11 16 16 AM" src="https://user-images.githubusercontent.com/32078831/141151209-af669c77-8e0f-4bc6-b685-80f605872dfa.png">