### PR TITLE
Fix UI bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.27.5",
+  "version": "4.27.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.27.5",
+  "version": "4.27.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -15,7 +15,7 @@
     </div>
     <div *ngIf="learningObjects" class="content" id="pageContent" tabindex="0">
       <div class="column-title" id="column-title">
-        <span tabindex="0" id="results">{{ copy.RESULTS }} ({{this.totalLearningObjects}})
+        <span tabindex="0" id="results">{{ copy.RESULTS }} ({{ this.totalLearningObjects ? this.totalLearningObjects : '0' }})
           <a class="clear-search" id="clear-search" (activate)="clearSearch()" *ngIf="query?.text !== '' || query.standardOutcomes.length">{{ copy.CLEARSEARCH }} </a>
           <span class="loading" *ngIf="loading"><i class="far fa-spinner-third fa-spin"></i></span>
         </span>

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -11,6 +11,7 @@ import { RatingService } from 'app/core/rating.service';
 import { ChangelogService } from 'app/core/changelog.service';
 import { LearningObjectService } from '../learning-object.service';
 import { trigger, style, group, transition, animate, query } from '@angular/animations';
+import { NavbarService } from 'app/core/navbar.service';
 @Component({
   selector: 'clark-library',
   templateUrl: './library.component.html',
@@ -81,6 +82,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     private ratings: RatingService,
     private changelogService: ChangelogService,
     private learningObjectService: LearningObjectService,
+    private navbarService: NavbarService,
   ) {}
 
   @HostListener('window:resize', ['$event'])
@@ -113,6 +115,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
+    this.navbarService.show();
     this.getScreenSize();
     this.loadLibrary();
   }


### PR DESCRIPTION
This PR fixes two UI bugs:
- The navbar disappears on the library page on reload
- The count on the browse page does not appear and instead should show 0.

Completes stories [6598/results-number-incorrect](https://app.shortcut.com/clarkcan/story/6598/results-number-incorrect) and [6603/navigation-bar-disappears-on-page-reload-of-library](https://app.shortcut.com/clarkcan/story/6603/navigation-bar-disappears-on-page-reload-of-library).