### PR TITLE
fix: [sc-14598] Mobile profile objects not displaying

### DIFF
--- a/src/app/cube/user-profile/components/profile-learning-objects/profile-learning-objects.component.html
+++ b/src/app/cube/user-profile/components/profile-learning-objects/profile-learning-objects.component.html
@@ -122,7 +122,7 @@
                             <ul class="menu">
                                 <li *ngFor="let collection of collectionsReleased; let indexOfCollection=index"
                                     tabindex="0"
-                                    (click)="content(tabMain, collectionsReleased[indexOfCollection].abvname); activateCollectionTab(indexOfCollection); toggleDropdown(false)">
+                                    (click)="content(tabMain, collection.abvName); activateCollectionTab(indexOfCollection); toggleDropdown(false)">
                                     {{collection.name}}</li>
                             </ul>
                         </div>


### PR DESCRIPTION
Story details: https://app.shortcut.com/clarkcan/story/14598

This PR addresses a small issue in clark-client on the profiles page in mobile view. 