### PR TITLE
Adjust URL for github actions auto PR

### DIFF
--- a/.github/workflows/branching-strategy-auto-pull-request.yml
+++ b/.github/workflows/branching-strategy-auto-pull-request.yml
@@ -42,7 +42,7 @@ jobs:
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.MACHINE_PAT }}" \
-            https://api.github.com/repos/Cyber4All/${{ github.repository }}/pulls \
+            https://api.github.com/repos/${{ github.repository }}/pulls \
             -d '{"head":"'"$PR_HEAD"'","base":"'"$PR_BASE"'","title":"'"$PR_TITLE"'","body":"'"$PR_BODY"'"}')
 
           echo $CREATE_RES | jq -C


### PR DESCRIPTION
This is a hotfix PR to change the github actions URL to remove a redundant Cyber4All in the url string