### PR TITLE
Fix OpenSSH command in Circle Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ jobs:
       - run:
           name: Install OpenSSH 8.1p1
           command: |
-            sudo apt-get update
+            exec apk update
             mkdir ~/tempdownload; 
             cd ~/tempdownload; 
             wget https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.1p1.tar.gz; 
             tar zxvf openssh-8.1p1.tar.gz; 
-            cd openssh-8.1p1 && ./configure && make && sudo make install
+            cd openssh-8.1p1 && ./configure && make && exec make install
       - setup-aws-cli:
           aws-access-key-id: MACHINE_AWS_CF_AccessKey
           aws-region: AWS_REGION_N_VA


### PR DESCRIPTION
This is a quick PR to update the values in the circleci config from 'sudo' to 'exec' and change 'apt-get' to 'apk'