### PR TITLE
Remove Status' from array

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -56,8 +56,6 @@ export class ChangeStatusModalComponent implements OnInit {
   hasNextModalPage() {
     return [
       LearningObject.Status.RELEASED,
-      LearningObject.Status.ACCEPTED_MAJOR,
-      LearningObject.Status.ACCEPTED_MINOR,
       LearningObject.Status.REJECTED,
     ].includes(this.selectedStatus as LearningObject.Status);
   }


### PR DESCRIPTION
This PR completes [Temporarily disable status change emails for review --> major or minor changes](https://app.shortcut.com/clarkcan/story/13839/temporarily-disable-status-change-emails-for-review-major-or-minor-changes)

The Accepted major/minor status' were removed from the array that would force the "send email to author modal" to pop up. 
If anyone has a better way to "Toggle" between the two states im open for comments.

Here is a quick video on how the workflow looks like now:

https://user-images.githubusercontent.com/72173743/193080986-24efd396-c6c6-40d4-b9bc-484cf8ab572b.mp4

