### PR TITLE
6174/learning object lifecycle status admin dashboard updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark",
-  "version": "4.27.11",
+  "version": "4.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.27.11",
+  "version": "4.28.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -48,11 +48,13 @@ $course-color: #1e4b25;
 
 // status colors
 $status_unreleased: #bdc1c3;
-$status_waiting: #5ec9da;
-$status_review: #f5a623;
-$status_proofing: #bd5eda;
-$status_released: $success-green;
-$status_rejected: $error-red;
+$status_waiting: #5EC9DA;
+$status_review: #094491;
+$status_accepted_minor: #31492C;
+$status_accepted_major: #53A52F;
+$status_proofing: #CC469F;
+$status_released: #1C70DD;
+$status_rejected: #CA2E1F;
 
 // tag colors
 $tag_revision: #622fed;

--- a/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.scss
+++ b/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.scss
@@ -144,6 +144,14 @@
     &.review {
       background: $status_review;
     }
+
+    &.accepted_minor {
+      background: $status_accepted_minor;
+    }
+
+    &.accepted_major {
+      background: $status_accepted_major;
+    }
   
     &.proofing {
       background: $status_proofing;

--- a/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.scss
+++ b/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.scss
@@ -161,7 +161,7 @@
       background: $status_released;
     }
   
