### PR TITLE
chore: [sc-14590] Allow edit for authors on details page

### DIFF
--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -1,5 +1,5 @@
 <div class="inner">
-  <div *ngIf="!isReleased && !revisedVersion" class="download-warning" tip="This learning object is pending review and may be downloaded when the review is complete."
+  <div *ngIf="isSubmitted && !isReleased && !revisedVersion" class="download-warning" tip="This learning object is pending review and may be downloaded when the review is complete."
     tipPosition="top">
     <i class="fas fa-exclamation"></i>Review Pending
   </div>

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -78,8 +78,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   ) { }
 
   async ngOnInit(): Promise<void> {
-    const userName = this.auth.username;
-    this.userIsAuthor = (this.learningObject.author.username === userName);
+    this.userIsAuthor = (this.learningObject.author.username === this.auth.username);
     this.auth.group
       .pipe(takeUntil(this.destroyed$))
       .subscribe(() => {

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -78,10 +78,12 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   ) { }
 
   async ngOnInit(): Promise<void> {
+    const userName = this.auth.username;
+    this.userIsAuthor = (this.learningObject.author.username === userName);
     this.auth.group
       .pipe(takeUntil(this.destroyed$))
       .subscribe(() => {
-        this.userCanRevise = this.auth.hasEditorAccess();
+        this.userCanRevise = this.auth.hasEditorAccess() || this.userIsAuthor;
         this.hasReviewerAccess = this.auth.hasReviewerAccess();
       });
     this.hasDownloadAccess = (this.hasReviewerAccess || this.isReleased) && this.auth.user !== null;
@@ -90,8 +92,6 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
     await this.libraryService.getLibrary();
     this.saved = this.libraryService.has(this.learningObject);
-    const userName = this.auth.username;
-    this.userIsAuthor = (this.learningObject.author.username === userName);
     this.getCollection();
     this.libraryService.loaded
       .subscribe(val => {
@@ -101,21 +101,21 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   }
 
   get mapAndTag() {
-    let canMapAndTag = false;
-    if (this.auth.user && this.auth.user.accessGroups) {
+    if (this.auth.user && this.auth.user.accessGroups && !this.userIsAuthor) {
       const privileges = ['admin', 'editor', 'mapper', 'curator', 'reviewer'];
-      for (let i = 0; i < privileges.length; i++) {
-        if (this.auth.user.accessGroups.includes(privileges[i]) ||
-          this.auth.user.accessGroups.some(res => res.includes(privileges[i]))) {
-            canMapAndTag = true;
-        }
+      if(this.auth.user.accessGroups.some(priv => privileges.includes(priv))) {
+        return true;
       }
     }
-    return canMapAndTag;
+    return false;
   }
 
   get isReleased(): boolean {
     return this.learningObject.status === LearningObject.Status.RELEASED;
+  }
+
+  get isSubmitted(): boolean {
+    return this.learningObject.status !== LearningObject.Status.UNRELEASED;
   }
 
   async addToLibrary(download?: boolean) {
@@ -132,7 +132,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
       );
     }
     try {
-      if (!this.userIsAuthor && this.learningObject.status === LearningObject.Status.RELEASED) {
+      if (!this.userIsAuthor && this.isReleased) {
         this.saved = this.libraryService.has(this.learningObject);
 
         if (!this.saved) {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -43,15 +43,16 @@ export class EditorialActionPadComponent implements OnInit {
   return (this.learningObject.status === 'waiting' || (this.revisedLearningObject && this.revisedLearningObject.status === 'waiting')) ||
          (this.learningObject.status === 'review' || (this.revisedLearningObject && this.revisedLearningObject.status === 'review')) ||
          (this.learningObject.status === 'proofing' || (this.revisedLearningObject && this.revisedLearningObject.status === 'proofing')) ||
-         (this.revisedLearningObject && this.revisedLearningObject.status === 'unreleased');
+         (this.learningObject.status === 'unreleased' ||
+         (this.revisedLearningObject && this.revisedLearningObject.status === 'unreleased'));
   }
 
   // Determines if an editor is not permitted to create a revision or make edits
   get notPermitted() {
     return (this.learningObject.status === 'released' &&
-    (this.revisedLearningObject &&
+      (this.revisedLearningObject &&
       (this.revisedLearningObject.status === 'unreleased' || this.revisedLearningObject.status === 'rejected'))) ||
-    (this.learningObject.status === 'unreleased' || this.learningObject.status === 'rejected');
+     (this.learningObject.status === 'rejected');
   }
 
   // Handles opening the create revision modal


### PR DESCRIPTION
Story details: https://app.shortcut.com/clarkcan/story/14590

Authors can now edit from the details page until their object is released

Authors can no longer tag their own objects

"! Review Pending" no longer appears before the object is submitted for review