### PR TITLE
:tada: Send username instead of id

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -185,7 +185,7 @@ export class ChangeStatusModalComponent implements OnInit {
    */
   async createChangelog(): Promise<{}> {
     return this.changelogService.createChangelog(
-      this.builderStore.learningObjectEvent.getValue().author.id,
+      this.builderStore.learningObjectEvent.getValue().author.username,
       this.builderStore.learningObjectEvent.getValue().cuid,
       this.changelog,
     );


### PR DESCRIPTION
This PR fixes an error in the change status component that sends the author id instead of the username to the change log creation route. Closes: https://app.shortcut.com/clarkcan/story/8374/changelog-cannot-find-username-of-userid-for-admins