### PR TITLE
Fix scroller and auto focus URLs when no files 

### DIFF
--- a/src/app/cube/details/components/materials/materials.component.ts
+++ b/src/app/cube/details/components/materials/materials.component.ts
@@ -53,6 +53,12 @@ export class MaterialsComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     this.emit();
+    // If the learning object doesn't have files or folders scroll to the URLs
+    if(this.materials.files.length === 0 && this.materials.folderDescriptions === undefined) {
+      this.previousSelection = this.currentSelection;
+      this.currentSelection = 'URLs';
+      this.rotateCarousel();
+    }
   }
 
   ngOnChanges(): void {

--- a/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
@@ -9,7 +9,7 @@
   </div>
 
 </div>
-<div (activate)="emitContainerClick($event)" class="flex-wrapper" [ngClass]="{empty: (currentNode$| async)?.isEmpty()}">
+<div (activate)="emitContainerClick($event)" [ngClass]="{'flex-wrapper': canManage, 'empty': (currentNode$| async)?.isEmpty()}">
   <div *ngIf="canManage && (currentNode$| async)?.isEmpty()" class="dropzone-message">
     <i class="fal fa-cloud-upload"></i>
     <div tabindex="0" class="empty-title">No materials here!</div>


### PR DESCRIPTION
This PR auto scrolls to URLs on the details page if there are no files and also fixes the double scrolling issue in the files components. 

Note on the double scroll issue: I was able to fix this problem by using an existing boolean to conditionally set the flex-wrapper class. This component is also used in the builder and requires flex for upload functionality. The details page does not need this so the class can be toggled off. 

Closes:
https://app.shortcut.com/clarkcan/story/8375/indicate-there-is-a-url-for-modules-that-have-no-files-in-materials
https://app.shortcut.com/clarkcan/story/7549/fix-virtual-scroller-on-file-previews-in-the-details-page