### PR TITLE
Build guard for cookies

### DIFF
--- a/src/app/auth/auth.routing.ts
+++ b/src/app/auth/auth.routing.ts
@@ -8,7 +8,7 @@ import { ResetPasswordComponent } from './reset-password/reset-password.componen
 import { CanResetPasswordGuard } from './can-reset-password.guard';
 import { AuthComponent } from './auth.component';
 import { EmailVerifiedComponent } from './email-verified/email-verified.component';
-
+import { CookieGuard } from 'app/core/cookie.guard';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const auth_routes: Routes = [
   {
@@ -17,7 +17,12 @@ const auth_routes: Routes = [
     children: [
       { path: '', redirectTo: 'login', pathMatch: 'full' },
       { path: 'login', component: LoginComponent, data: { title: 'Login' } },
-      { path: 'register', component: RegisterComponent, data: { title: 'Register' } },
+      {
+        path: 'register',
+        component: RegisterComponent,
+        data: { title: 'Register' },
+        canActivate: [CookieGuard],
+      },
       { path: 'forgot-password', component: ForgotPasswordComponent, data: { title: 'Change Password'} },
       {
         path: 'reset-password',

--- a/src/app/core/cookie.guard.ts
+++ b/src/app/core/cookie.guard.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import { CookieAgreementService } from 'app/core/cookie-agreement.service';
+import { ToastrOvenService } from '../shared/modules/toaster/notification.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * Checks if the cookie agreement has been accepted.
+ * Used to block access to the registration page if cookies have not been accepted
+ */
+export class CookieGuard implements CanActivate {
+  constructor(
+    private cookieAgreement: CookieAgreementService,
+    private toaster: ToastrOvenService
+  ) { }
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    const cookie = this.cookieAgreement.getCookieAgreementVal();
+    if(cookie) {
+      return true;
+    } else {
+      this.toaster.error('Cookies not accepted', 'Please accept our cookies to continue registration');
+      return false;
+    }
+  }
+}

--- a/src/app/core/cookie.guard.ts
+++ b/src/app/core/cookie.guard.ts
@@ -21,11 +21,10 @@ export class CookieGuard implements CanActivate {
     route: ActivatedRouteSnapshot,
     state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
     const cookie = this.cookieAgreement.getCookieAgreementVal();
-    if(cookie) {
-      return true;
-    } else {
+    if(!cookie) {
       this.toaster.error('Cookies not accepted', 'Please accept our cookies to continue registration');
       return false;
     }
+    return true;
   }
 }


### PR DESCRIPTION
This PR adds a guard that will check if the cookie agreement has been accepted. If it is the user will be able to continue to registration if they have not a toaster error will throw notifying them why they can not continue.
<img width="1010" alt="Screen Shot 2022-04-07 at 10 43 03 AM" src="https://user-images.githubusercontent.com/43140629/162225855-9c9cdf37-c37a-4cf9-98d3-fdbeeb56e477.png">
<img width="925" alt="Screen Shot 2022-04-07 at 10 43 21 AM" src="https://user-images.githubusercontent.com/43140629/162225913-20c640dd-d643-47e3-8eb6-06d5daace99f.png">

Closes: https://app.shortcut.com/clarkcan/story/8383/prevent-user-registration-if-cookies-have-not-been-accepted 