### PR TITLE
Change "About Us" to "About CLARK"

### DIFF
--- a/src/app/components/secondary-navbar/secondary-navbar.component.html
+++ b/src/app/components/secondary-navbar/secondary-navbar.component.html
@@ -1,5 +1,5 @@
 <div class="secondary-navbar" *ngIf="isDesktop && showNav">
-    <div class="item about-us" [routerLink]="['/about']">About Us</div>
+    <div class="item about-us" [routerLink]="['/about']">About CLARK</div>
     <div class="item collections" id="collectionsAnchor" #collectionsAnchor (click)="dropdowns.toggleCollectionDropdown()" tabindex="0">Collections
         <span *ngIf="!collectionsDropdown">
             <i class="fa fa-chevron-down"></i>

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -11,7 +11,7 @@
       </div>
       <div>
         <h3>Help</h3>
-        <a [routerLink]="['/about-us']" aria-label="About Us Page link" rel="noopener noreferrer"> About CLARK </a>
+        <a [routerLink]="['/about-us']" aria-label="About Us Page link" rel="noopener noreferrer"> About Us </a>
         <a aria-label="Clickable Ask for Help link" href="mailto:info@secured.team?subject=CLARK Help">{{ copy.HELP }}</a>
         <a [routerLink]="['/editorial-process']" aria-label="Editorial Process" rel="noopener noreferrer">Editorial Process</a>
         <a [routerLink]="['/contribute-page']" aria-label="Contribute Page" rel="noopener noreferrer"> Resources for Contributors </a>

--- a/src/app/cube/shared/footer/footer.copy.ts
+++ b/src/app/cube/shared/footer/footer.copy.ts
@@ -10,7 +10,7 @@ export const COPY = {
     ACCESSIBILITY: 'Accessibility',
     PRESS: 'Press and Media',
     OUTAGES: 'System Outages',
-    ABOUT: 'About Us',
+    ABOUT: 'About CLARK',
     SUBSCRIBE: 'Sign up for our Newsletter',
     ROADMAP: 'Roadmap'
 };


### PR DESCRIPTION
Completes story [13922](https://app.shortcut.com/clarkcan/story/13922/change-about-us-to-about-clark-in-navbar).

In this PR:
- Renames "About Us" to "About CLARK" in secondary navbar.
- Switches "About Us" and "About CLARK" names in footer.


<img width="759" alt="Screen Shot 2022-08-30 at 2 49 22 PM" src="https://user-images.githubusercontent.com/93054689/187518643-e3b1e2dd-72d9-4bf8-989d-93f7740c1ba0.png">
<img width="422" alt="Screen Shot 2022-08-30 at 2 49 39 PM" src="https://user-images.githubusercontent.com/93054689/187518684-32558971-590f-4804-8951-3240fd786c08.png">
