### PR TITLE
removed routes and checked they weren't used

### DIFF
--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -118,14 +118,6 @@ export const USER_ROUTES = {
   SEARCH_USERS(query: any) {
     return `${environment.apiURL}/users/search?${querystring.stringify(query)}`;
   },
-  // Deprecated
-  VALIDATE_TOKEN(username) {
-    return `${environment.apiURL}/users/${encodeURIComponent(username)}/tokens`;
-  },
-  // Deprecated
-  LOGOUT(username) {
-    return `${environment.apiURL}/users/${encodeURIComponent(username)}/tokens`;
-  },
   GET_MY_LEARNING_OBJECTS(username, filters: any, query: string, childId?: string) {
     // Onion
     let uri = `${environment.apiURL}/users/${encodeURIComponent(
@@ -194,12 +186,6 @@ export const USER_ROUTES = {
       environment.apiURL
       }/users/${params.userId}/learning-objects/${params.learningObjectId}/submissions?${q}`;
   },
-  // Deprecated
-  ADD_LEARNING_OBJET_TO_COLLECTION(learningObjectId: string) {
-    return `${environment.apiURL}/learning-objects/${encodeURIComponent(
-      learningObjectId
-    )}/collections`;
-  },
   GET_LEARNING_OBJECT(id) {
     return `${environment.apiURL}/learning-objects/${encodeURIComponent(id)}`;
   },
@@ -212,18 +198,6 @@ export const USER_ROUTES = {
     return `${environment.apiURL}/users/${encodeURIComponent(
       username
     )}/learning-objects/multiple/${encodeURIComponent(learningObjectNames)}`;
-  },
-  // Deprecated
-  POST_FILE_TO_LEARNING_OBJECT(id: string, username: string) {
-    return `${environment.contentManagerURL}/users/${encodeURIComponent(
-      username
-    )}/learning-objects/${id}/files`;
-  },
-  // Deprecated
-  POST_FILE_TO_LEARNING_OBJECT_ADMIN(id: string, username: string) {
-    return `${environment.contentManagerURLAdmin}/users/${encodeURIComponent(
-      username
-    )}/learning-objects/${id}/files`;
   },
   DELETE_FILE_FROM_LEARNING_OBJECT({
     authorUsername,
@@ -385,11 +359,6 @@ export const PUBLIC_LEARNING_OBJECT_ROUTES = {
   GET_COLLECTION_META(name: string) {
     return `${environment.apiURL}/collections/${encodeURIComponent(name)}/meta`;
   },
-  GET_USERS_PUBLIC_LEARNING_OBJECTS(username: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(
-      username
-    )}/learning-objects`;
-  },
   GET_LEARNING_OBJECT_PARENTS(username: string, id: string) {
     return `${environment.apiURL}/users/${username}/learning-objects/${id}/parents`;
   },
@@ -455,11 +424,6 @@ export const RATING_ROUTES = {
     )}/ratings/${encodeURIComponent(
       params.ratingId
     )}/responses`;
-  },
-  GET_RESPONSE(params: { learningObjectId: string; ratingId: string }) {
-    return `${environment.apiURL}/learning-objects/${encodeURIComponent(
-      params.learningObjectId
-    )}/ratings/${encodeURIComponent(params.ratingId)}/responses`;
   },
   UPDATE_RESPONSE(params: {
     username: string;
@@ -540,11 +504,6 @@ export const RATING_ROUTES = {
     )}/ratings/${encodeURIComponent(
       params.ratingId
     )}/flags`;
-  },
-  GET_USER_RATINGS(username: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(
-      username
-    )}/ratings`;
   }
 };
 export const MISC_ROUTES = {
@@ -558,7 +517,6 @@ export const STATS_ROUTES = {
   // fetches downloads and saves for ALL objects in system
   LIBRARY_METRICS: `${environment.apiURL}/learning-objects/metrics`,
   // fetches the blooms distribution
-  OUTCOMES_STATS: `${environment.apiURL}/outcomes/stats`,
   USERS_STATS: `${environment.apiURL}/users/stats` // nothing new
 };
 

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -516,7 +516,6 @@ export const STATS_ROUTES = {
   LEARNING_OBJECT_STATS: `${environment.apiURL}/learning-objects/stats`,
   // fetches downloads and saves for ALL objects in system
   LIBRARY_METRICS: `${environment.apiURL}/learning-objects/metrics`,
-  // fetches the blooms distribution
   USERS_STATS: `${environment.apiURL}/users/stats` // nothing new
 };
 


### PR DESCRIPTION
Removed: 
- VALIDATE_TOKEN
- LOGOUT
- ADD_LEARNING_OBJET_TO_COLLECTION
- POST_FILE_TO_LEARNING_OBJECT
- POST_FILE_TO_LEARNING_OBJECT_ADMIN
- GET_USERS_PUBLIC_LEARNING_OBJECTS
- GET_RESPONSE
- GET_USER_RATINGS
- OUTCOMES_STATS

This Pr completes [1274](https://app.shortcut.com/clarkcan/story/1274/remove-deprecated-routes-from-clark-client)
