### PR TITLE
Blogs for New Homepage

### DIFF
--- a/src/app/clark.component.scss
+++ b/src/app/clark.component.scss
@@ -6,10 +6,6 @@ clark-cookies {
     right: 0;
 }
 
-clark-primary-navbar, clark-secondary-navbar {
-    z-index: 999;
-}
-
 .modal-container {
     height: 475px;
     width: 560px;

--- a/src/app/clark.component.scss
+++ b/src/app/clark.component.scss
@@ -6,6 +6,10 @@ clark-cookies {
     right: 0;
 }
 
+clark-primary-navbar, clark-secondary-navbar {
+    z-index: 999;
+}
+
 .modal-container {
     height: 475px;
     width: 560px;

--- a/src/app/components/blogs/blogs.component.html
+++ b/src/app/components/blogs/blogs.component.html
@@ -1,5 +1,5 @@
 <div class="blogs-component" *ngIf="blogObservable | async as blog;">
-    <div @fadeInOut class="first-view" *ngIf="view===0">
+    <div @blogView class="first-view" *ngIf="view===0">
         <div class="left">
             <i class="fas fa-info-circle fa-2x"></i>
             <p>
@@ -13,7 +13,7 @@
         </div>
     </div>
 
-    <div @fadeInOut class="second-view" *ngIf="view===1">
+    <div @dismissView class="second-view" *ngIf="view===1">
         <div class="side-by-side">
             <button (click)="dismissOnce()">Dismiss Once</button>
             <button (click)="dismiss()">Dismiss</button>

--- a/src/app/components/blogs/blogs.component.scss
+++ b/src/app/components/blogs/blogs.component.scss
@@ -1,6 +1,10 @@
 @import 'vars.scss';
 
 .blogs-component {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    height: 79px;
     .first-view {
         display: flex;
         position: relative;
@@ -11,6 +15,10 @@
             display: flex;
             flex-direction: row;
             justify-content: flex-start;
+            
+            p {
+                font-size: 16px;
+            }
     
             .fa-2x {
                 margin: 10px;
@@ -50,6 +58,9 @@
         align-items: center;
 
         .side-by-side {
+            display: flex;
+            flex-direction: row;
+
             button {
                 background-color: $light-blue;
                 color: white;

--- a/src/app/components/blogs/blogs.component.scss
+++ b/src/app/components/blogs/blogs.component.scss
@@ -1,6 +1,6 @@
 @import 'vars.scss';
 
-div {
+.blogs-component {
     .first-view {
         display: flex;
         position: relative;

--- a/src/app/components/blogs/blogs.component.ts
+++ b/src/app/components/blogs/blogs.component.ts
@@ -9,11 +9,57 @@ import { Blog } from './types/blog';
   templateUrl: './blogs.component.html',
   styleUrls: ['./blogs.component.scss'],
   animations: [
-    trigger('fadeInOut', [
+    trigger('blogView', [
       transition(':enter', [
-        style({ opacity: 0 }),
-        animate('500ms', style({ opacity: 1 })
+        style({
+          position: 'relative',
+          left: '-100%'
+        }),
+        animate('500ms ease-out', style({
+          position: 'relative',
+          left: '0%'
+        })
         )
+      ]),
+      transition(':leave', [
+        style({
+          position: 'relative',
+          left: '0%'
+        }),
+        animate('500ms ease-out', style({
+          position: 'relative',
+          left: '-100%'
+        }))
+      ])
+    ]),
+    trigger('dismissView', [
+      transition(':enter', [
+        style({
+          position: 'absolute',
+          top: '0',
+          left: '150%',
+          overflow: 'hidden'
+        }),
+        animate('500ms ease-out', style({
+          position: 'absolute',
+          top: '0',
+          left: '40%',
+          overflow: 'hidden'
+        }))
+      ]),
+      transition(':leave', [
+        style({
+          position: 'absolute',
+          top: '0',
+          left: '40%',
+          overflow: 'hidden'
+        }),
+        animate('500ms ease-out', style({
+          position: 'absolute',
+          top: '0',
+          left: '150%',
+          overflow: 'hidden'
+        }))
       ])
     ])
   ]

--- a/src/app/components/primary-navbar/primary-navbar.component.scss
+++ b/src/app/components/primary-navbar/primary-navbar.component.scss
@@ -3,6 +3,7 @@
     max-height: 92px;
     background: white;
     color: $dark-grey;
+    position: relative;
     z-index: 4;
 
     .nav-wrapper {

--- a/src/app/components/secondary-navbar/secondary-navbar.component.scss
+++ b/src/app/components/secondary-navbar/secondary-navbar.component.scss
@@ -8,6 +8,7 @@
     height: 43px;
     width: 100%;
     border: solid 1px $secondary-white;
+    z-index: 4;
 
     .item {
         cursor: pointer;

--- a/src/app/core/blogs-component.service.ts
+++ b/src/app/core/blogs-component.service.ts
@@ -7,7 +7,7 @@ import { BlogsService } from './blogs.service';
 })
 export class BlogsComponentService {
   neverShowBanner = false; // true if the user doesn't want to see the blog again
-  showBanner = false; // true if blog is displayed. NOTE: hardcode this to false to disable blog banners
+  showBanner = true; // true if blog is displayed. NOTE: hardcode this to false to disable blog banners
 
   recentBlog: Blog; // holds the latest blogpost
 
@@ -73,7 +73,9 @@ export class BlogsComponentService {
    */
   setNeverShowBanner(args: {val: boolean, recentBlog?: Blog}) {
     localStorage.setItem('neverShowBanner', args.val.toString());
-    localStorage.setItem('bannerBlogId', args.recentBlog._id);
+    if(args.recentBlog) {
+      localStorage.setItem('bannerBlogId', args.recentBlog._id);
+    }
     this.neverShowBanner = args.val;
   }
 }

--- a/src/app/cube/home/home.module.ts
+++ b/src/app/cube/home/home.module.ts
@@ -34,8 +34,7 @@ import { BlogsComponent } from 'app/components/blogs/blogs.component';
     UsageComponent,
     CollectionsComponent,
     WhatClarkComponent,
-    FeaturedCollectionCardComponent,
-    BlogsComponent
+    FeaturedCollectionCardComponent
   ],
   providers: []
 })

--- a/src/app/cube/new-home/new-home.component.html
+++ b/src/app/cube/new-home/new-home.component.html
@@ -1,4 +1,9 @@
-<p>new-home works!</p>
+<clark-blogs
+    @blog
+    *ngIf="displayBlogsBanner()"
+    (showBlogsBanner)="showBlogsBanner($event)"
+    (neverShowBanner)="neverShowBanner($event)"
+  ></clark-blogs>
 <clark-splash></clark-splash>
 <clark-help></clark-help>
 <clark-mission></clark-mission>

--- a/src/app/cube/new-home/new-home.component.scss
+++ b/src/app/cube/new-home/new-home.component.scss
@@ -1,0 +1,5 @@
+clark-blogs {
+    z-index: 1;
+    position: absolute;
+    width: 100%;
+}

--- a/src/app/cube/new-home/new-home.component.scss
+++ b/src/app/cube/new-home/new-home.component.scss
@@ -1,5 +1,5 @@
 clark-blogs {
-    z-index: 1;
     position: absolute;
+    background-color: rgba(190, 190, 190, 0.7);
     width: 100%;
 }

--- a/src/app/cube/new-home/new-home.component.ts
+++ b/src/app/cube/new-home/new-home.component.ts
@@ -1,15 +1,64 @@
+import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, OnInit } from '@angular/core';
+import { Blog } from 'app/components/blogs/types/blog';
+import { BlogsComponentService } from 'app/core/blogs-component.service';
 
 @Component({
   selector: 'clark-new-home',
   templateUrl: './new-home.component.html',
-  styleUrls: ['./new-home.component.scss']
+  styleUrls: ['./new-home.component.scss'],
+  animations: [
+    trigger('blog', [
+      transition(':enter', [
+        style({
+          transform: 'translateY(-100%)',
+          zIndex: 0
+        }),
+        animate('300ms 1200ms ease-out', style({
+          transform: 'translateY(0%)',
+          zIndex: 0
+        }))
+      ]),
+      transition(':leave', [
+        style({ zIndex: 3 }),
+        animate('300ms ease-out', style({ transform: 'translate3d(0, -100%, 1px)', zIndex: 3 }))
+      ])
+    ])
+  ]
 })
 export class NewHomeComponent implements OnInit {
 
-  constructor() { }
+  constructor(private blogsComponentService: BlogsComponentService) { }
 
   ngOnInit(): void {
+  }
+
+  /**
+   * Catches the output emitted by clark-blogs to dismiss the banner
+   *
+   * @param val The value of showBanner
+   */
+   showBlogsBanner(val: boolean) {
+    this.blogsComponentService.setShowBanner(val);
+  }
+
+  /**
+   * Catches the checkbox output emitted by clark-blogs to never see the banner again
+   *
+   * @param args: val - the value of the checkbox
+   *              recentBlog - the blog that was dismissed
+   */
+  neverShowBanner(args: {val: boolean, recentBlog?: Blog}) {
+    this.blogsComponentService.setNeverShowBanner(args);
+  }
+
+  /**
+   * Determines if the blogs banner is to be shown
+   *
+   * @returns a value determining if the blogs banner is shown
+   */
+  displayBlogsBanner() {
+    return this.blogsComponentService.getShowBanner() && !this.blogsComponentService.getNeverShowBanner();
   }
 
 }

--- a/src/app/cube/new-home/new-home.component.ts
+++ b/src/app/cube/new-home/new-home.component.ts
@@ -11,12 +11,10 @@ import { BlogsComponentService } from 'app/core/blogs-component.service';
     trigger('blog', [
       transition(':enter', [
         style({
-          transform: 'translateY(-100%)',
-          zIndex: 0
+          transform: 'translateY(-100%)'
         }),
         animate('300ms 1200ms ease-out', style({
-          transform: 'translateY(0%)',
-          zIndex: 0
+          transform: 'translateY(0%)'
         }))
       ]),
       transition(':leave', [

--- a/src/app/cube/new-home/new-home.module.ts
+++ b/src/app/cube/new-home/new-home.module.ts
@@ -16,6 +16,9 @@ import { StickyMenuComponent } from './learning-object-info/sticky-menu/sticky-m
 import { CubeSharedModule } from '../shared/cube-shared.module';
 import { SharedModule } from 'app/shared/shared.module';
 import { RouterModule } from '@angular/router';
+import { BlogsComponent } from 'app/components/blogs/blogs.component';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 
 
@@ -33,7 +36,8 @@ import { RouterModule } from '@angular/router';
     LearningOutcomesComponent,
     HierarchiesComponent,
     CollectionsComponent,
-    StickyMenuComponent
+    StickyMenuComponent,
+    BlogsComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
Completes story [12585](https://app.shortcut.com/clarkcan/story/12585/re-implement-blogs-banner-for-new-homepage).

This PR simply adds the blog banner to the new homepage. This will also toggle the blogs back on once this is deployed to production.

I've also taken the opportunity to tweak the animation of the blog banner for better UX. Let me know if the new one is better than the old one or if we should keep the old one.

# New Animation (Slide Left & Right)
![newBlogs](https://user-images.githubusercontent.com/93054689/183740792-39edc123-324a-4adc-bae8-3ad6981f0934.gif)

# Old Animation (Fade In & Out)
![oldBlogs](https://user-images.githubusercontent.com/93054689/183740809-01171047-cbcb-40f4-a0b4-97df5f57651d.gif)
