### PR TITLE
Andy/fix edit for authors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.0.5",
+      "version": "5.0.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -10,7 +10,7 @@
           <ng-container *ngTemplateOutlet="libraryButtonsTemplate"></ng-container>
         </div>
       </ng-container>
-      <clark-editorial-action-pad *ngIf="userCanRevise" [hasRevision]="hasRevision" [learningObject]="learningObject" [revisedLearningObject]="revisedLearningObject"></clark-editorial-action-pad>
+      <clark-editorial-action-pad *ngIf="userCanRevise" [userIsAuthor]="userIsAuthor" [hasRevision]="hasRevision" [learningObject]="learningObject" [revisedLearningObject]="revisedLearningObject"></clark-editorial-action-pad>
     </div>
     <ng-container *ngIf="!auth.user">
       <div tabindex="0" class="action-message" id="login-msg">Please

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -19,6 +19,7 @@ export class EditorialActionPadComponent implements OnInit {
 
   @Input() hasRevision: boolean;
   @Input() learningObject: LearningObject;
+  @Input() userIsAuthor: boolean;
   openRevisionModal: boolean;
   showPopup = false;
 
@@ -67,12 +68,13 @@ export class EditorialActionPadComponent implements OnInit {
     this.openRevisionModal = false;
   }
 
-  // Redirects the editor to the builder to make edits to a waiting, review, or proofing object
+  // Redirects the editors and authors to the builder to make edits to a waiting, review, or proofing object
   editLearningObject() {
+    const userOrAdminRoute = (this.userIsAuthor) ? 'onion' : 'admin';
     if (this.revisedLearningObject) {
-      this.router.navigate([`/admin/learning-object-builder/${this.revisedLearningObject.id}`]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.revisedLearningObject.id]);
     } else {
-      this.router.navigate([`admin/learning-object-builder/${this.learningObject.id}`]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.learningObject.id]);
     }
   }
 


### PR DESCRIPTION
this is a bug fix for a chore that was deployed on 10/6/22 the edit button on the details page was originally intended only for admins but can now be used by authors as well