### PR TITLE
Collections shows empty page

### DIFF
--- a/src/app/collection/collection.routing.ts
+++ b/src/app/collection/collection.routing.ts
@@ -10,7 +10,8 @@ import { NotFoundComponent } from 'app/not-found.component';
 const collection_routes: Routes = [
     {
         path: '',
-        component: CollectionIndexComponent,
+        redirectTo: '/c',
+        pathMatch: 'full'
     },
     {
         path: 'nice',


### PR DESCRIPTION
[15686](https://app.shortcut.com/clarkcan/story/15686/collections-shows-empty-page)

Since /collections shows an empty component, we will just redirect /collections to /c, which is a list of collections.