### PR TITLE
Josue/fix bundling error

### DIFF
--- a/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.html
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.html
@@ -8,6 +8,7 @@
   (descriptionUpdated)="saveDescription($event.description, $event.file)"
   canManage="true"
   (packageableToggled)="packageableToggled.emit($event)"
+  [inBuilder]="true"
   ></clark-file-browser>
 
 <clark-context-menu *ngIf="showNewOptions" [anchor]="menuAnchor" (close)="closeContextMenu()">

--- a/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
+++ b/src/app/shared/modules/filesystem/file-browser/file-browser.component.html
@@ -25,6 +25,7 @@
     (emitDesc)="emitDesc($event)" 
     (emitContextOpen)="meatballClick.emit($event)"
     (emitBundle)="packageableToggled.emit($event)"
+    [inBuilder]="inBuilder"
     >
   </clark-file-list-view>
 </div>

--- a/src/app/shared/modules/filesystem/file-browser/file-browser.component.ts
+++ b/src/app/shared/modules/filesystem/file-browser/file-browser.component.ts
@@ -39,6 +39,7 @@ export class FileBrowserComponent implements OnInit, OnDestroy {
     LearningObject.Material.File[]
   >([]);
   @Input() folderMeta$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>([]);
+  @Input() inBuilder = false;
   @Output() path: EventEmitter<string> = new EventEmitter<string>();
   @Output()
   containerClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -12,7 +12,7 @@ import { AuthService } from 'app/core/auth.service';
 export class FileListItemComponent implements OnInit {
   @Input() file: LearningObject.Material.File;
   @Input() showOptionButton = false;
-
+  @Input() inBuilder = false;
   @Output() clicked: EventEmitter<void> = new EventEmitter();
   @Output() menuClicked: EventEmitter<MouseEvent> = new EventEmitter();
   @Output() toggleClicked: EventEmitter<boolean> = new EventEmitter();
@@ -72,6 +72,6 @@ export class FileListItemComponent implements OnInit {
    * @returns boolean value if the user is valid
    */
   checkAccessGroups(): boolean {
-    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
+    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -11,7 +11,7 @@ import { AuthService } from 'app/core/auth.service';
 export class FolderListItemComponent implements OnInit {
   @Input() folder: DirectoryNode;
   @Input() showOptionButton = false;
-
+  @Input() inBuilder = false;
   @Output() clicked: EventEmitter<void> = new EventEmitter();
   @Output() menuClicked: EventEmitter<MouseEvent> = new EventEmitter();
   @Output() toggleClicked: EventEmitter<boolean> = new EventEmitter();
@@ -154,6 +154,6 @@ export class FolderListItemComponent implements OnInit {
    * @returns boolean value if the user is valid
    */
     checkAccessGroups(): boolean {
-    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
+    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.html
@@ -21,6 +21,7 @@
         (clicked)="openFolder(item.name)"
         (menuClicked)="handleMenuClicked($event, item)"
         (toggleClicked)="handleToggleClicked($event, item)"
+        [inBuilder]="inBuilder"
         [folder]="item"
         [showOptionButton]="canManage"
       ></clark-folder-list-item>
@@ -32,6 +33,7 @@
         (clicked)="openFile(item)"
         (menuClicked)="handleMenuClicked($event, item)"
         (toggleClicked)="handleToggleClicked($event, item)"
+        [inBuilder]="inBuilder"
         [file]="item"
         [showOptionButton]="canManage"
       ></clark-file-list-item>

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -26,6 +26,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   node$: BehaviorSubject<DirectoryNode> = new BehaviorSubject<DirectoryNode>(
     null
   );
+  @Input() inBuilder = false;
   @Output()
   emitPath: EventEmitter<string> = new EventEmitter<string>();
   @Output()
@@ -195,7 +196,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
    * @returns boolean value if the user is valid
    */
    checkAccessGroups(): boolean {
-    return this.accessGroups.includes('admin') || this.accessGroups.includes('curator');
+    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This PR completes [Fix `toggle bundle` displaying on details page Description](https://app.shortcut.com/clarkcan/story/13107/fix-toggle-bundle-displaying-on-details-page)

An input `inBuilder` for the file item viewer and folder item viewer was added. 