-    &.denied {
+    &.rejected {
       background: $status_rejected;
     }
   

--- a/src/app/admin/components/change-author/change-author.component.html
+++ b/src/app/admin/components/change-author/change-author.component.html
@@ -18,8 +18,8 @@
             <span *ngIf="highlightedLearningObject.status === 'proofing'"><i class="fas fa-shield"></i></span>
             <span *ngIf="highlightedLearningObject.status === 'released'"><i class="fas fa-eye"></i></span>
             <span *ngIf="highlightedLearningObject.status === 'rejected'"><i class="fas fa-ban"></i></span>
-            <span *ngIf="learningObject.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
-            <span *ngIf="learningObject.status === 'accepted_major'"><i class="fas fa-check"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
+            <span *ngIf="highlightedLearningObject.status === 'accepted_major'"><i class="fas fa-check"></i></span>
           </div>
           <div>
             {{ (highlightedLearningObject.name.length > 40) ? (highlightedLearningObject.name | slice:0:40) + '...' : highlightedLearningObject.name }}

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -70,6 +70,14 @@
     &.review {
       background: $status_review;
     }
+
+    &.accepted_minor {
+      background: $status_accepted_minor;
+    }
+
+    &.accepted_major {
+      background: $status_accepted_major;
+    }
   
     &.proofing {
       background: $status_proofing;

--- a/src/app/admin/components/change-author/change-author.component.scss
+++ b/src/app/admin/components/change-author/change-author.component.scss
@@ -87,7 +87,7 @@
       background: $status_released;
     }
   
-    &.denied {
+    &.rejected {
       background: $status_rejected;
     }
   

--- a/src/app/admin/components/draggable-dashboard-item/draggable-dashboard-item.component.scss
+++ b/src/app/admin/components/draggable-dashboard-item/draggable-dashboard-item.component.scss
@@ -42,7 +42,7 @@
       background: $status_released;
     }
   
-    &.denied {
+    &.rejected {
       background: $status_rejected;
     }
   

--- a/src/app/admin/components/draggable-dashboard-item/draggable-dashboard-item.component.scss
+++ b/src/app/admin/components/draggable-dashboard-item/draggable-dashboard-item.component.scss
@@ -25,6 +25,14 @@
     &.review {
       background: $status_review;
     }
+
+    &.accepted_minor {
+      background: $status_accepted_minor;
+    }
+
+    &.accepted_major {
+      background: $status_accepted_major;
+    }
   
     &.proofing {
       background: $status_proofing;

--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -100,7 +100,7 @@
                 [ngClass]="status"
                 (activate)="toggleStatusFilter(status)">
                   <div *ngIf="filters.has(status)" class="indicator"></div>
-                  <i [ngClass]="getStatusIcon(status)"></i> {{ status | titlecase }}
+                  <i [ngClass]="getStatusIcon(status)"></i> {{ status.replace('_', ' ') | titlecase }}
               </li>
             </ul>
           </div>

--- a/src/app/admin/components/filter-search/filter-search.component.scss
+++ b/src/app/admin/components/filter-search/filter-search.component.scss
@@ -126,6 +126,40 @@
       }
     }
 
+    &.accepted_minor {
+      color: $status_accepted_minor;
+
+      .indicator {
+        background: $status_accepted_minor;
+      }
+
+      &:hover {
+        color: white;
+        background: $status_accepted_minor;
+
+        .indicator {
+          background: white;
+        }
+      }
+    }
+
+    &.accepted_major {
+      color: $status_accepted_major;
+
+      .indicator {
+        background: $status_accepted_major;
+      }
+
+      &:hover {
+        color: white;
+        background: $status_accepted_major;
+
+        .indicator {
+          background: white;
+        }
+      }
+    }
+
     &.proofing {
       color: $status_proofing;
 

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
@@ -42,7 +42,7 @@
     background: $status_released;
   }
 
-  &.denied {
+  &.rejected {
     background: $status_rejected;
   }
 

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.scss
@@ -26,6 +26,14 @@
     background: $status_review;
   }
 
+  &.accepted_minor {
+    background: $status_accepted_minor;
+  }
+
+  &.accepted_major {
+    background: $status_accepted_major;
+  }
+
   &.proofing {
     background: $status_proofing;
   }

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -149,7 +149,7 @@ export class LearningObjectListItemComponent implements OnChanges {
    * Reaches to a service to unrelease the object.
    */
   unreleaseLearningObject() {
-    this.unreleaseService.unreleaseLearningObject(this.learningObject.author.username, this.learningObject.cuid)
+    this.unreleaseService.unreleaseLearningObject(this.learningObject.author.username, this.learningObject.id)
       .then(() => {
       this.toaster.success('Success', 'Learning object was successfully unreleased');
       this.learningObject.status = LearningObject.Status.PROOFING;

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -8,8 +8,7 @@ import {
 import { LearningObject, LearningOutcome } from '@entity';
 import { CookieService } from 'ngx-cookie';
 
-import { USER_ROUTES, PUBLIC_LEARNING_OBJECT_ROUTES } from '@env/route';
-import { AuthService } from '../../core/auth.service';
+import { USER_ROUTES, PUBLIC_LEARNING_OBJECT_ROUTES, ADMIN_ROUTES } from '@env/route';
 
 import { retry, catchError, takeUntil } from 'rxjs/operators';
 import { throwError, Subject, BehaviorSubject } from 'rxjs';
@@ -493,6 +492,25 @@ export class LearningObjectService {
   }): Promise<string[]> {
     const route = USER_ROUTES.ADD_FILE_META(username, objectId);
     return this.handleFileMetaRequests(files, route);
+  }
+
+  async changeStatus({
+    username,
+    objectId,
+    status,
+    reason
+  }: {
+    username: string,
+    objectId: string,
+    status: LearningObject.Status,
+    reason?: string
+  }): Promise<void> {
+    await this.http.post<void>(
+      ADMIN_ROUTES.CHANGE_STATUS(username, objectId),
+      { status, reason },
+      // @ts-ignore
+      { withCredentials: true, responseType: 'text' },
+    ).toPromise();
   }
 
   /**

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -195,12 +195,13 @@ export class LearningObjectService {
     id: string,
     authorUsername: string,
     learningObject: { [key: string]: any },
+    reason?: string,
   ): Promise<{}> {
     const route = USER_ROUTES.UPDATE_MY_LEARNING_OBJECT(authorUsername, id);
     return this.http
       .patch(
         route,
-        { learningObject },
+        { learningObject, reason },
         { headers: this.headers, withCredentials: true, responseType: 'text' }
       )
       .pipe(

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.scss
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.scss
@@ -82,6 +82,14 @@
     background: $status_review;
   }
 
+  &.accepted_minor {
+    background: $status_accepted_minor;
+  }
+
+  &.accepted_major {
+    background: $status_accepted_major;
+  }
+
   &.proofing {
     background: $status_proofing;
   }

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.scss
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.scss
@@ -98,7 +98,7 @@
     background: $status_released;
   }
 
-  &.denied {
+  &.rejected {
     background: $status_rejected;
   }
 

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -15,7 +15,6 @@ import { AuthService } from 'app/core/auth.service';
 import { LearningObject } from 'entity/learning-object/learning-object';
 import { LearningObjectService } from 'app/onion/core/learning-object.service';
 import { UriRetrieverService } from 'app/core/uri-retriever.service';
-import { takeUntil } from 'rxjs/operators';
 
 
 @Component({
@@ -135,7 +134,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
         this.learningObject.length !== 'nanomodule'
       ],
       manageMaterials: ['unreleased', 'accepted_minor', 'accepted_major', this.verifiedEmail],
-      submit: ['unreleased', this.verifiedEmail],
+      submit: ['unreleased', 'accepted_minor', 'accepted_major', this.verifiedEmail],
       resubmit: ['accepted_minor', 'accepted_major'],
       view: ['released'],
       delete: ['unreleased', 'rejected'],

--- a/src/app/onion/dashboard/components/list/list.component.scss
+++ b/src/app/onion/dashboard/components/list/list.component.scss
@@ -222,7 +222,7 @@
       }
     }
 
-    &.denied {
+    &.rejected {
       color: $status_rejected;
 
       .indicator {

--- a/src/app/onion/dashboard/components/list/list.component.scss
+++ b/src/app/onion/dashboard/components/list/list.component.scss
@@ -154,6 +154,40 @@
       }
     }
 
+    &.accepted_minor {
+      color: $status_accepted_minor;
+
+      .indicator {
+        background: $status_accepted_minor;
+      }
+
+      &:hover {
+        color: white;
+        background: $status_accepted_minor;
+
+        .indicator {
+          background: white;
+        }
+      }
+    }
+
+    &.accepted_major {
+      color: $status_accepted_major;
+
+      .indicator {
+        background: $status_accepted_major;
+      }
+
+      &:hover {
+        color: white;
+        background: $status_accepted_major;
+
+        .indicator {
+          background: white;
+        }
+      }
+    }
+
     &.proofing {
       color: $status_proofing;
 

--- a/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.html
+++ b/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.html
@@ -13,6 +13,8 @@
           <span *ngIf="revision.status === 'proofing'"><i class="fas fa-shield"></i></span>
           <span *ngIf="revision.status === 'released'"><i class="fas fa-eye"></i></span>
           <span *ngIf="revision.status === 'rejected'"><i class="fas fa-ban"></i></span>
+          <span *ngIf="revision.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
+          <span *ngIf="revision.status === 'accepted_major'"><i class="fas fa-check"></i></span>
         </div>
         <p class="revision-name">{{ revision.name }}</p>
       </div>

--- a/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.scss
+++ b/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.scss
@@ -68,7 +68,7 @@
       background: $status_released;
     }
   
-    &.denied {
+    &.rejected {
       background: $status_rejected;
     }
   }

--- a/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.scss
+++ b/src/app/onion/dashboard/components/side-panel-content/revision/revision.component.scss
@@ -51,6 +51,14 @@
     &.review {
       background: $status_review;
     }
+
+    &.accepted_minor {
+      background: $status_accepted_minor;
+    }
+
+    &.accepted_major {
+      background: $status_accepted_major;
+    }
   
     &.proofing {
       background: $status_proofing;

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -218,8 +218,23 @@ export class DashboardComponent implements OnInit, OnDestroy {
    * @param event
    */
   submitLearningObjectToCollection(event: LearningObject) {
-    this.currentlySubmittingObject = event;
-    this.submitToCollection = true;
+    // If the object is unreleased, submit it, else resubmit it (because minor/major changes were asked for)
+    if (LearningObject.Status.UNRELEASED === event.status) {
+      this.currentlySubmittingObject = event;
+      this.submitToCollection = true;
+    } else {
+      this.learningObjectService.changeStatus({
+        username: event.author.username,
+        objectId: event.id,
+        status: LearningObject.Status.REVIEW,
+      })
+        .then(() => {
+          this.notificationService.success('Done!', 'Learning Object Resubmitted for Review!');
+          event.status = LearningObject.Status.REVIEW;
+        })
+        .catch(() => this.notificationService.error('Error!',
+          'There was an issue resubmitting the learning object, please try again later!'));
+    }
   }
 
    /**

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -42,7 +42,8 @@ export enum BUILDER_ACTIONS {
   UPDATE_MATERIAL_NOTES,
   UPDATE_FILE_DESCRIPTION,
   UPDATE_FOLDER_DESCRIPTION,
-  DELETE_FILES
+  DELETE_FILES,
+  CHANGE_STATUS,
 }
 
 export enum BUILDER_ERRORS {
@@ -393,6 +394,8 @@ export class BuilderStore {
         });
       case BUILDER_ACTIONS.DELETE_FILES:
         return await this.removeFiles(data.fileIds);
+      case BUILDER_ACTIONS.CHANGE_STATUS:
+        return await this.changeStatus(data.status, data.reason);
       default:
         console.error('Error! Invalid action taken!');
         return;
@@ -414,6 +417,15 @@ export class BuilderStore {
   ///////////////////////////////
   //  BUILDER ACTION HANDLERS  //
   ///////////////////////////////
+
+  private async changeStatus(status: LearningObject.Status, reason?: string) {
+    await this.learningObjectService.changeStatus({
+      username: this.learningObject.author.username,
+      objectId: this.learningObject.id,
+      status,
+      reason,
+    });
+  }
 
   private createOutcome() {
     const outcome: Partial<LearningOutcome> = {

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.html
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.html
@@ -1,6 +1,6 @@
 <clark-popup *ngIf="shouldShow" (closed)="closeModal()">
   <div class="popup-inner" #popupInner>
-    <ng-container [ngTemplateOutlet]="page === 1 ? changeStatus : updateChangelog"></ng-container>
+    <ng-container [ngTemplateOutlet]="page === 1 ? changeStatus : selectedStatus === 'accepted_major' || selectedStatus === 'accepted_minor' ? requestChanges : updateChangelog"></ng-container>
   </div>
 </clark-popup>
 
@@ -14,8 +14,8 @@
       </div>
     </div>
     <div class="btn-group to-right">
-      <button *ngIf="selectedStatus && selectedStatus === 'released'" class="button good" (activate)="advance()">Next</button>
-      <button *ngIf="selectedStatus && selectedStatus !== 'released'" class="button good" (activate)="updateStatus()">Confirm</button>
+      <button *ngIf="selectedStatus && (selectedStatus === 'released' || selectedStatus === 'accepted_major' || selectedStatus === 'accepted_minor')" class="button good" (activate)="advance()">Next</button>
+      <button *ngIf="selectedStatus && (selectedStatus !== 'released' && selectedStatus !== 'accepted_major' && selectedStatus !== 'accepted_minor')" class="button good" (activate)="updateStatus()">Confirm</button>
       <button class="button neutral" (activate)="closeModal()">Cancel</button>
     </div>
   </div>
@@ -25,5 +25,16 @@
   <div [@carousel]="direction">
     <p class="title">What changes were made?</p>
     <clark-edit-changelog [(changelog)]="changelog" (back)="regress()" (cancel)="closeModal()" (confirm)="updateStatus()"></clark-edit-changelog>
+  </div>
+</ng-template>
+
+<ng-template #requestChanges>
+  <div [@carousel]="direction">
+    <p class="title">What changes would you like to request?</p>
+    <clark-text-editor editorPlaceholder="What changes would you like the author(s) to make?" [(savedContent)]="reason" name="change-reason"></clark-text-editor>
+    <div class="btn-group to-right">
+      <button class="button good" (activate)="updateStatus()">Confirm</button>
+      <button class="button neutral" (activate)="closeModal()">Cancel</button>
+    </div>
   </div>
 </ng-template>

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.html
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.html
@@ -1,6 +1,6 @@
 <clark-popup *ngIf="shouldShow" (closed)="closeModal()">
   <div class="popup-inner" #popupInner>
-    <ng-container [ngTemplateOutlet]="page === 1 ? changeStatus : selectedStatus === 'accepted_major' || selectedStatus === 'accepted_minor' ? requestChanges : updateChangelog"></ng-container>
+    <ng-container [ngTemplateOutlet]="page === 1 ? changeStatus : selectedStatus === 'accepted_major' || selectedStatus === 'accepted_minor'  || selectedStatus === 'rejected' ? requestChanges : updateChangelog"></ng-container>
   </div>
 </clark-popup>
 
@@ -14,8 +14,8 @@
       </div>
     </div>
     <div class="btn-group to-right">
-      <button *ngIf="selectedStatus && (selectedStatus === 'released' || selectedStatus === 'accepted_major' || selectedStatus === 'accepted_minor')" class="button good" (activate)="advance()">Next</button>
-      <button *ngIf="selectedStatus && (selectedStatus !== 'released' && selectedStatus !== 'accepted_major' && selectedStatus !== 'accepted_minor')" class="button good" (activate)="updateStatus()">Confirm</button>
+      <button *ngIf="selectedStatus && hasNextModalPage()" class="button good" (activate)="advance()">Next</button>
+      <button *ngIf="selectedStatus && !hasNextModalPage()" class="button good" (activate)="updateStatus()">Confirm</button>
       <button class="button neutral" (activate)="closeModal()">Cancel</button>
     </div>
   </div>
@@ -31,7 +31,12 @@
 <ng-template #requestChanges>
   <div [@carousel]="direction">
     <p class="title">What changes would you like to request?</p>
-    <clark-text-editor editorPlaceholder="What changes would you like the author(s) to make?" [(savedContent)]="reason" name="change-reason"></clark-text-editor>
+    <clark-text-editor
+      editorPlaceholder="What changes would you like the author(s) to make?"
+      [(savedContent)]="reason"
+      (textOutput)="reason = $event"
+      name="reason">
+    </clark-text-editor>
     <div class="btn-group to-right">
       <button class="button good" (activate)="updateStatus()">Confirm</button>
       <button class="button neutral" (activate)="closeModal()">Cancel</button>

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -10,6 +10,7 @@ import { LearningObject } from '@entity';
 import { BUILDER_ACTIONS, BuilderStore } from '../../../builder-store.service';
 import { ChangelogService } from 'app/core/changelog.service';
 import { carousel } from './clark-change-status-modal.animations';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'clark-change-status-modal',
@@ -33,7 +34,8 @@ export class ChangeStatusModalComponent implements OnInit {
   constructor(
     private builderStore: BuilderStore,
     private changelogService: ChangelogService,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private router: Router,
   ) {}
 
   ngOnInit() {
@@ -44,6 +46,10 @@ export class ChangeStatusModalComponent implements OnInit {
     this.closed.next();
   }
 
+  /**
+   * Sets the valid status moves depending on which status the learning
+   * object is currently
+   */
   private setValidStatusMoves() {
     switch (this.learningObject.status) {
       case LearningObject.Status.WAITING:
@@ -68,6 +74,16 @@ export class ChangeStatusModalComponent implements OnInit {
   }
 
   /**
+   * Navigates the user to the map and tag builder
+   */
+  private moveToMapAndTag() {
+    // Set a small timeout before navigating so that the change in status applies
+    setTimeout(() => {
+      this.router.navigate(['onion', 'relevancy-builder', this.learningObject.id, 'outcomes']);
+    }, 1000);
+  }
+
+  /**
    * Navigate to the RTF to create a changelog
    */
   advance() {
@@ -85,6 +101,12 @@ export class ChangeStatusModalComponent implements OnInit {
     this.page = 1;
   }
 
+  /**
+   * Gets the text of the status to move to
+   *
+   * @param status The status to get the text of
+   * @returns A string description
+   */
   getStatusText(status: string) {
     switch (status) {
       case LearningObject.Status.RELEASED:
@@ -119,8 +141,14 @@ export class ChangeStatusModalComponent implements OnInit {
     ]).then(() => {
       this.closeModal();
       this.serviceInteraction = false;
+
+      // If the object released, move to map and tag, else update the valid status moves
       this.learningObject.status = this.selectedStatus as LearningObject.Status;
-      this.setValidStatusMoves();
+      if (this.selectedStatus === LearningObject.Status.RELEASED) {
+        this.moveToMapAndTag();
+      } else {
+        this.setValidStatusMoves();
+      }
     }).catch(error => {
       console.log('An error occurred!');
       this.serviceInteraction = false;

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -100,6 +100,13 @@ export class ChangeStatusModalComponent implements OnInit {
   }
 
   /**
+   * Navigates the user to the admin dashboard
+   */
+  private moveToAdminDashboard() {
+    this.router.navigate(['admin', 'learning-objects']);
+  }
+
+  /**
    * Navigate to the RTF to create a changelog
    */
   advance() {
@@ -159,6 +166,8 @@ export class ChangeStatusModalComponent implements OnInit {
       this.learningObject.status = this.selectedStatus as LearningObject.Status;
       if (this.selectedStatus === LearningObject.Status.RELEASED) {
         this.moveToMapAndTag();
+      } else if (this.learningObject.status === LearningObject.Status.REJECTED) {
+        this.moveToAdminDashboard();
       } else {
         this.setValidStatusMoves();
       }

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -24,6 +24,7 @@ export class ChangeStatusModalComponent implements OnInit {
   @Output() closed = new EventEmitter();
   selectedStatus: string;
   changelog: string;
+  reason: string;
   statuses = [];
 
   page: 1 | 2 = 1;
@@ -44,6 +45,9 @@ export class ChangeStatusModalComponent implements OnInit {
 
   closeModal() {
     this.closed.next();
+    this.selectedStatus = undefined;
+    this.changelog = undefined;
+    this.reason = undefined;
   }
 
   /**
@@ -133,7 +137,7 @@ export class ChangeStatusModalComponent implements OnInit {
     this.serviceInteraction = true;
     await Promise.all([
       this.builderStore
-      .execute(BUILDER_ACTIONS.MUTATE_OBJECT, { status: this.selectedStatus })
+      .execute(BUILDER_ACTIONS.MUTATE_OBJECT, { status: this.selectedStatus, reason: this.reason })
       .catch(error => {
         console.error(error);
       }),

--- a/src/app/onion/shared/status-indicator/status-indicator.component.scss
+++ b/src/app/onion/shared/status-indicator/status-indicator.component.scss
@@ -21,6 +21,14 @@
     background: $status_review;
   }
 
+  &.accepted_minor {
+    background: $status_accepted_minor;
+  }
+
+  &.accepted_major {
+    background: $status_accepted_major;
+  }
+
   &.proofing {
     background: $status_proofing;
   }

--- a/src/app/onion/shared/status-indicator/status-indicator.component.scss
+++ b/src/app/onion/shared/status-indicator/status-indicator.component.scss
@@ -40,6 +40,7 @@
   &.rejected {
     background: $status_rejected;
   }
+  
   &:hover {
     box-shadow: 0 0 20px 2px rgba(0, 0, 0, 0.08);
   }

--- a/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.html
+++ b/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.html
@@ -7,6 +7,8 @@
       <span *ngIf="learningObject.status === 'proofing'"><i class="fas fa-shield"></i></span>
       <span *ngIf="learningObject.status === 'released'"><i class="fas fa-eye"></i></span>
       <span *ngIf="learningObject.status === 'rejected'"><i class="fas fa-ban"></i></span>
+      <span *ngIf="learningObject.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
+      <span *ngIf="learningObject.status === 'accepted_major'"><i class="fas fa-check"></i></span>
     </div>
     <div>
       {{ (learningObject.name.length > 40) ? (learningObject.name | slice:0:40) + '...' : learningObject.name }}

--- a/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.scss
+++ b/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.scss
@@ -51,7 +51,7 @@
         background: $status_released;
       }
     
-      &.denied {
+      &.rejected {
         background: $status_rejected;
       }
     

--- a/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.scss
+++ b/src/app/shared/components/add-evaluator/components/highlighted-learning-object/highlighted-learning-object.component.scss
@@ -34,6 +34,14 @@
       &.review {
         background: $status_review;
       }
+
+      &.accepted_minor {
+        background: $status_accepted_minor;
+      }
+  
+      &.accepted_major {
+        background: $status_accepted_major;
+      }
     
       &.proofing {
         background: $status_proofing;

--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -768,10 +768,10 @@ export namespace LearningObject {
     UNRELEASED = 'unreleased',
     WAITING = 'waiting',
     REVIEW = 'review',
+    ACCEPTED_MINOR = 'accepted_minor',
+    ACCEPTED_MAJOR = 'accepted_major',
     PROOFING = 'proofing',
     RELEASED = 'released',
-    ACCEPTED_MAJOR = 'accepted_major',
-    ACCEPTED_MINOR = 'accepted_minor',
   }
 
   export enum Level {

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -24,8 +24,11 @@ export const ADMIN_ROUTES = {
   CHANGE_AUTHOR(userId: string, id: string): string {
     return `${environment.apiURL}/users/${encodeURIComponent(userId)}/learning-objects/${id}/change-author`;
   },
-  UNRELEASE_OBJECT(username: string, cuid: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${cuid}/status`;
+  CHANGE_STATUS(username: string, id: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${id}/status`;
+  },
+  UNRELEASE_OBJECT(username: string, id: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${id}/status`;
   },
   DELETE_REVISION(username: string, cuid: string, version: number) {
     return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${cuid}/versions/${version}`;


### PR DESCRIPTION
This PR updates the client to reflect the changes in the status updates.  Note that there is a UI bug for rejected status where it doesn't show the red.  If the object is released the editor/admin is automatically sent to the relevancy builder.  If it is rejected then they are sent to the admin dashboard.  Completes story [6174/learning-object-lifecycle-status-admin-dashboard-updates](https://app.shortcut.com/clarkcan/story/6174/learning-object-lifecycle-status-admin-dashboard-updates).

Status icon changes:
<img width="1363" alt="Screen Shot 2022-01-20 at 2 24 38 PM" src="https://user-images.githubusercontent.com/32078831/150409040-72045348-4bc3-4f48-8c58-a5ab7ee7e350.png">

Valid status moves:
<img width="608" alt="Screen Shot 2022-01-20 at 2 25 13 PM" src="https://user-images.githubusercontent.com/32078831/150409100-efa346c1-c49d-4959-bbb4-9602a5d5d941.png">

Requesting change reasons (only on accepted major, minor, and rejected moves):
<img width="608" alt="Screen Shot 2022-01-20 at 2 25 32 PM" src="https://user-images.githubusercontent.com/32078831/150409186-6b21f0ae-c24a-49eb-8b67-45832fcda1dc.png">

Another valid status moves:
<img width="608" alt="Screen Shot 2022-01-20 at 2 25 46 PM" src="https://user-images.githubusercontent.com/32078831/150409270-33c0aea8-3897-4ac9-91cd-fde03136e514.png">

Author editing an object that is in accepted major/minor:
<img width="1653" alt="Screen Shot 2022-01-20 at 2 28 27 PM" src="https://user-images.githubusercontent.com/32078831/150409337-f1d7aa76-3a2c-4ec9-a912-29b5ad023e5c.png">

Resubmitting accepted major/minor for review:
<img width="1543" alt="Screen Shot 2022-01-20 at 2 28 54 PM" src="https://user-images.githubusercontent.com/32078831/150409420-06090b1c-fbdd-409f-87f3-bf34ef858578.png">