### PR TITLE
Alphabetizes footer platform section and adds privacy link

### DIFF
--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -4,10 +4,11 @@
       <div>
         <h3>Platform</h3>
         <a [routerLink]="['/system/accessibility-statement']" aria-label="Accessbility Statement link" target="_blank" rel="noopener noreferrer">{{ copy.ACCESSIBILITY }}</a>
+        <a aria-label="Clickable Privacy Notice link" href="https://secured.team/privacy-policy/" target="_blank">{{ copy.PRIVACY }}</a>
+        <a aria-label="Clickable Roadmap link" href="https://securedteam.notion.site/361b86788dc2493e95c990d77594e6ed?v=7bfe3912023b41f28739e4976d6f9861" target="_blank" rel="noopener noreferrer">{{ copy.ROADMAP }}</a>
         <a [routerLink]="['/system/status']" aria-label="Clickable System Outages link" target="_blank" rel="noopener noreferrer">{{ copy.OUTAGES }}</a>
         <a [routerLink]="['/system/termsofservice']" aria-label="Clickable Terms of Service link" target="_blank" rel="noopener noreferrer">{{ copy.TERMS }}</a>
         <a aria-label="Clickable Usage Statistics link" [routerLink]="['/system/usage']" target="_blank" rel="noopener noreferrer">{{ copy.USAGE }}</a>
-        <a aria-label="Clickable Roadmap link" href="https://securedteam.notion.site/361b86788dc2493e95c990d77594e6ed?v=7bfe3912023b41f28739e4976d6f9861" target="_blank" rel="noopener noreferrer">{{ copy.ROADMAP }}</a>
       </div>
       <div>
         <h3>Help</h3>

--- a/src/app/cube/shared/footer/footer.copy.ts
+++ b/src/app/cube/shared/footer/footer.copy.ts
@@ -12,5 +12,6 @@ export const COPY = {
     OUTAGES: 'System Outages',
     ABOUT: 'About CLARK',
     SUBSCRIBE: 'Sign up for our Newsletter',
-    ROADMAP: 'Roadmap'
+    ROADMAP: 'Roadmap',
+    PRIVACY: 'Privacy Policy'
 };


### PR DESCRIPTION
Adds privacy link to CLARK footer. Sorts platform section to be alphabetized. [15073](https://app.shortcut.com/clarkcan/story/15073/add-privacy-policy-page-to-clark-and-card).
![Screen Shot 2022-10-13 at 2 56 52 PM](https://user-images.githubusercontent.com/93054689/195683172-a5003125-de25-4463-b796-935d3d12443b.png)
