### PR TITLE
Add Sort By Date on Admin Dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "4.29.30",
+  "version": "4.29.31",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "4.29.30",
+      "version": "4.29.31",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "4.29.30",
+  "version": "4.29.31",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -28,11 +28,17 @@
             <div>Author</div>
             <div>Length</div>
             <div>Date
-              <button class="sort" (activate)="sortByDate(1)" aria-label="Sort learning objects in ascending order" [tip]="'Sort Ascending'" tipPosition="top" [tipDisabled]="false">
+              <!-- <button class="sort" (activate)="sortByDate(1)" aria-label="Sort learning objects in ascending order" [tip]="'Sort Ascending'" tipPosition="top" [tipDisabled]="false">
                 <i style="font-size: 18px" class="fas fa-angle-up"></i>
               </button>
               <button class="sort" (activate)="sortByDate(-1)" aria-label="Sort learning objects in descending order" [tip]="'Sort Descending'" tipPosition="top" [tipDisabled]="false">
                 <i style="font-size: 18px" class="fas fa-angle-down"></i>
+              </button> -->
+              <button class="sort" (activate)="sortByDate()">
+                <span *ngIf="!_query.sortType else sortArrows">
+                  <i style="font-size: 18px;" class="far fa-sort"></i>
+                </span>
+                
               </button>
             </div>
           </div>
@@ -78,4 +84,13 @@
     <i class="far fa-thumbs-up"></i>
     You've reached the end of the list!
   </div>
+</ng-template>
+
+<ng-template #sortArrows>
+  <span *ngIf="_query.sortType.toString() === '1'">
+    <i style="font-size: 18px;" class="far fa-sort-up"></i>
+  </span>
+  <span *ngIf="_query.sortType.toString() === '-1'">
+    <i style="font-size: 18px;" class="far fa-sort-down"></i>
+  </span>
 </ng-template>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -28,17 +28,10 @@
             <div>Author</div>
             <div>Length</div>
             <div>Date
-              <!-- <button class="sort" (activate)="sortByDate(1)" aria-label="Sort learning objects in ascending order" [tip]="'Sort Ascending'" tipPosition="top" [tipDisabled]="false">
-                <i style="font-size: 18px" class="fas fa-angle-up"></i>
-              </button>
-              <button class="sort" (activate)="sortByDate(-1)" aria-label="Sort learning objects in descending order" [tip]="'Sort Descending'" tipPosition="top" [tipDisabled]="false">
-                <i style="font-size: 18px" class="fas fa-angle-down"></i>
-              </button> -->
               <button class="sort" (activate)="sortByDate()">
                 <span *ngIf="!_query.sortType else sortArrows">
                   <i style="font-size: 18px;" class="far fa-sort"></i>
                 </span>
-                
               </button>
             </div>
           </div>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -108,7 +108,18 @@ export class LearningObjectsComponent
         debounceTime(650)
       )
       .subscribe(searchTerm => {
-        this.query = { currPage: 1, sortType: this.query.sortType, orderBy: this.query.orderBy, text: searchTerm };
+        this.query = { currPage: 1, text: searchTerm };
+        if (!searchTerm || searchTerm.length <= 0) {
+          this.query = {
+            sortType: SortType.Descending,
+            orderBy: OrderBy.Date
+          };
+        } else {
+          this.query = {
+            sortType: undefined,
+            orderBy: undefined
+          };
+        }
         this.learningObjects = [];
 
         this.getLearningObjects();
@@ -217,13 +228,17 @@ export class LearningObjectsComponent
    */
   sortByDate() {
     if(!this.query.sortType) {
-      this.query['sortType'] = SortType.Descending;
-      this.query['orderBy'] = OrderBy.Date;
+      this.query = {
+        sortType: SortType.Descending,
+        orderBy: OrderBy.Date
+      };
     } else if (this.query.sortType.toString() === '-1') {
       this.query.sortType = SortType.Ascending;
     } else if (this.query.sortType.toString() === '1') {
-      delete this.query.sortType;
-      delete this.query.orderBy;
+      this.query = {
+        sortType: undefined,
+        orderBy: undefined
+      };
     }
 
     this.learningObjects = [];

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -215,8 +215,17 @@ export class LearningObjectsComponent
    *
    * @param direction the direction of the sort (ASC or DESC)
    */
-  sortByDate(direction: SortType) {
-    this.query = { ...this.query, sortType: direction };
+  sortByDate() {
+    if(!this.query.sortType) {
+      this.query['sortType'] = SortType.Descending;
+      this.query['orderBy'] = OrderBy.Date;
+    } else if (this.query.sortType.toString() === '-1') {
+      this.query.sortType = SortType.Ascending;
+    } else if (this.query.sortType.toString() === '1') {
+      delete this.query.sortType;
+      delete this.query.orderBy;
+    }
+
     this.learningObjects = [];
 
     this.getLearningObjects();


### PR DESCRIPTION
Partially completes [13627](https://app.shortcut.com/clarkcan/story/13627/add-toggle-for-sortby-on-admin-dashboard). The other PR is in Learning Object service.

In this PR:
- Replaces the date arrow buttons with one single button that displays sorting behaviors.
- Adds a third option to button to completely remove the option to sort the learning objects by date.
- By default, the learning objects are sorted by most recent first.
- On text input, the learning objects are not sorted by date at all. However, if the search field has no text, then it will sort the learning objects by most recent first.

## Before

<img width="1440" alt="Screen Shot 2022-08-22 at 2 08 53 PM" src="https://user-images.githubusercontent.com/93054689/186698309-6e9e1b31-aa60-4018-91b1-8290144516a0.png">

## Test Run (After)

https://user-images.githubusercontent.com/93054689/186698089-b31c360d-e88a-43c2-af9e-2190a27ee8ce.mov
