### PR TITLE
Implement mission section for Homepage Redesign

### DIFF
--- a/src/app/cube/new-home/mission/mission.component.html
+++ b/src/app/cube/new-home/mission/mission.component.html
@@ -9,7 +9,7 @@
         </p>
         <p>
             CLARK fulfills a demonstrated need for a high-quality and
-            high-availability repositor for curricular resources for 
+            high-availability repository for curricular resources for 
             the cybersecurity education community. It provides cybersecurity
             educators with the building blocks to train the next wave
             of researchers and better prepare the cybersecurity workforce.
@@ -24,9 +24,10 @@
             </span>
             <h2>Easy In / Easy Out</h2>
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-                Cursus euismod quis viverra nibh cras pulvinar.
+                Register today with a valid email address and you’re all set! 
+                You can easily build your curriculum and develop learning outcomes using Bloom’s Taxonomy. 
+                All curriculum released on CLARK is free and can be easily found and 
+                downloaded through the browse page.
             </p>
         </div>
         
@@ -37,9 +38,10 @@
             </span>
             <h2>Quality Curriculum</h2>
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-                Cursus euismod quis viverra nibh cras pulvinar.
+                All curricula undergo a review process determined by the collection each one is submitted to. 
+                Each collection has active curators reviewing and releasing learning objects checking for 
+                not only the relevance of the topic to cyber education, but also for grammar and spelling, 
+                accessibility, and the overall format of your curriculum.
             </p>
         </div>
         
@@ -50,9 +52,17 @@
             </span>
             <h2>Relevant</h2>
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-                Cursus euismod quis viverra nibh cras pulvinar.
+                All learning objects undergo a relevancy review on CLARK. 
+                This ensures that the curriculum stays not only relevant to the cyber community, 
+                but also keeps the curriculum updated with modern examples and solutions to uphold the integrity 
+                of these free resources so that they can always be used as “off-the-shelf” lessons in the classroom. 
+                To learn more about our relevancy review process, check out our 
+                <a 
+                href="https://securedteam.notion.site/securedteam/Curriculum-Relevancy-on-CLARK-324ca3b482644068affe46c1ccbd28ff" 
+                target="_blank"
+                >
+                blog.
+                </a>
             </p>
         </div>
         

--- a/src/app/cube/new-home/mission/mission.component.html
+++ b/src/app/cube/new-home/mission/mission.component.html
@@ -1,35 +1,60 @@
-<h1>Securing the nation through education</h1>
-<p>
-    CLARK, the Cybersecurity Labs and Resource Knowledge-base,
-    is a platform for building and sharing free cybersecurity
-    curricula. It includes a model for building cirriculum, the
-    digital library system, and distinct curriculum collections.
-</p>
-<p>
-    CLARK fulfills a demonstrated need for a high-quality and
-    high-availability repositor for curricular resources for 
-    the cybersecurity education community. It provides cybersecurity
-    educators with the building blocks to train the next wave
-    of researchers and better prepare the cybersecurity workforce.
-</p>
-
-<h2>Easy In / Easy Out</h2>
-<p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-    Cursus euismod quis viverra nibh cras pulvinar.
-</p>
-
-<h2>Quality Curriculum</h2>
-<p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-    Cursus euismod quis viverra nibh cras pulvinar.
-</p>
-
-<h2>Relevant</h2>
-<p>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
-    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
-    Cursus euismod quis viverra nibh cras pulvinar.
-</p>
+<div class="wrapper">
+    <div class="first">
+        <h1>Securing the nation through education</h1>
+        <p>
+            CLARK, the Cybersecurity Labs and Resource Knowledge-base,
+            is a platform for building and sharing free cybersecurity
+            curricula. It includes a model for building cirriculum, the
+            digital library system, and distinct curriculum collections.
+        </p>
+        <p>
+            CLARK fulfills a demonstrated need for a high-quality and
+            high-availability repositor for curricular resources for 
+            the cybersecurity education community. It provides cybersecurity
+            educators with the building blocks to train the next wave
+            of researchers and better prepare the cybersecurity workforce.
+        </p>
+    </div>
+    
+    <div class="second">
+        <div class="second-element">
+            <span class="fa-stack fa-2x">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="far fa-cloud fa-stack-1x"></i>
+            </span>
+            <h2>Easy In / Easy Out</h2>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                Cursus euismod quis viverra nibh cras pulvinar.
+            </p>
+        </div>
+        
+        <div class="second-element">
+            <span class="fa-stack fa-2x">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="far fa-star fa-stack-1x"></i>
+            </span>
+            <h2>Quality Curriculum</h2>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                Cursus euismod quis viverra nibh cras pulvinar.
+            </p>
+        </div>
+        
+        <div class="second-element">
+            <span class="fa-stack fa-2x">
+                <i class="fas fa-circle fa-stack-2x"></i>
+                <i class="far fa-history fa-stack-1x"></i>                
+            </span>
+            <h2>Relevant</h2>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+                Cursus euismod quis viverra nibh cras pulvinar.
+            </p>
+        </div>
+        
+    </div>    
+</div>

