### PR TITLE
Fix New Homepage Featured Objects Error

### DIFF
--- a/src/app/core/featuredObjects.service.spec.ts
+++ b/src/app/core/featuredObjects.service.spec.ts
@@ -1,21 +1,27 @@
 import { TestBed } from '@angular/core/testing';
 import { FeaturedObjectsService } from './featuredObjects.service';
 import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
+import { ProfileService } from './profiles.service';
+import { AuthService } from './auth.service';
 
 
 describe('FeaturedService', () => {
   let featuredObjectsService: FeaturedObjectsService;
+  let profileService: ProfileService;
+  let authService: AuthService;
   let httpTestingController: HttpTestingController;
 
   beforeAll(() => {
     TestBed.configureTestingModule({
     imports: [HttpClientTestingModule],
-    providers: [FeaturedObjectsService],
+    providers: [FeaturedObjectsService, ProfileService, AuthService],
     teardown: { destroyAfterEach: false }
 });
 
     httpTestingController = TestBed.inject(HttpTestingController);
     featuredObjectsService = TestBed.inject(FeaturedObjectsService);
+    profileService = TestBed.inject(ProfileService);
+    authService = TestBed.inject(AuthService);
   });
 
   afterEach(() => {

--- a/src/app/core/featuredObjects.service.ts
+++ b/src/app/core/featuredObjects.service.ts
@@ -64,7 +64,6 @@ export class FeaturedObjectsService {
       // Grabs the complete Learning Object from the LO database
       // For some reason, the method itself returns the full Learning Object,
       //    but when entered into the array it turns into a Promise.
-      // TODO: Refactor the profileService method
       return await this.profileService.fetchLearningObject({
         author: undefined,
         cuid: learningObject.cuid

--- a/src/app/core/featuredObjects.service.ts
+++ b/src/app/core/featuredObjects.service.ts
@@ -6,6 +6,7 @@ import { catchError, retry } from 'rxjs/operators';
 import { throwError, BehaviorSubject } from 'rxjs';
 import { Query } from 'app/interfaces/query';
 import * as querystring from 'querystring';
+import { ProfileService } from './profiles.service';
 
 @Injectable({
   providedIn: 'root'
@@ -21,7 +22,8 @@ export class FeaturedObjectsService {
   private headers = new HttpHeaders();
   featuredObjectIds: string[];
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient,
+              private profileService: ProfileService) { }
 
   get featuredObjects() {
     return this._featuredObjects$.asObservable();
@@ -33,8 +35,12 @@ export class FeaturedObjectsService {
     return this._submitError$.asObservable();
   }
 
+  /**
+   * Gets 5 featured full learning objects and saves it in the _featuredObjects subject
+   */
   async getFeaturedObjects() {
-    return await this.http
+    // Grabs featured Learning Objects from the Featured Database
+    const objects: LearningObject[] = await this.http
       .get(FEATURED_ROUTES.GET_FEATURED)
       .pipe(
         retry(3),
@@ -52,8 +58,24 @@ export class FeaturedObjectsService {
         } else if (featuredObjects.length !== 5) {
           this._submitError$.next(true);
         }
-        this._featuredObjects$.next(Object.assign({}, this.featuredStore).featured);
+        return featuredObjects;
       });
+    const promisedObjectsArray = objects.map(async (learningObject: LearningObject) => {
+      // Grabs the complete Learning Object from the LO database
+      // For some reason, the method itself returns the full Learning Object,
+      //    but when entered into the array it turns into a Promise.
+      // TODO: Refactor the profileService method
+      return await this.profileService.fetchLearningObject({
+        author: undefined,
+        cuid: learningObject.cuid
+      });
+    });
+    // Resolves the array of Promises into an array of complete Learning Objects
+    this.featuredStore.featured = await Promise.all(promisedObjectsArray).then(async (learningObject: LearningObject[]) => {
+      return learningObject;
+    });
+    // Save the array into the _featuredObjects subject to be observed
+    this._featuredObjects$.next(Object.assign({}, this.featuredStore).featured);
   }
 
   filterOutFeaturedObjects() {

--- a/src/app/cube/home/learning-object-info/learning-objects/learning-objects.component.ts
+++ b/src/app/cube/home/learning-object-info/learning-objects/learning-objects.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { LearningObject, User } from '@entity';
 import { FeaturedObjectsService } from 'app/core/featuredObjects.service';
-import { LearningObjectService } from 'app/core/learning-object.service';
 import { UserService } from 'app/core/user.service';
 import { UsageStatsService } from 'app/cube/core/usage-stats/usage-stats.service';
 
@@ -17,7 +16,6 @@ export class LearningObjectsComponent implements OnInit {
   page='homepage';
 
   constructor(private featureService: FeaturedObjectsService,
-              private learningObjectService: LearningObjectService,
               private userService: UserService,
               private usageStatsService: UsageStatsService) { }
 
@@ -28,15 +26,6 @@ export class LearningObjectsComponent implements OnInit {
     await this.featureService.getFeaturedObjects();
     await this.featureService.featuredObjects.subscribe(objects => {
       this.featuredObject = objects[1];
-    });
-    await this.learningObjectService.fetchLearningObjectWithResources({
-      author: this.featuredObject.author._name,
-      cuidInfo: {
-        cuid: this.featuredObject.cuid
-      },
-      id: this.featuredObject.id
-    }, ['outcomes']).subscribe((object: LearningObject) => {
-      this.featuredObject = object;
     });
   }
 


### PR DESCRIPTION
Fixes bug [14269](https://app.shortcut.com/clarkcan/story/14269/fix-new-homepage-featured-objects-section-error).

Note:
- Changing the `featuredObjects` service led to changes to the related unit test file for `featuredObjects`. Let me know if these test file changes should be done differently.