### PR TITLE
6451/dom-element-persists-after-download-below-footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.27.4",
+  "version": "4.27.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.27.4",
+  "version": "4.27.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/library.service.ts
+++ b/src/app/core/library.service.ts
@@ -144,9 +144,10 @@ export class LibraryService {
     // Create the iframe HTML element
     const iframe = document.createElement('iframe');
     // Hide the iframe
-    iframe.setAttribute('style', 'none');
     iframe.setAttribute('sandbox', 'allow-same-origin allow-downloads');
     iframe.setAttribute('id', iframeParentID);
+    iframe.style.visibility = 'hidden';
+    iframe.style.position = 'fixed';
     // Append iframe to the page
     document.body.appendChild(iframe);
     // Retrieve bundle from service


### PR DESCRIPTION
This PR hides the iFrame when a download occurs.  Completes story [6451/dom-element-persists-after-download-below-footer](https://app.shortcut.com/clarkcan/story/6451/dom-element-persists-after-download-below-footer).