--- a/src/app/cube/new-home/mission/mission.component.html
+++ b/src/app/cube/new-home/mission/mission.component.html
@@ -1,1 +1,35 @@
-<p>mission works!</p>
+<h1>Securing the nation through education</h1>
+<p>
+    CLARK, the Cybersecurity Labs and Resource Knowledge-base,
+    is a platform for building and sharing free cybersecurity
+    curricula. It includes a model for building cirriculum, the
+    digital library system, and distinct curriculum collections.
+</p>
+<p>
+    CLARK fulfills a demonstrated need for a high-quality and
+    high-availability repositor for curricular resources for 
+    the cybersecurity education community. It provides cybersecurity
+    educators with the building blocks to train the next wave
+    of researchers and better prepare the cybersecurity workforce.
+</p>
+
+<h2>Easy In / Easy Out</h2>
+<p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    Cursus euismod quis viverra nibh cras pulvinar.
+</p>
+
+<h2>Quality Curriculum</h2>
+<p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    Cursus euismod quis viverra nibh cras pulvinar.
+</p>
+
+<h2>Relevant</h2>
+<p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    Cursus euismod quis viverra nibh cras pulvinar.
+</p>

--- a/src/app/cube/new-home/mission/mission.component.html
+++ b/src/app/cube/new-home/mission/mission.component.html
@@ -17,7 +17,7 @@
     </div>
     
     <div class="second">
-        <div class="second-element">
+        <div class="clark-quality">
             <span class="fa-stack fa-2x">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="far fa-cloud fa-stack-1x"></i>
@@ -30,7 +30,7 @@
             </p>
         </div>
         
-        <div class="second-element">
+        <div class="clark-quality">
             <span class="fa-stack fa-2x">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="far fa-star fa-stack-1x"></i>
@@ -43,7 +43,7 @@
             </p>
         </div>
         
-        <div class="second-element">
+        <div class="clark-quality">
             <span class="fa-stack fa-2x">
                 <i class="fas fa-circle fa-stack-2x"></i>
                 <i class="far fa-history fa-stack-1x"></i>                

--- a/src/app/cube/new-home/mission/mission.component.scss
+++ b/src/app/cube/new-home/mission/mission.component.scss
@@ -44,7 +44,7 @@ p {
     font-size: 18px;
 }
 
-@media screen and (max-width: 425px) {
+@media screen and (max-width: 768px) {
     .wrapper{
         padding: 10px 30px;
         .first {

--- a/src/app/cube/new-home/mission/mission.component.scss
+++ b/src/app/cube/new-home/mission/mission.component.scss
@@ -41,7 +41,7 @@
 
 p {
     font-weight: 400;
-    font-size: 20px;
+    font-size: 18px;
 }
 
 @media screen and (max-width: 425px) {

--- a/src/app/cube/new-home/mission/mission.component.scss
+++ b/src/app/cube/new-home/mission/mission.component.scss
@@ -1,0 +1,45 @@
+@import 'vars.scss';
+
+.wrapper {
+    display: flex;
+    flex-direction: column;
+    padding: 10px 60px;
+
+    .first {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        padding: 0px 60px 60px;
+    }
+
+    .second {
+        display: flex;
+        flex-direction: row;
+
+        .second-element {
+            margin-right: 50px;
+
+            h2 {
+                margin: 10px 0 auto;
+            }
+            span {
+                position: relative;
+                left: -10px;
+                .fa-stack-2x {
+                    color: rgba(96, 154, 230, 0.237);
+                }
+    
+                .fa-stack-1x {
+                    color: $light-blue;
+                }
+            }
+            
+        }
+    }
+}
+
+p {
+    font-weight: 400;
+    font-size: 20px;
+}

--- a/src/app/cube/new-home/mission/mission.component.scss
+++ b/src/app/cube/new-home/mission/mission.component.scss
@@ -43,3 +43,26 @@ p {
     font-weight: 400;
     font-size: 20px;
 }
+
+@media screen and (max-width: 425px) {
+    .wrapper{
+        padding: 10px 30px;
+        .first {
+            padding: 0px 0px 60px;
+        }
+        .second {
+            display: flex;
+            flex-direction: column;
+
+            .second-element {
+                margin: 0px 0px 60px;
+                text-align: center;
+
+                span {
+                    left: 0px;
+                }
+            }
+        }
+    }
+    
+}

--- a/src/app/cube/new-home/mission/mission.component.scss
+++ b/src/app/cube/new-home/mission/mission.component.scss
@@ -17,7 +17,7 @@
         display: flex;
         flex-direction: row;
 
-        .second-element {
+        .clark-quality {
             margin-right: 50px;
 
             h2 {
@@ -54,7 +54,7 @@ p {
             display: flex;
             flex-direction: column;
 
-            .second-element {
+            .clark-quality {
                 margin: 0px 0px 60px;
                 text-align: center;
 


### PR DESCRIPTION
Partially completes [12302](https://app.shortcut.com/clarkcan/story/12302/implement-hero-splash-and-mission-sections).

In this PR:
- Adds mobile and desktop views for the mission section.

## Screenshots

Desktop View
<img width="1440" alt="Screen Shot 2022-07-27 at 10 20 06 AM" src="https://user-images.githubusercontent.com/93054689/181271038-c369f763-7911-47b8-ba98-f38f9e7cc76a.png">

Mobile View
![mission mobile gif](https://user-images.githubusercontent.com/93054689/181272419-81b75477-e116-4cc2-998d-beb243885067.gif)
