### PR TITLE
add faq section

### DIFF
--- a/src/app/cube/collection-details/collection-details.component.html
+++ b/src/app/cube/collection-details/collection-details.component.html
@@ -28,5 +28,9 @@
       </a>
     </div>
     <cube-featured [collection]="key"></cube-featured>
+    <div class="faq-section" *ngIf="collection?.faq">
+      <div class="header">Frequently Asked Questions</div>
+      <clark-faq-section [faq]="collection?.faq"></clark-faq-section>      
+    </div>
   </section>
 </div>

--- a/src/app/cube/collection-details/collection-details.component.scss
+++ b/src/app/cube/collection-details/collection-details.component.scss
@@ -141,4 +141,13 @@
       }
     }
   }
+
+  .faq-section {
+    .header {
+      padding: 20px;
+      color: $dark-grey;
+      font-weight: bold;
+      font-size: $larger;
+    }
+  }
 }

--- a/src/app/cube/collection-details/collection-details.module.ts
+++ b/src/app/cube/collection-details/collection-details.module.ts
@@ -7,6 +7,9 @@ import { CubeSharedModule } from '../shared/cube-shared.module';
 import { SharedModule } from '../../shared/shared.module';
 import { RouterModule } from '@angular/router';
 import { ActionPanelComponent } from './components/action-panel/action-panel.component';
+import { FaqSectionComponent } from './faq-section/faq-section.component';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   imports: [
@@ -14,9 +17,15 @@ import { ActionPanelComponent } from './components/action-panel/action-panel.com
     FormsModule,
     CubeSharedModule,
     SharedModule,
-    RouterModule
+    RouterModule,
+    MatExpansionModule,
+    MatDividerModule
   ],
   exports: [],
-  declarations: [CollectionDetailsComponent, ActionPanelComponent]
+  declarations: [
+    CollectionDetailsComponent,
+    ActionPanelComponent,
+    FaqSectionComponent
+  ]
 })
 export class CollectionModule {}

--- a/src/app/cube/collection-details/faq-section/faq-section.component.html
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.html
@@ -1,0 +1,13 @@
+<mat-accordion>
+    <mat-expansion-panel *ngFor="let qa of faq" class="panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title class="title">
+            {{ qa.question }}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
+        <mat-divider></mat-divider>
+        <p>
+          {{ qa.answer }}
+        </p>
+      </mat-expansion-panel>
+</mat-accordion>

--- a/src/app/cube/collection-details/faq-section/faq-section.component.html
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.html
@@ -1,8 +1,8 @@
 <mat-accordion>
     <mat-expansion-panel *ngFor="let qa of faq" class="panel">
         <mat-expansion-panel-header>
-          <mat-panel-title class="title">
-            {{ qa.question }}
+          <mat-panel-title>
+            <p class="title-content">{{ qa.question }}</p>
           </mat-panel-title>
         </mat-expansion-panel-header>
         <mat-divider></mat-divider>

--- a/src/app/cube/collection-details/faq-section/faq-section.component.scss
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.scss
@@ -1,6 +1,6 @@
 .panel {
     margin-top: 20px;
-    .title {
-        margin: 1px;
+    .title-content {
+        margin: 10px 0;
     }
 }

--- a/src/app/cube/collection-details/faq-section/faq-section.component.scss
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.scss
@@ -1,0 +1,6 @@
+.panel {
+    margin-top: 20px;
+    .title {
+        margin: 1px;
+    }
+}

--- a/src/app/cube/collection-details/faq-section/faq-section.component.spec.ts
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FaqSectionComponent } from './faq-section.component';
+
+describe('FaqSectionComponent', () => {
+  let component: FaqSectionComponent;
+  let fixture: ComponentFixture<FaqSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ FaqSectionComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FaqSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cube/collection-details/faq-section/faq-section.component.ts
+++ b/src/app/cube/collection-details/faq-section/faq-section.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+interface CollectionFaq {
+  question: String
+  answer: String
+}
+
+@Component({
+  selector: 'clark-faq-section',
+  templateUrl: './faq-section.component.html',
+  styleUrls: ['./faq-section.component.scss']
+})
+export class FaqSectionComponent implements OnInit {
+
+  @Input() faq: CollectionFaq[] = [];
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
This story completes [add faq section to collection page](https://app.shortcut.com/clarkcan/story/15235/add-faq-section-to-collection-page)

In the collection collection within mongodb a new field will need to be added to collections that have an faq section. Format:
```json
{
     "question": "A question",
     "answer": "An answer"
}
```

Screenshots:

## Mobile View
<img width="480" alt="Screen Shot 2022-11-22 at 10 50 13 AM" src="https://user-images.githubusercontent.com/72173743/203362826-16b13b3f-555c-4c00-a8e7-325f50cdbee9.png">

## Collection page with faq section
<img width="1739" alt="Screen Shot 2022-11-22 at 11 06 08 AM" src="https://user-images.githubusercontent.com/72173743/203363256-7d53097b-8e9b-4787-9520-386279820cf5.png">

## Collection page without faq section
<img width="1931" alt="Screen Shot 2022-11-22 at 10 50 37 AM" src="https://user-images.githubusercontent.com/72173743/203362830-8d2d9afa-f20e-4721-beb1-2efd4d1c9df9.png">
