### PR TITLE
Toggle Bundle - Folder does not appear in builder

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -92,7 +92,7 @@ export class NavbarComponent implements OnInit {
 
       this.router.events.subscribe(e => {
         if (e instanceof NavigationEnd) {
-          let url = e.url.split('/');
+          const url = e.url.split('/');
           this.showNav = (
             url[1] === 'auth' ||
             url[1] === 'onion' ||

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -72,6 +72,9 @@ export class FileListItemComponent implements OnInit {
    * @returns boolean value if the user is valid
    */
   checkAccessGroups(): boolean {
-    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+    if(this.accessGroups && this.accessGroups.length > 0) {
+      return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+    }
+    return false;
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.ts
@@ -154,6 +154,9 @@ export class FolderListItemComponent implements OnInit {
    * @returns boolean value if the user is valid
    */
     checkAccessGroups(): boolean {
-    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+      if(this.accessGroups && this.accessGroups.length > 0) {
+        return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+      }
+      return false;
   }
 }

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -196,7 +196,10 @@ export class FileListViewComponent implements OnInit, OnDestroy {
    * @returns boolean value if the user is valid
    */
    checkAccessGroups(): boolean {
-    return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+    if(this.accessGroups && this.accessGroups.length > 0) {
+      return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+    }
+    return false;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
Addresses [13641](https://app.shortcut.com/clarkcan/story/13641/folder-does-not-appear-in-builder).

The option to bundle toggle needs to check if the user's access groups include admin or editor. However, not all users have access groups. This fix adds another conditional to this check to see if the user has access groups in the first place.