### PR TITLE
Swap secinj for intro_to_cyber on homepage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.29.2",
+  "version": "4.29.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.29.2",
+      "version": "4.29.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.29.3",
+  "version": "4.29.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.29.3",
+      "version": "4.29.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.29.2",
+  "version": "4.29.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.29.3",
+  "version": "4.29.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -78,7 +78,7 @@ export class HomeComponent implements OnInit {
       .getCollections()
       .then(collections => {
         this.collections = collections.filter(
-          c => c.abvName === 'nccp' || c.abvName === 'ncyte' || c.abvName === 'secinj'
+          c => c.abvName === 'nccp' || c.abvName === 'ncyte' || c.abvName === 'intro_to_cyber'
         );
       })
       .catch(e => {


### PR DESCRIPTION
This PR swaps the security injections collection link for the intro to cyber collection.
![Screen Shot 2022-02-15 at 3 20 58 PM](https://user-images.githubusercontent.com/43140629/154142688-5fc1421f-8f0c-41a7-b71e-da448c193874.png)
 