### PR TITLE
Toggling Files to be Included in a Bundle

### DIFF
--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -156,7 +156,7 @@ export class LearningObjectsComponent
         relativeTo: this.route,
         replaceUrl: true
       }
-    )
+    );
   }
 
   /**

--- a/src/app/core/learning-object.service.ts
+++ b/src/app/core/learning-object.service.ts
@@ -123,6 +123,15 @@ export class LearningObjectService {
     );
   }
 
+  toggleFilesToBundle(username: string, learningObjectID: string, selected: string[], deselected: string[]) {
+    return this.http.patch(
+      USER_ROUTES.TOGGLE_FILES_TO_BUNDLE({ username, learningObjectID }),
+      {
+        selected: selected,
+        deselected: deselected,
+      }
+    );
+  }
   /**
    * Returns the route that needs to be hit in order to load Learning Object based on the params passed in
    *

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -45,15 +45,15 @@ export class LearningObjectService {
    *
    * @param username The currently logged in user
    * @param learningObjectID The current learning object's ID
-   * @param selected Files where the packageable property must be toggled on
-   * @param deselected Files where the packageable property must be toggled off
+   * @param fileIDs An array of file IDs that need to be updated
+   * @param state The new packageable property to update to
    * @returns A promise
    */
   toggleBundle(
     username: string,
     learningObjectID: string,
-    selected?: string[],
-    deselected?: string[]
+    fileIDs: string[],
+    state: boolean
   ) {
     const route = ADMIN_ROUTES.TOGGLE_BUNDLE(username, learningObjectID);
 
@@ -61,8 +61,8 @@ export class LearningObjectService {
       .patch(
         route,
         {
-          selected: selected,
-          deselected: deselected
+          fileIDs: fileIDs,
+          state: state
         },
         { headers: this.headers, withCredentials: true }
       )

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -40,6 +40,30 @@ export class LearningObjectService {
     }
   }
 
+  toggleBundle(
+    username: string,
+    learningObjectID: string,
+    selected?: string[],
+    deselected?: string[]
+  ) {
+    const route = ADMIN_ROUTES.TOGGLE_BUNDLE(username, learningObjectID);
+
+    return this.http
+      .patch(
+        route,
+        {
+          selected: selected,
+          deselected: deselected
+        },
+        { headers: this.headers, withCredentials: true }
+      )
+      .pipe(
+        retry(3),
+        catchError(this.handleError)
+      )
+      .toPromise();
+  }
+
   /**
    * Sends serialized Learning Object to API for creation
    * Returns new Learningbject's ID on success

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -40,6 +40,15 @@ export class LearningObjectService {
     }
   }
 
+  /**
+   * Calls LO service to update the packageable status of toggled files
+   *
+   * @param username The currently logged in user
+   * @param learningObjectID The current learning object's ID
+   * @param selected Files where the packageable property must be toggled on
+   * @param deselected Files where the packageable property must be toggled off
+   * @returns A promise
+   */
   toggleBundle(
     username: string,
     learningObjectID: string,

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -412,7 +412,14 @@ export class BuilderStore {
     }
   }
 
-  getAllFolderFileIDs(folder: DirectoryNode) {
+  /**
+   * Grabs all file IDs of the root folder.
+   * Helper function for toggleBundle
+   *
+   * @param folder the current folder to grab fileIDs
+   * @returns all of the subFile IDs of the root folder
+   */
+  private getAllFolderFileIDs(folder: DirectoryNode) {
     const fileIDs = [];
 
     // add folder's files to fileIDs list
@@ -429,6 +436,12 @@ export class BuilderStore {
     return fileIDs;
   }
 
+  /**
+   * Calls toggleBundle in LO service to save packageable property
+   *
+   * @param event - state: the new packageable property
+   *              - item: the file/folder to save
+   */
   async toggleBundle(event: {
     state: boolean,
     item: any

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -412,6 +412,23 @@ export class BuilderStore {
     }
   }
 
+  getAllFolderFileIDs(folder: DirectoryNode) {
+    const fileIDs = [];
+
+    // add folder's files to fileIDs list
+    folder.getFiles().forEach(file => {
+      fileIDs.push(file.id);
+    });
+
+    // recursively check subfolders for files and do the same thing
+    folder.getFolders().forEach(subFolder => {
+      fileIDs.concat(this.getAllFolderFileIDs(subFolder));
+    });
+
+    // return fileIDs
+    return fileIDs;
+  }
+
   async toggleBundle(event: {
     state: boolean,
     item: any
@@ -419,25 +436,37 @@ export class BuilderStore {
     console.log('We made it!', event.state, event.item);
 
     if(event.item instanceof DirectoryNode) {
-      console.log('this is a folder');
-    } else { // event.item is a File
+      const fileIDs = this.getAllFolderFileIDs(event.item);
       if(event.state) {
-        const selected = [event.item.id];
-        console.log('selected', selected);
         await this.learningObjectService.toggleBundle(
           this.auth.username,
           this.learningObject.id,
-          selected,
+          fileIDs,
           []
         );
       } else {
-        const deselected = [event.item.id];
-        console.log('deselected', deselected);
         await this.learningObjectService.toggleBundle(
           this.auth.username,
           this.learningObject.id,
           [],
-          deselected
+          fileIDs
+        );
+      }
+    } else { // event.item is a File
+      const fileID = [event.item.id];
+      if(event.state) {
+        await this.learningObjectService.toggleBundle(
+          this.auth.username,
+          this.learningObject.id,
+          fileID,
+          []
+        );
+      } else {
+        await this.learningObjectService.toggleBundle(
+          this.auth.username,
+          this.learningObject.id,
+          [],
+          fileID
         );
       }
     }

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -446,7 +446,6 @@ export class BuilderStore {
     state: boolean,
     item: any
   }) {
-    console.log('We did it!', event.item);
     if(event.item instanceof DirectoryNode) { // event.item is a Folder
       const fileIDs = this.getAllFolderFileIDs(event.item);
       await this.learningObjectService.toggleBundle(

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -429,7 +429,7 @@ export class BuilderStore {
 
     // recursively check subfolders for files and do the same thing
     folder.getFolders().forEach(subFolder => {
-      fileIDs.concat(this.getAllFolderFileIDs(subFolder));
+      fileIDs.push(...this.getAllFolderFileIDs(subFolder));
     });
 
     // return fileIDs
@@ -446,8 +446,6 @@ export class BuilderStore {
     state: boolean,
     item: any
   }) {
-    console.log('We made it!', event.state, event.item);
-
     if(event.item instanceof DirectoryNode) {
       const fileIDs = this.getAllFolderFileIDs(event.item);
       if(event.state) {

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -414,9 +414,33 @@ export class BuilderStore {
 
   async toggleBundle(event: {
     state: boolean,
-    item: DirectoryNode | LearningObject.Material.File
+    item: any
   }) {
     console.log('We made it!', event.state, event.item);
+
+    if(event.item instanceof DirectoryNode) {
+      console.log('this is a folder');
+    } else { // event.item is a File
+      if(event.state) {
+        const selected = [event.item.id];
+        console.log('selected', selected);
+        await this.learningObjectService.toggleBundle(
+          this.auth.username,
+          this.learningObject.id,
+          selected,
+          []
+        );
+      } else {
+        const deselected = [event.item.id];
+        console.log('deselected', deselected);
+        await this.learningObjectService.toggleBundle(
+          this.auth.username,
+          this.learningObject.id,
+          [],
+          deselected
+        );
+      }
+    }
   }
   /**
    *

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -17,6 +17,7 @@ import { FileUploadMeta } from './components/content-upload/app/services/typings
 import { Title } from '@angular/platform-browser';
 import { UriRetrieverService } from 'app/core/uri-retriever.service';
 import { v4 as uuidv4 } from 'uuid';
+import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 
 /**
  * Defines a list of actions the builder can take
@@ -44,6 +45,7 @@ export enum BUILDER_ACTIONS {
   UPDATE_FOLDER_DESCRIPTION,
   DELETE_FILES,
   CHANGE_STATUS,
+  TOGGLE_BUNDLE
 }
 
 export enum BUILDER_ERRORS {
@@ -402,12 +404,20 @@ export class BuilderStore {
         return await this.removeFiles(data.fileIds);
       case BUILDER_ACTIONS.CHANGE_STATUS:
         return await this.changeStatus(data.status, data.reason);
+      case BUILDER_ACTIONS.TOGGLE_BUNDLE:
+        return await this.toggleBundle(data);
       default:
         console.error('Error! Invalid action taken!');
         return;
     }
   }
 
+  async toggleBundle(event: {
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  }) {
+    console.log('We made it!', event.state, event.item);
+  }
   /**
    *
    *

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -446,40 +446,23 @@ export class BuilderStore {
     state: boolean,
     item: any
   }) {
-    if(event.item instanceof DirectoryNode) {
+    console.log('We did it!', event.item);
+    if(event.item instanceof DirectoryNode) { // event.item is a Folder
       const fileIDs = this.getAllFolderFileIDs(event.item);
-      if(event.state) {
-        await this.learningObjectService.toggleBundle(
-          this.auth.username,
-          this.learningObject.id,
-          fileIDs,
-          []
-        );
-      } else {
-        await this.learningObjectService.toggleBundle(
-          this.auth.username,
-          this.learningObject.id,
-          [],
-          fileIDs
-        );
-      }
+      await this.learningObjectService.toggleBundle(
+        this.auth.username,
+        this.learningObject.id,
+        fileIDs,
+        event.state
+      );
     } else { // event.item is a File
       const fileID = [event.item.id];
-      if(event.state) {
-        await this.learningObjectService.toggleBundle(
-          this.auth.username,
-          this.learningObject.id,
-          fileID,
-          []
-        );
-      } else {
-        await this.learningObjectService.toggleBundle(
-          this.auth.username,
-          this.learningObject.id,
-          [],
-          fileID
-        );
-      }
+      await this.learningObjectService.toggleBundle(
+        this.auth.username,
+        this.learningObject.id,
+        fileID,
+        event.state
+      );
     }
   }
   /**

--- a/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.html
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.html
@@ -1,5 +1,14 @@
-<clark-file-browser [currentNode$]="currentNode$" [filesystem$]="directoryTree$" [folderMeta$]="folderMeta$" (meatballClick)="openFileOptions($event)" (newOptionsClick)="openNewOptions($event)" (path)="emitPath($event)" (descriptionUpdated)="saveDescription($event.description, $event.file)"
-  canManage="true"></clark-file-browser>
+<clark-file-browser 
+  [currentNode$]="currentNode$" 
+  [filesystem$]="directoryTree$" 
+  [folderMeta$]="folderMeta$" 
+  (meatballClick)="openFileOptions($event)" 
+  (newOptionsClick)="openNewOptions($event)" 
+  (path)="emitPath($event)" 
+  (descriptionUpdated)="saveDescription($event.description, $event.file)"
+  canManage="true"
+  (packageableToggled)="packageableToggled.emit($event)"
+  ></clark-file-browser>
 
 <clark-context-menu *ngIf="showNewOptions" [anchor]="menuAnchor" (close)="closeContextMenu()">
   <ul #contextMenu>

--- a/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
@@ -44,6 +44,11 @@ export class FileManagerComponent implements OnInit, OnDestroy {
   openFilePicker: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output()
   path: EventEmitter<string> = new EventEmitter<string>();
+  @Output()
+  packageableToggled: EventEmitter <{
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  }> = new EventEmitter();
 
   @Output()
   downloadClicked: EventEmitter<

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.html
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.html
@@ -41,6 +41,7 @@
           (path)="openPath = $event"
           (solutionUpload)="handleSolution($event)"
           (downloadClicked)="handleFileDownload($event)"
+          (packageableToggled)="packageableToggled.emit($event)"
         ></onion-file-manager>
       </div>
       <div [@fadeIn] *ngIf="slide === 2" class="slide slide2">

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -32,6 +32,7 @@ import { UPLOAD_ERRORS } from './errors';
 import { AuthService } from 'app/core/auth.service';
 import { getUserAgentBrowser } from 'getUserAgentBrowser';
 import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
+import { HttpErrorResponse } from '@angular/common/http';
 
 export interface FileInput extends File {
   fullPath?: string;
@@ -223,11 +224,13 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
 
     this.error$
       .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((err: Error | string) => {
+      .subscribe((err: Error | string | HttpErrorResponse) => {
         let message: string;
         if (err) {
           if (err instanceof Error) {
             message = err.message;
+          } else if (err instanceof HttpErrorResponse){
+            message = err.error.message;
           } else {
             message = err;
           }

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -31,6 +31,7 @@ import {
 import { UPLOAD_ERRORS } from './errors';
 import { AuthService } from 'app/core/auth.service';
 import { getUserAgentBrowser } from 'getUserAgentBrowser';
+import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 
 export interface FileInput extends File {
   fullPath?: string;
@@ -119,6 +120,11 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   }> = new EventEmitter<{ index: number; description: string }>();
   @Output()
   notesUpdated: EventEmitter<string> = new EventEmitter<string>();
+  @Output()
+  packageableToggled: EventEmitter<{
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  }> = new EventEmitter();
 
   notes$: Subject<string> = new Subject<string>();
 

--- a/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.html
+++ b/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.html
@@ -20,6 +20,7 @@
       (folderDescriptionUpdated)="handleFolderDescriptionUpdate($event)"
       (notesUpdated)="handleNotesUpdate($event)"
       (uploadComplete)="handleUploadComplete($event)"
+      (packageableToggled)="handlePackageableToggled($event)"
     ></app-upload>
     <clark-skip-link title="Go to Materials Tab List" skipLocation="form"></clark-skip-link>
     <clark-skip-link title="Skip to Submit for Review" skipLocation="submit"></clark-skip-link>

--- a/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
+++ b/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
@@ -4,6 +4,7 @@ import { BuilderStore, BUILDER_ACTIONS } from '../../builder-store.service';
 import { takeUntil, filter } from 'rxjs/operators';
 import { Subject, Observable } from 'rxjs';
 import { FileUploadMeta } from '../../components/content-upload/app/services/typings';
+import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 
 @Component({
   selector: 'clark-materials-page',
@@ -114,6 +115,17 @@ export class MaterialsPageComponent implements OnInit, OnDestroy {
   async handleNotesUpdate(notes: string) {
     try {
       await this.store.execute(BUILDER_ACTIONS.UPDATE_MATERIAL_NOTES, notes);
+    } catch (e) {
+      this.error$.next(e);
+    }
+  }
+
+  async handlePackageableToggled(event: {
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  }) {
+    try {
+      await this.store.execute(BUILDER_ACTIONS.TOGGLE_BUNDLE, event);
     } catch (e) {
       this.error$.next(e);
     }

--- a/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
+++ b/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
@@ -120,6 +120,12 @@ export class MaterialsPageComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Executes builder service action to save the file/folder's new packageable property
+   *
+   * @param event - state: the new packageable property
+   *              - item: the file/folder to save
+   */
   async handlePackageableToggled(event: {
     state: boolean,
     item: DirectoryNode | LearningObject.Material.File

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -158,13 +158,13 @@ export class SubmitComponent implements OnInit {
 
     if(!this.isValidLearningObject()) {
       proceed = false;
-      let missingFields = this.buildUnfinishedLOErrorMsg();
+      const missingFields = this.buildUnfinishedLOErrorMsg();
       this.toasterService.error(
         'Incomplete Learning Object!',
         `Please provide the following fields to submit: ${missingFields}.`
       );
     }
-    
+
     if (proceed) {
       this.loading.push(true);
       this.collectionService

--- a/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
@@ -16,8 +16,16 @@
     <button class="button good" id="new-file" (activate)="emitNewOptionClick($event)">Click here to upload</button>
     <span *ngIf="dragAndDropSupported">or drag and drop files and folders here</span>
   </div>
-  <clark-file-list-view *ngIf="!(currentNode$ | async)?.isEmpty()"
-    class="full-width" [node$]="currentNode$" [canManage]="canManage" (emitPath)="openFolder($event)" (emitDesc)="emitDesc($event)" (emitContextOpen)="meatballClick.emit($event)">
+  <clark-file-list-view 
+    *ngIf="!(currentNode$ | async)?.isEmpty()"
+    class="full-width" 
+    [node$]="currentNode$" 
+    [canManage]="canManage" 
+    (emitPath)="openFolder($event)" 
+    (emitDesc)="emitDesc($event)" 
+    (emitContextOpen)="meatballClick.emit($event)"
+    (emitBundle)="packageableToggled.emit($event)"
+    >
   </clark-file-list-view>
 </div>
 <clark-skip-link  *ngIf="canManage && !(currentNode$ | async)?.isEmpty()" title="Go to New Upload" skipLocation="new-file"></clark-skip-link>

--- a/src/app/shared/modules/filesystem/file-browser/file-browser.component.ts
+++ b/src/app/shared/modules/filesystem/file-browser/file-browser.component.ts
@@ -50,6 +50,11 @@ export class FileBrowserComponent implements OnInit, OnDestroy {
   descriptionUpdated: EventEmitter<DescriptionUpdate> = new EventEmitter<
     DescriptionUpdate
   >();
+  @Output()
+  packageableToggled: EventEmitter<{
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  }> = new EventEmitter();
 
   @Input() filesystem$: BehaviorSubject<DirectoryTree> = new BehaviorSubject(
     new DirectoryTree()

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
@@ -23,7 +23,7 @@
     {{ file?.size | fileSize }}
   </div>
   <div>
-    <clark-toggle-switch [state]="file.packageable" (toggled)="toggler()"></clark-toggle-switch>
+    <clark-toggle-switch [state]="file.packageable" (toggled)="handleToggle($event)"></clark-toggle-switch>
   </div>
   <a
     tabindex="0"

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
@@ -22,8 +22,11 @@
   <div class="text-contained filesize" id="file-size" attr.aria-label="{{ file?.size }}">
     {{ file?.size | fileSize }}
   </div>
-  <div>
-    <clark-toggle-switch [state]="file.packageable" (toggled)="handleToggle($event)"></clark-toggle-switch>
+  <div class="bundle" *ngIf="checkAccessGroups() else notAdminOrCurator">
+    <clark-toggle-switch
+      [state]="file.packageable" 
+      (toggled)="handleToggle($event)"
+      ></clark-toggle-switch>
   </div>
   <a
     tabindex="0"
@@ -35,3 +38,9 @@
     <div></div>
   </a>
 </div>
+
+<ng-template #notAdminOrCurator>
+  <div class="text-contained bundle">
+    {{file.packageable ? 'On' : 'Off'}}
+  </div>
+</ng-template>

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
@@ -22,6 +22,9 @@
   <div class="text-contained filesize" id="file-size" attr.aria-label="{{ file?.size }}">
     {{ file?.size | fileSize }}
   </div>
+  <div>
+    <clark-toggle-switch [state]="file.packageable" (toggled)="toggler()"></clark-toggle-switch>
+  </div>
   <a
     tabindex="0"
     *ngIf="showOptionButton"

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
@@ -1,4 +1,8 @@
-<div class="grid-row wrapper" role="link" tabindex="0" attr.aria-labelledby="file-name file-description file-updated file-size">
+<div 
+  class="grid-row wrapper"
+  [ngClass]="{'bundle': checkAccessGroups()}"
+  role="link" tabindex="0" 
+  attr.aria-labelledby="file-name file-description file-updated file-size">
   <div
     (activate)="handleClick($event)"
     class="text-contained inline-flex"
@@ -22,7 +26,7 @@
   <div class="text-contained filesize" id="file-size" attr.aria-label="{{ file?.size }}">
     {{ file?.size | fileSize }}
   </div>
-  <div class="bundle" *ngIf="checkAccessGroups() else notAdminOrCurator">
+  <div class="toggleBundle" *ngIf="checkAccessGroups()">
     <clark-toggle-switch
       [state]="file.packageable" 
       (toggled)="handleToggle($event)"
@@ -38,9 +42,3 @@
     <div></div>
   </a>
 </div>
-
-<ng-template #notAdminOrCurator>
-  <div class="text-contained bundle">
-    {{file.packageable ? 'On' : 'Off'}}
-  </div>
-</ng-template>

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
@@ -77,11 +77,17 @@
   }
 }
 
-clark-toggle-switch {
+.bundle {
   display: flex;
   justify-content: center;
-  position: relative;
+  
+  clark-toggle-switch {
+    display: flex;
+    justify-content: center;
+    position: relative;
+  }
 }
+
 
 .external-link-icon {
   color: $light-blue;

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
@@ -12,7 +12,7 @@
 }
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;
@@ -75,6 +75,13 @@
     width: 6px;
     flex: 0 0 auto;
   }
+}
+
+clark-toggle-switch {
+  display: flex;
+  justify-content: center;
+  position: relative;
+  left: -17px;
 }
 
 .external-link-icon {

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
@@ -12,7 +12,7 @@
 }
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;
@@ -21,6 +21,10 @@
   justify-self: center;
   border-bottom: 1px solid rgba(0, 0, 0, 0.07);
   margin-bottom: 8px;
+
+  &.bundle {
+    grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  }
 }
 
 .text-contained {
@@ -77,7 +81,7 @@
   }
 }
 
-.bundle {
+.toggleBundle {
   display: flex;
   justify-content: center;
   

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
@@ -81,7 +81,6 @@ clark-toggle-switch {
   display: flex;
   justify-content: center;
   position: relative;
-  left: -17px;
 }
 
 .external-link-icon {

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -20,6 +20,7 @@ export class FileListItemComponent implements OnInit {
   icon = '';
   timestampAge = '';
   previewUrl = '';
+  accessGroups: string[];
 
   constructor(private auth: AuthService) {}
 
@@ -27,6 +28,7 @@ export class FileListItemComponent implements OnInit {
     this.icon = getIcon(this.file.extension);
     this.timestampAge = TimeFunctions.getTimestampAge(+this.file.date);
     this.previewUrl = this.file.previewUrl;
+    this.accessGroups = this.auth.accessGroups;
   }
 
   /**
@@ -63,5 +65,13 @@ export class FileListItemComponent implements OnInit {
     this.menuClicked.emit(event);
   }
 
-
+  /**
+   * Checks if the current user is an admin or curator.
+   * If true, allows the user to change the bundling status of a file/folder.
+   *
+   * @returns boolean value if the user is valid
+   */
+  checkAccessGroups(): boolean {
+    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
+  }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -41,6 +41,7 @@ export class FileListItemComponent implements OnInit {
   }
 
   handleToggle(event: boolean) {
+    this.file.packageable = event;
     this.toggleClicked.emit(event);
   }
 

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -15,6 +15,7 @@ export class FileListItemComponent implements OnInit {
 
   @Output() clicked: EventEmitter<void> = new EventEmitter();
   @Output() menuClicked: EventEmitter<MouseEvent> = new EventEmitter();
+  @Output() toggleClicked: EventEmitter<boolean> = new EventEmitter();
 
   icon = '';
   timestampAge = '';
@@ -39,6 +40,10 @@ export class FileListItemComponent implements OnInit {
     }
   }
 
+  handleToggle(event: boolean) {
+    this.toggleClicked.emit(event);
+  }
+
   /**
    * Emits click event of meatball was clicked
    *
@@ -50,7 +55,5 @@ export class FileListItemComponent implements OnInit {
     this.menuClicked.emit(event);
   }
 
-  toggler() {
-    console.log('gottem');
-  }
+
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -40,6 +40,13 @@ export class FileListItemComponent implements OnInit {
     }
   }
 
+  /**
+   * Updates the file's packageable property:
+   *  1. Updates the file in the client to immediately display changes
+   *  2. Emits toggleClicked to save the update in the database
+   *
+   * @param event the new packageable state
+   */
   handleToggle(event: boolean) {
     this.file.packageable = event;
     this.toggleClicked.emit(event);

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -49,4 +49,8 @@ export class FileListItemComponent implements OnInit {
     event.stopPropagation();
     this.menuClicked.emit(event);
   }
+
+  toggler() {
+    console.log('gottem');
+  }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -1,4 +1,10 @@
-<div role="link" tabindex="0" attr.aria-labelledby="folder-name folder-description folder-updated" (activate)="handleClick($event)" class="grid-row wrapper">
+<div 
+  role="link" 
+  tabindex="0" 
+  attr.aria-labelledby="folder-name folder-description folder-updated" 
+  (activate)="handleClick($event)" 
+  class="grid-row wrapper"
+  [ngClass]="{'bundle': checkAccessGroups()}">
   <div class="text-contained inline-flex" id="folder-name" attr.aria-label="{{ folder?.getName() }} Folder">
     <i class="fas fa-folder icon"></i>
     {{ folder?.getName() }}
@@ -10,7 +16,7 @@
     {{ timestampAge }}
   </div>
   <div class="empty"></div>
-  <div class="toggleBundle" *ngIf="checkAccessGroups() else notAdminOrCurator">
+  <div class="toggleBundle" *ngIf="checkAccessGroups()">
     <clark-toggle-switch 
       [state]="getFolderBundleStatus(folder)" 
       (click)="$event.stopPropagation()" 
@@ -27,9 +33,3 @@
     <div></div>
   </a>
 </div>
-
-<ng-template #notAdminOrCurator>
-  <div class="toggleBundle text-contained">
-    {{ getFolderBundleStatus(folder) ? 'On' : 'Off' }}
-  </div>
-</ng-template>

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -11,7 +11,7 @@
   </div>
   <div class="empty"></div>
   <div class="toggleBundle">
-    <clark-toggle-switch [state]="true"></clark-toggle-switch>
+    <clark-toggle-switch [state]="getFolderBundleStatus(folder)"></clark-toggle-switch>
   </div>
   <a
     tabindex="0"

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -11,7 +11,7 @@
   </div>
   <div class="empty"></div>
   <div class="toggleBundle">
-    <clark-toggle-switch [state]="getFolderBundleStatus(folder)"></clark-toggle-switch>
+    <clark-toggle-switch [state]="getFolderBundleStatus(folder)" (click)="$event.stopPropagation()" (toggled)="handleBundleToggle(folder, $event)"></clark-toggle-switch>
   </div>
   <a
     tabindex="0"

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -10,8 +10,12 @@
     {{ timestampAge }}
   </div>
   <div class="empty"></div>
-  <div class="toggleBundle">
-    <clark-toggle-switch [state]="getFolderBundleStatus(folder)" (click)="$event.stopPropagation()" (toggled)="handleBundleToggle(folder, $event)"></clark-toggle-switch>
+  <div class="toggleBundle" *ngIf="checkAccessGroups() else notAdminOrCurator">
+    <clark-toggle-switch 
+      [state]="getFolderBundleStatus(folder)" 
+      (click)="$event.stopPropagation()" 
+      (toggled)="handleBundleToggle(folder, $event)"
+      ></clark-toggle-switch>
   </div>
   <a
     tabindex="0"
@@ -23,3 +27,9 @@
     <div></div>
   </a>
 </div>
+
+<ng-template #notAdminOrCurator>
+  <div class="toggleBundle text-contained">
+    {{ getFolderBundleStatus(folder) ? 'On' : 'Off' }}
+  </div>
+</ng-template>

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -10,7 +10,9 @@
     {{ timestampAge }}
   </div>
   <div class="empty"></div>
-  <div class="empty"></div>
+  <div class="toggleBundle">
+    <clark-toggle-switch [state]="true"></clark-toggle-switch>
+  </div>
   <a
     tabindex="0"
     attr.aria-label="Clickable Option Menu for {{ folder?.getName() }}"

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -10,6 +10,7 @@
     {{ timestampAge }}
   </div>
   <div class="empty"></div>
+  <div class="empty"></div>
   <a
     tabindex="0"
     attr.aria-label="Clickable Option Menu for {{ folder?.getName() }}"

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -18,9 +18,10 @@
   font-size: 20px;
   margin-right: 5px;
 }
+
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;
@@ -29,6 +30,10 @@
   justify-self: center;
   border-bottom: 1px solid $light-grey;
   margin-bottom: 8px;
+
+  &.bundle {
+    grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  }
 }
 
 .text-contained {

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -20,7 +20,7 @@
 }
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1.5fr 1fr  1fr 25px;
+  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -64,6 +64,14 @@
   color: $dark-grey;
 }
 
+.toggleBundle {
+  clark-toggle-switch {
+    display: flex;
+    justify-content: center;
+    position: relative;
+  }
+}
+
 .meatballs {
   display: flex;
   flex-direction: row;

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -20,7 +20,7 @@
 }
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1.5fr 1fr  1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -65,6 +65,9 @@
 }
 
 .toggleBundle {
+  display: flex;
+  justify-content: center;
+  
   clark-toggle-switch {
     display: flex;
     justify-content: center;

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 import { TimeFunctions } from 'app/onion/learning-object-builder/components/content-upload/app/shared/time-functions';
+import { AuthService } from 'app/core/auth.service';
 
 @Component({
   selector: 'clark-folder-list-item',
@@ -16,11 +17,13 @@ export class FolderListItemComponent implements OnInit {
   @Output() toggleClicked: EventEmitter<boolean> = new EventEmitter();
 
   timestampAge = '';
+  accessGroups?: string[];
 
-  constructor() {}
+  constructor(private authService: AuthService) {}
 
   ngOnInit() {
     this.timestampAge = TimeFunctions.getTimestampAge(this.getLatestDate());
+    this.accessGroups = this.authService.accessGroups;
   }
 
   /**
@@ -142,5 +145,15 @@ export class FolderListItemComponent implements OnInit {
     });
 
     this.toggleClicked.emit(event);
+  }
+
+  /**
+   * Checks if the current user is an admin or curator.
+   * If true, allows the user to change the bundling status of a file/folder.
+   *
+   * @returns boolean value if the user is valid
+   */
+    checkAccessGroups(): boolean {
+    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -70,4 +70,32 @@ export class FolderListItemComponent implements OnInit {
     event.stopPropagation();
     this.menuClicked.emit(event);
   }
+
+  /**
+   * Recursively iterates through a chosen folder to determine if the folder itself is packageable.
+   * If any one of the files within the folder is not packageable, then the folder is not packageable.
+   * Mainly used for displaying the folder's packageable status, since it does not have a direct property.
+   *
+   * @param folder The current folder item to recursively iterate through
+   * @returns The packageable status of the folder (boolean)
+   */
+  getFolderBundleStatus(folder: DirectoryNode): boolean {
+    const files = folder.getFiles();
+    const folders = folder.getFolders();
+    let status = true;
+
+    files.forEach(file => {
+      if (!file.packageable) {
+        status = false;
+      }
+    });
+
+    folders.forEach(subFolder => {
+      if(!this.getFolderBundleStatus(subFolder)) {
+        status = false;
+      }
+    });
+
+    return status;
+  }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -100,6 +100,14 @@ export class FolderListItemComponent implements OnInit {
     return status;
   }
 
+  /**
+   * Helper function for handleBundleToggle. Prevents multiple emits occuring at once due to recursion.
+   * Recursively iterates through the root folder's subfolders and changes files
+   * to the new packageable status.
+   *
+   * @param subFolder The current subfolder to recursively iterate through
+   * @param event The bundling status of the root folder
+   */
   togglePackageableSubFiles(subFolder: DirectoryNode, event: boolean) {
     const subFiles = subFolder.getFiles();
     const subFolders = subFolder.getFolders();
@@ -113,6 +121,14 @@ export class FolderListItemComponent implements OnInit {
     });
   }
 
+  /**
+   * Handles changing the packageable status of files:
+   *  1. Changes all subfiles packageable property to immediately display event changes
+   *  2. Emits an event to the backend to save this change to the database
+   *
+   * @param folder The current folder item to recursively iterate through
+   * @param event The bundling status of the folder
+   */
   handleBundleToggle(folder: DirectoryNode, event: boolean) {
     const files = folder.getFiles();
     const folders = folder.getFolders();

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -100,6 +100,19 @@ export class FolderListItemComponent implements OnInit {
     return status;
   }
 
+  togglePackageableSubFiles(subFolder: DirectoryNode, event: boolean) {
+    const subFiles = subFolder.getFiles();
+    const subFolders = subFolder.getFolders();
+
+    subFiles.forEach(subFile => {
+      subFile.packageable = event;
+    });
+
+    subFolders.forEach(subSubFolder => {
+      this.togglePackageableSubFiles(subSubFolder, event);
+    });
+  }
+
   handleBundleToggle(folder: DirectoryNode, event: boolean) {
     const files = folder.getFiles();
     const folders = folder.getFolders();
@@ -109,7 +122,7 @@ export class FolderListItemComponent implements OnInit {
     });
 
     folders.forEach(subFolder => {
-      this.handleBundleToggle(subFolder, event);
+      this.togglePackageableSubFiles(subFolder, event);
     });
 
     this.toggleClicked.emit(event);

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -13,6 +13,7 @@ export class FolderListItemComponent implements OnInit {
 
   @Output() clicked: EventEmitter<void> = new EventEmitter();
   @Output() menuClicked: EventEmitter<MouseEvent> = new EventEmitter();
+  @Output() toggleClicked: EventEmitter<boolean> = new EventEmitter();
 
   timestampAge = '';
 
@@ -97,5 +98,20 @@ export class FolderListItemComponent implements OnInit {
     });
 
     return status;
+  }
+
+  handleBundleToggle(folder: DirectoryNode, event: boolean) {
+    const files = folder.getFiles();
+    const folders = folder.getFolders();
+
+    files.forEach(file => {
+      file.packageable = event;
+    });
+
+    folders.forEach(subFolder => {
+      this.handleBundleToggle(subFolder, event);
+    });
+
+    this.toggleClicked.emit(event);
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -6,7 +6,7 @@
       <div>Date</div>
       <div>Size</div>
       <div class="toggle">
-        <p>Toggle Bundle</p>
+        <p>Bundle</p>
         <div class="icon" [tip]="toggleToolTip" [tipDisabled]="false">
           <i class="fas fa-question-circle"></i>
         </div>

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -20,6 +20,7 @@
         class="folder"
         (clicked)="openFolder(item.name)"
         (menuClicked)="handleMenuClicked($event, item)"
+        (toggleClicked)="handleToggleClicked($event, item)"
         [folder]="item"
         [showOptionButton]="canManage"
       ></clark-folder-list-item>

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -30,6 +30,7 @@
         class="file"
         (clicked)="openFile(item)"
         (menuClicked)="handleMenuClicked($event, item)"
+        (toggleClicked)="handleToggleClicked($event, item)"
         [file]="item"
         [showOptionButton]="canManage"
       ></clark-file-list-item>

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -1,11 +1,11 @@
 <div *ngIf="preview">
   <div class="wrapper">
-    <div class="grid-row header">
+    <div class="grid-row header" [ngClass]="{'bundle': checkAccessGroups()}">
       <div>Name</div>
       <div>Description</div>
       <div>Date</div>
       <div>Size</div>
-      <div class="toggle">
+      <div class="toggle" *ngIf="checkAccessGroups()">
         <p>Bundle</p>
         <div class="icon" [tip]="toggleToolTip" [tipDisabled]="false">
           <i class="fas fa-question-circle"></i>

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -5,6 +5,12 @@
       <div>Description</div>
       <div>Date</div>
       <div>Size</div>
+      <div class="toggle">
+        <p>Toggle Bundle</p>
+        <div class="icon" [tip]="toggleToolTip" [tipDisabled]="false">
+          <i class="fas fa-question-circle"></i>
+        </div>
+      </div>
       <div *ngIf="canManage" class="placeholder"></div>
     </div>
     <div *ngFor="let item of directoryListing">

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
@@ -20,7 +20,7 @@
 
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;
@@ -33,6 +33,15 @@
     background: transparent;
     padding: 0;
     margin-bottom: 15px;
+  }
+
+  .toggle {
+    display: flex;
+    align-items: center;
+
+    .icon {
+      margin-left: 5px;
+    }
   }
 }
 

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
@@ -38,6 +38,7 @@
   .toggle {
     display: flex;
     align-items: center;
+    justify-content: center;
 
     .icon {
       margin-left: 5px;

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.scss
@@ -20,13 +20,17 @@
 
 .grid-row {
   display: grid;
-  grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  grid-template-columns: 2fr 2fr 1fr 1fr 25px;
   grid-column-gap: 20px;
   align-items: center;
   width: 100%;
   background: white;
   padding: 0 0 8px;
   justify-self: center;
+
+  &.bundle {
+    grid-template-columns: 2fr 2fr 1.5fr 1fr 1fr 25px;
+  }
 
   &.header {
     color: $dark-grey;

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -37,6 +37,11 @@ export class FileListViewComponent implements OnInit, OnDestroy {
     event: MouseEvent;
     item: any;
   }> = new EventEmitter();
+  @Output()
+  emitBundle: EventEmitter<{
+    state: boolean;
+    item: DirectoryNode | LearningObject.Material.File;
+  }> = new EventEmitter();
 
   private editableFile: LearningObject.Material.File | DirectoryNode;
 
@@ -124,6 +129,16 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   ) {
     event.stopPropagation();
     this.emitContextOpen.next({ event, item });
+  }
+
+  handleToggleClicked(
+    state: boolean,
+    item: DirectoryNode | LearningObject.Material.File
+  ) {
+    this.emitBundle.emit({
+      state: state,
+      item: item
+    });
   }
 
   returnToFileView() {

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -47,6 +47,8 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   file: LearningObject.Material.File;
   directoryListing = [];
 
+  toggleToolTip = 'If an item is toggled on, then the selected item will be included in the zip file to be downloaded for users.';
+
   constructor(private auth: AuthService) {}
 
   ngOnInit(): void {

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -52,13 +52,16 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   file: LearningObject.Material.File;
   directoryListing = [];
 
-  toggleToolTip = 'If an item is toggled on, then the selected item will be included in the zip file to be downloaded for users.';
+  toggleToolTip = `Selected items will be included in the bundle download. 
+    Deselected items will be accessible through a download link in the PDF.`;
+  accessGroups: string[];
 
   constructor(private auth: AuthService) {}
 
   ngOnInit(): void {
     this.subToDirChange();
     this.subToDescription();
+    this.accessGroups = this.auth.accessGroups;
   }
 
   /**
@@ -183,6 +186,16 @@ export class FileListViewComponent implements OnInit, OnDestroy {
       return elm.getPath();
     }
     return elm.id || index;
+  }
+
+  /**
+   * Checks if the current user is an admin or curator.
+   * If true, allows the user to change the bundling status of a file/folder.
+   *
+   * @returns boolean value if the user is valid
+   */
+   checkAccessGroups(): boolean {
+    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
   }
 
   ngOnDestroy() {

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -131,6 +131,12 @@ export class FileListViewComponent implements OnInit, OnDestroy {
     this.emitContextOpen.next({ event, item });
   }
 
+  /**
+   * Emits bundling event indicating the file/folder with a new packageable property to be saved
+   *
+   * @param state The new packageable state to save to the database
+   * @param item The folder or file to be handled
+   */
   handleToggleClicked(
     state: boolean,
     item: DirectoryNode | LearningObject.Material.File

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -347,6 +347,16 @@ export const USER_ROUTES = {
   GET_KEY_PAIR(): string {
     return `${environment.apiURL}/keys`;
   },
+  TOGGLE_FILES_TO_BUNDLE(params: {
+    username: string,
+    learningObjectID: string,
+  }): string {
+    return `${environment.apiURL}/users/${encodeURIComponent(
+      params.username
+    )}/learning-objects/${encodeURIComponent(
+      params.learningObjectID
+    )}/files/bundle`;
+  }
 };
 
 export const PUBLIC_LEARNING_OBJECT_ROUTES = {

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -36,6 +36,9 @@ export const ADMIN_ROUTES = {
   UPDATE_OBJECT_SUBMITTED_COLLECTION(username: string, cuid: string) {
     return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${encodeURIComponent(cuid)}/collection`;
   },
+  TOGGLE_BUNDLE(username: string, id: string) {
+    return `${environment.apiURL}/users/${encodeURIComponent(username)}/learning-objects/${encodeURIComponent(id)}/files/bundle`;
+  }
 };
 
 export const CHANGELOG_ROUTES = {


### PR DESCRIPTION
Partially completes [12115](https://app.shortcut.com/clarkcan/story/12115/add-toggle-for-admins-and-curators-to-select-deselect-files-to-be-included-excluded-from-a-bundle).

In this PR:
- A bundle toggle option has been added to all files and folders in the learning object builder.
- Toggling this function will change whether or not the file/folder will be bundled.
    - For folders, toggling the bundle option will affect the packageable properties for all its files, depending on what the status was toggled to.

## Screenshots

Screenshot
<img width="1440" alt="Screen Shot 2022-08-02 at 1 17 20 PM" src="https://user-images.githubusercontent.com/93054689/182435135-352bac5e-f1b8-4ada-a7de-f71d2ab58b0a.png">

Testing Toggling
![togglingbundlefrontend](https://user-images.githubusercontent.com/93054689/182436387-9040bbdb-1829-44e5-a673-0de20031d569.gif)
