### PR TITLE
Modal click registers when hovering over overlay

### DIFF
--- a/src/app/shared/directives/activate.directive.ts
+++ b/src/app/shared/directives/activate.directive.ts
@@ -14,7 +14,7 @@ export class ActivateDirective {
     this.el.nativeElement.style.cursor = 'pointer';
   }
 
-  @HostListener('click', ['$event'])
+  @HostListener('mousedown', ['$event'])
   @HostListener('keypress', ['$event'])
   handleActivate(event: KeyboardEvent | MouseEvent) {
 


### PR DESCRIPTION
Story [14635](https://app.shortcut.com/clarkcan/story/14635/modal-click-registers-when-hovering-over-overlay).

## About the Bug
If the mouseup event occurs outside of the pop-up when the mousedown event happens inside the pop-up, it will close. This is problematic since users may click and drag inside an input field and end up with their mouse outside the pop-up, leading to it closing. See the video attached to the story for details.

## Note about the Fix
This is a potential solution to this problem. However, I recognize that the directive is used everywhere else in the client. It can be dangerous to change something here, but I'm also hesitant to create a completely identical directive for the purpose of this story.