### PR TITLE
Adds philosophy component 🪦

### DIFF
--- a/src/app/cube/content-pages/about-us/philosophy/philosophy.component.html
+++ b/src/app/cube/content-pages/about-us/philosophy/philosophy.component.html
@@ -1,0 +1,11 @@
+<section class="philosophy">
+  <div class="philosophy__values">
+    <div attr.aria-label="{{ value.title }}: {{ value.items.join(', ') }}" *ngFor="let value of values" class="values__wrapper">
+      <i class="{{ value.icon }}"></i>
+      <p aria-hidden="true" class="values__title">{{ value.title }}</p>
+      <ul aria-hidden="true" class="values__list">
+        <li *ngFor="let item of value.items" class="values__list-item">{{ item }}</li>
+      </ul>
+    </div>
+  </div>
+</section>

--- a/src/app/cube/content-pages/about-us/philosophy/philosophy.component.scss
+++ b/src/app/cube/content-pages/about-us/philosophy/philosophy.component.scss
@@ -1,0 +1,52 @@
+@import 'vars.scss';
+
+.philosophy {
+  padding: 40px;
+  background: white;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+}
+
+.philosophy__values {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 45px 0 25px;
+  width: 100%;
+  max-width: 1450px;
+  flex-wrap: wrap;
+  color: $darker-grey;
+  
+  .values__wrapper {
+    width: 210px;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: center;
+    position: relative;
+    margin: 20px 10px;
+
+    .svg-inline--fa {
+      font-size: 50px;
+    }
+  }
+
+  .values__title {
+    margin-top: 10px;
+    font-size: $large;
+    width: fit-content;
+  }
+
+  .values__list {
+    width: fit-content;
+    min-width: 175px;
+    padding: 0;
+    text-align: center;
+    font-size: $normal;
+    color: $dark-grey;
+  }
+
+  .values__list-item {
+    list-style-type: none;
+  }
+}

--- a/src/app/cube/content-pages/about-us/philosophy/philosophy.component.ts
+++ b/src/app/cube/content-pages/about-us/philosophy/philosophy.component.ts
@@ -1,0 +1,60 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'clark-philosophy',
+  templateUrl: './philosophy.component.html',
+  styleUrls: ['./philosophy.component.scss']
+})
+export class AboutPhilosophyComponent implements OnInit {
+  values = [
+    {
+      title: 'Easy In',
+      items: [
+        'Bloom\'s Taxonomy',
+        'Mutually Beneficial',
+        'Easy Updates'
+      ],
+      icon: 'fal fa-cloud-upload'
+    },
+    {
+      title: 'Quality Curriculum',
+      items: [
+        'Peer Review',
+        'Active Curators',
+        'Clear Learning Outcomes'
+      ],
+      icon: 'fal fa-check'
+    },
+    {
+      title: 'Easy Out',
+      items: [
+        'Free Content',
+        'No Hooks',
+        'Faceted Search'
+      ],
+      icon: 'fal fa-cloud-download'
+    },
+    {
+      title: 'Relevant',
+      items: [
+        'Curriculum Revisions',
+        'Crowdsourced Reviews',
+        'Pertinent Topics',
+      ],
+      icon: 'fal fa-history'
+    },
+    {
+      title: 'Ownership',
+      items: [
+        'Content',
+        'Format',
+        'Web Presence'
+      ],
+      icon: 'fal fa-grin-beam'
+    }
+  ];
+
+  constructor() { }
+
+  ngOnInit(): void { }
+}

--- a/src/app/cube/cube.module.ts
+++ b/src/app/cube/cube.module.ts
@@ -54,6 +54,7 @@ import { ProfileLearningObjectsComponent } from './user-profile/components/profi
 import { ProfileHeaderComponent } from './user-profile/components/profile-header/profile-header.component';
 import { EditProfileComponent } from './user-profile/components/edit-profile/edit-profile.component';
 import { HomeModule } from './home/home.module';
+import { AboutPhilosophyComponent } from './content-pages/about-us/philosophy/philosophy.component';
 
 
 /**
@@ -87,6 +88,7 @@ import { HomeModule } from './home/home.module';
     ProfileLearningObjectsComponent,
     ProfileHeaderComponent,
     EditProfileComponent,
+    AboutPhilosophyComponent,
   ],
   schemas: [
     NO_ERRORS_SCHEMA,


### PR DESCRIPTION
[15679](https://app.shortcut.com/clarkcan/story/15679/about-us-philosophy-section-is-missing-an-image)

The bug was referencing an incorrect philosophy component. The old philosophy component somehow disappeared, so we brought it back from the grave 🪦 (aka pre 5.0.0)

Note that the component has been renamed to `AboutPhilosophyComponent` to separate itself from the other `PhilosophyComponent`.

![Screen Shot 2022-11-10 at 2 08 32 PM](https://user-images.githubusercontent.com/93054689/201184742-f8eb5e0b-6811-4932-9640-29ec5e208207.png)
