### PR TITLE
Andy/disappearing navbar fix

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -5,8 +5,6 @@ import {
 } from '@angular/core';
 import {
   Router,
-  ActivatedRoute,
-  NavigationStart,
   NavigationEnd
 } from '@angular/router';
 

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -94,14 +94,16 @@ export class NavbarComponent implements OnInit {
 
       this.router.events.subscribe(e => {
         if (e instanceof NavigationEnd) {
-          // if we're in onion, auth, or admin, toggle the navbar off
-          this.showNav = e.url.match(/\/*onion[\/*[0-z]*]*/)
-            || e.url.match(/\/*auth[\/*[0-z]*]*/)
-            || e.url.match(/\/*admin[\/*[0-z]*]*/) ? false : true;
+          let url = e.url.split('/');
+          this.showNav = (
+            url[1] === 'auth' ||
+            url[1] === 'onion' ||
+            url[1] === 'admin'
+          ) ? false : true;
 
-          if (e.url.match(/\/*onion[\/*[0-z]*]*/)) {
+          if(url[1] === 'onion') {
             this.menuOpen = this.searchDown = false;
-          };
+          }
           this.url = e.url;
         };
         window.scrollTo(0, 0);


### PR DESCRIPTION
This PR completes [7879](https://app.shortcut.com/clarkcan/story/7879/navbar-disappears-on-user-profile)

the problem was that the regex was picking up on 'auth' in 'authormike' username and was hiding the navbar because of it. I've split the route at '/' and looked at the second index to get the main route