### PR TITLE
Added message for empty notes section for a learning object

### DIFF
--- a/src/app/cube/details/components/materials/components/notes/notes.component.html
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.html
@@ -1,3 +1,3 @@
 <section class='notes'>
-  <p tab-index='0' >{{ notes ? notes: 'This Learning Object does not have any notes' }}
+  <p tab-index='0' [innerHtml]="notes">{{ notes }}</p>
 </section>

--- a/src/app/cube/details/components/materials/components/notes/notes.component.html
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.html
@@ -1,3 +1,3 @@
 <section class='notes'>
-  <p tab-index='0' [innerHtml]="notes">{{ notes ? notes: 'This Learning Object does not have any notes' }}</p>
+  <p tab-index='0' [innerHtml]="notes">{{ notes }}</p>
 </section>

--- a/src/app/cube/details/components/materials/components/notes/notes.component.html
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.html
@@ -1,3 +1,3 @@
 <section class='notes'>
-  <p tab-index='0' [innerHtml]="notes">{{ notes }}</p>
+  <p tab-index='0' >{{ notes ? notes: 'This Learning Object does not have any notes' }}
 </section>

--- a/src/app/cube/details/components/materials/components/notes/notes.component.ts
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.ts
@@ -11,5 +11,9 @@ export class NotesComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() { }
+  ngOnInit() {
+    if (!this.notes) {
+      this.notes = 'This Learning Object does not have any notes';
+    }
+  }
 }

--- a/src/app/cube/details/components/materials/components/notes/notes.component.ts
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.ts
@@ -12,6 +12,8 @@ export class NotesComponent implements OnInit {
   constructor() { }
 
   ngOnInit() {
+    if (!this.notes) {
+      this.notes = 'This Learning Object does not have any notes';
+    }
   }
-
 }

--- a/src/app/cube/details/components/materials/components/notes/notes.component.ts
+++ b/src/app/cube/details/components/materials/components/notes/notes.component.ts
@@ -11,9 +11,5 @@ export class NotesComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
-    if (!this.notes) {
-      this.notes = 'This Learning Object does not have any notes';
-    }
-  }
+  ngOnInit() { }
 }


### PR DESCRIPTION
Replaces an empty box with a message denoting that a learning object does not have any notes if none exist
<img width="974" alt="Screen Shot 2022-06-13 at 9 20 51 AM" src="https://user-images.githubusercontent.com/43356775/173363037-d142a6ee-6b31-4541-b6c3-a55f28737544.png">
.