### PR TITLE
add admin dashboard button to moble view

### DIFF
--- a/src/app/components/primary-navbar/primary-navbar.component.html
+++ b/src/app/components/primary-navbar/primary-navbar.component.html
@@ -102,6 +102,7 @@
                 <div class="side-padding-20">
                     <ul class="menu-items">
                         <li [routerLink]="['library']">Your Library</li>
+                        <li [routerLink]="['admin']" *ngIf="auth.hasCuratorAccess()">{{ auth.hasEditorAccess() ? 'Admin' : 'Curator' }} Dashboard</li>
                         <li (click)="auth.logout()">Sign Out</li>
                     </ul>
                 </div>


### PR DESCRIPTION
This PR completes [Mobile menu does not have the same options as nav bar](https://app.shortcut.com/clarkcan/story/15835/mobile-menu-does-not-have-the-same-options-as-nav-bar)

# Screenshots

## Non-Admin View
<img width="332" alt="Screen Shot 2022-11-22 at 11 46 56 AM" src="https://user-images.githubusercontent.com/72173743/203373438-8b5ac1fe-a62d-487c-92ea-7d68e57b637d.png">

## Admin View
<img width="335" alt="Screen Shot 2022-11-22 at 11 47 26 AM" src="https://user-images.githubusercontent.com/72173743/203373439-66bc164c-ff57-4514-86dd-85f28fe61eea.png">
