### PR TITLE
Object naming error has errors

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -636,7 +636,9 @@ export class BuilderStore {
       this.learningObject = new LearningObject(learningObject);
     }
 
-    this.saveObject(data, true);
+    if(this.validator.saveable) {
+      this.saveObject(data, true);
+    }
   }
 
   private addContributor(user: User) {


### PR DESCRIPTION
PR 1 of 2 for [15046](https://app.shortcut.com/clarkcan/story/15046/object-naming-error-has-errors). Another bug for the same story is in learning-object-service.

This bug begins when a user tries to enter a learning object name longer than the given limit. It throws the exceeded character limit error initially, but a new error shows up with an empty toaster message. (see the second and third image in the Shortcut story)

The builder properly checks and throws the error in the client when the name exceeds the limit. However, the builder will still attempt to save the object to the database. Learning-object-service would then throw its own error, causing the empty toaster message. The solution is to save the object only when the builder detects no errors.

