### PR TITLE
Disable the Blog Banner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.29.26",
+  "version": "4.29.27",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.29.26",
+      "version": "4.29.27",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.29.26",
+  "version": "4.29.27",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/clark.component.html
+++ b/src/app/clark.component.html
@@ -6,12 +6,6 @@
 
 <ng-template #clarkBodyTemplate>
   <clark-navbar *ngIf = "isSupportedBrowser"></clark-navbar>
-  <clark-blogs
-    [@blog]
-    *ngIf="displayBlogsBanner()"
-    (showBlogsBanner)="showBlogsBanner($event)"
-    (neverShowBanner)="neverShowBanner($event)"
-  ></clark-blogs>
   <router-outlet></router-outlet>
   <clark-popup *ngIf="isOldVersion" (closed)="isOldVersion = false">
     <div #popupInner class="popup-inner">

--- a/src/app/clark.component.scss
+++ b/src/app/clark.component.scss
@@ -6,13 +6,6 @@ clark-cookies {
     right: 0;
 }
 
-clark-blogs {
-    position: absolute;
-    background-color: rgb(255, 255, 255, 0.7);
-    width: 100%;
-    z-index: 3;
-}
-
 .modal-container {
     height: 475px;
     width: 560px;

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -14,8 +14,7 @@ import { ToastrOvenService } from './shared/modules/toaster/notification.service
 import { CookieAgreementService } from './core/cookie-agreement.service';
 import { SubscriptionAgreementService } from './core/subscription-agreement.service';
 import { NavbarService } from './core/navbar.service';
-import { BlogsComponentService } from './core/blogs-component.service';
-import { Blog } from './components/blogs/types/blog';
+
 @Component({
   selector: 'clark-root',
   templateUrl: './clark.component.html',
@@ -47,16 +46,6 @@ import { Blog } from './components/blogs/types/blog';
             opacity: 0
           })
         )
-      ])
-    ]),
-    trigger('blog', [
-      transition(':enter', [
-        style({ transform: 'translateY(-100%)' }),
-        animate('300ms 1500ms ease-out', style({ transform: 'translateY(0%)' }))
-      ]),
-      transition(':leave', [
-        style({ zIndex: 3 }),
-        animate('300ms ease-out', style({ transform: 'translate3d(0, -100%, 1px)', zIndex: 3 }))
       ])
     ])
   ]
