### PR TITLE
Adds number to advanced search and suppresses not found error for empty changelogs

### DIFF
--- a/src/app/cube/browse/components/filter/filter.component.html
+++ b/src/app/cube/browse/components/filter/filter.component.html
@@ -16,7 +16,7 @@
 
   <!-- Guidelines Filters -->
   <clark-filter-section [info]="frameworkFilter" (change)="registerChange()">
-    <a (click)="openAdvancedSearch()">Advanced</a>
+    <a (click)="openAdvancedSearch()">Advanced <span *ngIf="guidelineFilter.length > 0">({{ guidelineFilter.length }} Selected)</span></a>
   </clark-filter-section>
 </div>
 

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -373,8 +373,8 @@ export class DetailsComponent implements OnInit, OnDestroy {
         } else if (error.status !== 404) {
           errorMessage = `We encountered an error while attempting to
           retrieve change logs for this Learning Object. Please try again later.`;
+          this.toastService.error('Error!', errorMessage);
         }
-        this.toastService.error('Error!', errorMessage);
       }
       this.loadingChangelogs = false;
       this.openChangelogModal = true;

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -370,7 +370,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
         if (error.status === 401) {
           // user isn't logged-in, set client's state to logged-out and reload so that the route guards can redirect to login page
           this.auth.logout();
-        } else {
+        } else if (error.status != 404) {
           errorMessage = `We encountered an error while attempting to
           retrieve change logs for this Learning Object. Please try again later.`;
         }

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -370,7 +370,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
         if (error.status === 401) {
           // user isn't logged-in, set client's state to logged-out and reload so that the route guards can redirect to login page
           this.auth.logout();
-        } else if (error.status != 404) {
+        } else if (error.status !== 404) {
           errorMessage = `We encountered an error while attempting to
           retrieve change logs for this Learning Object. Please try again later.`;
         }


### PR DESCRIPTION
This PR resolves two bugs on the client outline in the following stories:
https://app.shortcut.com/clarkcan/story/7431/advanced-search-should-display-number-of-filters-applied
https://app.shortcut.com/clarkcan/story/7437/suppress-error-when-viewing-changelogs