### PR TITLE
Animation Fixes for New Homepage

### DIFF
--- a/src/app/components/blogs/blogs.component.scss
+++ b/src/app/components/blogs/blogs.component.scss
@@ -89,9 +89,14 @@
         }
 
     }
+}
     
-    @media screen and(max-width:800px){
+@media screen and(max-width:800px) {
+    .blogs-component {
+        height: 100%;
+
         .first-view {
+            display: flex;
             flex-direction: column;
         }
         
@@ -101,6 +106,7 @@
                     width: auto;
                 }
             }
+
             p {
                 text-align: center;
             }

--- a/src/app/components/blogs/blogs.component.ts
+++ b/src/app/components/blogs/blogs.component.ts
@@ -83,7 +83,6 @@ export class BlogsComponent implements OnInit {
         this.blog = blogArray[0];
       }
     );
-    console.log(window.outerWidth < 1024, window.outerWidth);
   }
 
   /**

--- a/src/app/components/blogs/blogs.component.ts
+++ b/src/app/components/blogs/blogs.component.ts
@@ -24,7 +24,7 @@ import { Blog } from './types/blog';
       transition(':leave', [
         style({
           position: 'relative',
-          left: '0%'
+          left: '0%',
         }),
         animate('500ms ease-out', style({
           position: 'relative',
@@ -43,7 +43,8 @@ import { Blog } from './types/blog';
         animate('500ms ease-out', style({
           position: 'absolute',
           top: '0',
-          left: '40%',
+          left: '50%',
+          transform: 'translateX(-50%)',
           overflow: 'hidden'
         }))
       ]),
@@ -82,6 +83,7 @@ export class BlogsComponent implements OnInit {
         this.blog = blogArray[0];
       }
     );
+    console.log(window.outerWidth < 1024, window.outerWidth);
   }
 
   /**
@@ -105,5 +107,15 @@ export class BlogsComponent implements OnInit {
    */
   toggleCheckbox() {
     this.checkbox = !this.checkbox;
+  }
+
+  /**
+   * Disables the animations if the view width is smaller than laptop width
+   *
+   * @returns boolean determining if animations should be disabled
+   */
+  disableAnimations() {
+    const laptopWidth = 1024; // threshold to disable animations
+    return window.outerWidth < laptopWidth;
   }
 }

--- a/src/app/cube/home/help/help.component.html
+++ b/src/app/cube/home/help/help.component.html
@@ -1,17 +1,23 @@
 <div class="wrapper">
     <h1>What can we help you with today?</h1>
 
-    <div @helpCard class="grid" *ngIf="selectedTemplate === -1">
-        <clark-help-card *ngFor="let option of helpOptions" [option]="option" (activate)="selectTemplate(option.value)"></clark-help-card>
+    <div class="help-wrapper">
+        <div @helpCard class="grid" *ngIf="selectedTemplate === -1">
+            <clark-help-card *ngFor="let option of helpOptions" [option]="option" (activate)="selectTemplate(option.value)"></clark-help-card>
+        </div>
+        <clark-help-back-btn 
+            @helpBackButton
+            *ngIf="selectedTemplate === 0 || selectedTemplate === 1" 
+            [option]="helpOptions[selectedTemplate]" 
+            (activate)="selectTemplate(-1); handleFrameworkClicked();"
+            ></clark-help-back-btn>
+        <clark-teach-now 
+            @helpComponent
+            *ngIf="selectedTemplate === 0"
+            ></clark-teach-now>
+        <clark-build-program 
+            @helpComponent
+            *ngIf="selectedTemplate === 1"
+            ></clark-build-program>
     </div>
-    
-    <clark-help-back-btn 
-        @helpBackButton
-        *ngIf="selectedTemplate === 0 || selectedTemplate === 1" 
-        [option]="helpOptions[selectedTemplate]" 
-        (activate)="selectTemplate(-1); handleFrameworkClicked();"
-        ></clark-help-back-btn>
-    <clark-teach-now @helpComponent *ngIf="selectedTemplate === 0"></clark-teach-now>
-    <clark-build-program @helpComponent *ngIf="selectedTemplate === 1"></clark-build-program>
-
 </div>

--- a/src/app/cube/home/help/help.component.scss
+++ b/src/app/cube/home/help/help.component.scss
@@ -14,4 +14,8 @@ h1 {
 
 .wrapper {
     margin: 0 20px;
+
+        .help-wrapper {
+            position: relative;
+        }
 }

--- a/src/app/cube/home/help/help.component.ts
+++ b/src/app/cube/home/help/help.component.ts
@@ -43,7 +43,7 @@ import { BuildProgramComponentService } from 'app/cube/core/build-program-compon
       transition(':leave', [
         style({
           position: 'absolute',
-          top: '185px'
+          top: '0'
         }),
         animate('400ms 0ms ease-out', style({
           transform: 'translateX(166%)',
@@ -66,7 +66,7 @@ import { BuildProgramComponentService } from 'app/cube/core/build-program-compon
       transition(':leave', [
         style({
           position: 'absolute',
-          top: '275px'
+          top: '90px'
         }),
         animate('400ms 0ms ease-out', style({
           transform: 'translateX(50%)',

--- a/src/app/cube/home/home.component.scss
+++ b/src/app/cube/home/home.component.scss
@@ -3,3 +3,9 @@ clark-blogs {
     background-color: rgba(190, 190, 190, 0.7);
     width: 100%;
 }
+
+@media screen and (max-width: 768px) {
+    clark-blogs {
+        margin-bottom: 20px;
+    }
+}


### PR DESCRIPTION
Completes [13809](https://app.shortcut.com/clarkcan/story/13809/fix-animations-on-new-homepage).

In this PR:
- Fixes help component where leaving the view would result in the component overlapping with the splash
- Fixes mobile animation for the blogs component where the button would slide in before the rest of the component.

## Help Exit Animation
https://user-images.githubusercontent.com/93054689/187527064-93d904bf-074c-492e-942f-731af86cd3ba.mov
## Blogs Enter Animation (Mobile View)

https://user-images.githubusercontent.com/93054689/187527776-47585cb0-7479-4819-ae9e-14dbb3eae8f5.mov