@@ -93,8 +82,7 @@ export class ClarkComponent implements OnInit {
     private toaster: ToastrOvenService,
     private view: ViewContainerRef,
     private cookieAgreement: CookieAgreementService,
-    private subscriptionAgreement: SubscriptionAgreementService,
-    private blogsComponentService: BlogsComponentService
+    private subscriptionAgreement: SubscriptionAgreementService
   ) {
     this.isUnderMaintenance = false;
 
@@ -150,33 +138,7 @@ export class ClarkComponent implements OnInit {
     location.reload();
   }
 
-  /**
-   * Catches the output emitted by clark-blogs to dismiss the banner
-   *
-   * @param val The value of showBanner
-   */
-  showBlogsBanner(val: boolean) {
-    this.blogsComponentService.setShowBanner(val);
-  }
 
-  /**
-   * Catches the checkbox output emitted by clark-blogs to never see the banner again
-   *
-   * @param args: val - the value of the checkbox
-   *              recentBlog - the blog that was dismissed
-   */
-  neverShowBanner(args: {val: boolean, recentBlog?: Blog}) {
-    this.blogsComponentService.setNeverShowBanner(args);
-  }
-
-  /**
-   * Determines if the blogs banner is to be shown
-   *
-   * @returns a value determining if the blogs banner is shown
-   */
-  displayBlogsBanner() {
-    return this.blogsComponentService.getShowBanner() && !this.blogsComponentService.getNeverShowBanner();
-  }
 
   /**
    * Function passes cookie agreement service val to create new agreement

--- a/src/app/clark.module.ts
+++ b/src/app/clark.module.ts
@@ -21,7 +21,6 @@ import { MaintenancePageComponent } from './maintenance-page/maintenance-page.co
 import { UnauthorizedComponent } from './unauthorized.component';
 import { FormsModule } from '@angular/forms';
 import { SubscriptionComponent } from './components/subscription/subscription.component';
-import { BlogsComponent } from './components/blogs/blogs.component';
 @NgModule({
   imports: [
     BrowserModule,
@@ -42,8 +41,7 @@ import { BlogsComponent } from './components/blogs/blogs.component';
     SearchComponent,
     MaintenancePageComponent,
     UnauthorizedComponent,
-    SubscriptionComponent,
-    BlogsComponent
+    SubscriptionComponent
   ],
   bootstrap: [ClarkComponent],
   providers: [TitleCasePipe, Title, { provide: UrlSerializer, useClass: CustomUrlSerializer }]

--- a/src/app/core/blogs-component.service.ts
+++ b/src/app/core/blogs-component.service.ts
@@ -7,7 +7,7 @@ import { BlogsService } from './blogs.service';
 })
 export class BlogsComponentService {
   neverShowBanner = false; // true if the user doesn't want to see the blog again
-  showBanner = true; // true if blog is displayed
+  showBanner = true; // true if blog is displayed. NOTE: hardcode this to false to disable blog banners
 
   recentBlog: Blog; // holds the latest blogpost
 
@@ -25,6 +25,10 @@ export class BlogsComponentService {
    * @returns the showBanner boolean
    */
   getShowBanner(): boolean {
+    const recentBlogDateTime = new Date(this.recentBlog.timestamp);
+    if(Date.now() - recentBlogDateTime.valueOf() > 604800000) { // if the most recent blog is older than 1 week
+      return false;
+    }
     return this.showBanner;
   }
 

--- a/src/app/core/blogs-component.service.ts
+++ b/src/app/core/blogs-component.service.ts
@@ -7,7 +7,7 @@ import { BlogsService } from './blogs.service';
 })
 export class BlogsComponentService {
   neverShowBanner = false; // true if the user doesn't want to see the blog again
-  showBanner = true; // true if blog is displayed. NOTE: hardcode this to false to disable blog banners
+  showBanner = false; // true if blog is displayed. NOTE: hardcode this to false to disable blog banners
 
   recentBlog: Blog; // holds the latest blogpost
 
@@ -26,7 +26,7 @@ export class BlogsComponentService {
    */
   getShowBanner(): boolean {
     const recentBlogDateTime = new Date(this.recentBlog.timestamp);
-    if(Date.now() - recentBlogDateTime.valueOf() > 604800000) { // if the most recent blog is older than 1 week
+    if(Date.now() - recentBlogDateTime.valueOf() > 604800000) { // if the most recent blog is older than 1 week, do not display a banner
       return false;
     }
     return this.showBanner;

--- a/src/app/cube/home/home.component.html
+++ b/src/app/cube/home/home.component.html
@@ -1,4 +1,10 @@
 <main aria-label="CLARK Homepage" id="pageContent" tabindex="-1">
+  <clark-blogs
+    [@blog]
+    *ngIf="displayBlogsBanner()"
+    (showBlogsBanner)="showBlogsBanner($event)"
+    (neverShowBanner)="neverShowBanner($event)"
+  ></clark-blogs>
   <section class="top">
     <clark-homepage-splash [placeholderText]="placeholderText" (search)="search($event)"></clark-homepage-splash>
   </section>

--- a/src/app/cube/home/home.component.scss
+++ b/src/app/cube/home/home.component.scss
@@ -1,6 +1,13 @@
 @import 'vars.scss';
 @import './home';
 
+clark-blogs {
+  position: absolute;
+  background-color: rgb(255, 255, 255, 0.7);
+  width: 100%;
+  z-index: 5;
+}
+
 :host {
   background: white;
   display: block;

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -7,11 +7,26 @@ import { COPY } from './home.copy';
 import { CollectionService, Collection } from '../../core/collection.service';
 import { UsageStats } from '../shared/types/usage-stats';
 import { UsageStatsService } from '../core/usage-stats/usage-stats.service';
+import { BlogsComponentService } from 'app/core/blogs-component.service';
+import { Blog } from 'app/components/blogs/types/blog';
+import { animate, style, transition, trigger } from '@angular/animations';
 
 @Component({
   selector: 'cube-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
+  animations: [
+    trigger('blog', [
+      transition(':enter', [
+        style({ transform: 'translateY(-100%)' }),
+        animate('300ms 1200ms ease-out', style({ transform: 'translateY(0%)' }))
+      ]),
+      transition(':leave', [
+        style({ zIndex: 3 }),
+        animate('300ms ease-out', style({ transform: 'translate3d(0, -100%, 1px)', zIndex: 3 }))
+      ])
+    ])
+  ]
 })
 export class HomeComponent implements OnInit {
   copy = COPY;
@@ -56,7 +71,8 @@ export class HomeComponent implements OnInit {
     public learningObjectService: LearningObjectService,
     private router: Router,
     private collectionService: CollectionService,
-    private statsService: UsageStatsService
+    private statsService: UsageStatsService,
+    private blogsComponentService: BlogsComponentService
   ) {}
 
   ngOnInit() {
@@ -105,5 +121,33 @@ export class HomeComponent implements OnInit {
   donateToClark() {
     this.router.navigate(['donate'], {
     });
+  }
+
+  /**
+   * Catches the output emitted by clark-blogs to dismiss the banner
+   *
+   * @param val The value of showBanner
+   */
+      showBlogsBanner(val: boolean) {
+      this.blogsComponentService.setShowBanner(val);
+    }
+
+  /**
+   * Catches the checkbox output emitted by clark-blogs to never see the banner again
+   *
+   * @param args: val - the value of the checkbox
+   *              recentBlog - the blog that was dismissed
+   */
+  neverShowBanner(args: {val: boolean, recentBlog?: Blog}) {
+    this.blogsComponentService.setNeverShowBanner(args);
+  }
+
+  /**
+   * Determines if the blogs banner is to be shown
+   *
+   * @returns a value determining if the blogs banner is shown
+   */
+  displayBlogsBanner() {
+    return this.blogsComponentService.getShowBanner() && !this.blogsComponentService.getNeverShowBanner();
   }
 }

--- a/src/app/cube/home/home.component.ts
+++ b/src/app/cube/home/home.component.ts
@@ -128,9 +128,9 @@ export class HomeComponent implements OnInit {
    *
    * @param val The value of showBanner
    */
-      showBlogsBanner(val: boolean) {
-      this.blogsComponentService.setShowBanner(val);
-    }
+  showBlogsBanner(val: boolean) {
+    this.blogsComponentService.setShowBanner(val);
+  }
 
   /**
    * Catches the checkbox output emitted by clark-blogs to never see the banner again

--- a/src/app/cube/home/home.module.ts
+++ b/src/app/cube/home/home.module.ts
@@ -12,6 +12,7 @@ import { UsageComponent } from './components/usage/usage.component';
 import { CollectionsComponent } from './components/collections/collections.component';
 import { WhatClarkComponent } from './components/what-clark/what-clark.component';
 import { FeaturedCollectionCardComponent } from './components/featured-collection-card/featured-collection-card.component';
+import { BlogsComponent } from 'app/components/blogs/blogs.component';
 
 @NgModule({
   imports: [
@@ -34,6 +35,7 @@ import { FeaturedCollectionCardComponent } from './components/featured-collectio
     CollectionsComponent,
     WhatClarkComponent,
     FeaturedCollectionCardComponent,
+    BlogsComponent
   ],
   providers: []
 })


### PR DESCRIPTION
Completes story [12496](https://app.shortcut.com/clarkcan/story/12496/disable-the-blog-banner).

In this PR:
- If the most recent blog is older than a week, the banner will not display.
- Relocates the blog banner to only be displayed in the homepage.
- Hardcodes the blog banner such that it is disabled. This means that to re-enable the blog banner you must set `showBanner` to `true` and deploy it.