### PR TITLE
Bug/sc 17688/collection page without logo contains collection

### DIFF
--- a/src/app/cube/collection-details/collection-details.component.html
+++ b/src/app/cube/collection-details/collection-details.component.html
@@ -2,7 +2,7 @@
   <section class="hero">
       <div class="inner">
         <div class="logos" [ngClass]="{'long': collection?.abvName === 'ncyte' || collection?.abvName === 'cae_community' || collection?.abvName === 'nice' || collection?.abvName === 'deterlab' || collection?.abvName === '502_project' || collection?.abvName === 'ncc'}">
-          <img *ngIf="pictureLocation" src="{{ pictureLocation }}" alt="collection logo">
+          <img *ngIf="pictureLocation" src="{{ pictureLocation }}" alt="collection logo" (error)="resetPictureLocation()">
           <div *ngIf="!pictureLocation" class="title__icon">
             <i class="far fa-cubes"></i>
           </div>

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -57,6 +57,8 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
       && this.collection.abvName !== 'plan c'
     ) {
       this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
+    } else {
+      this.pictureLocation = null;
     }
     if (this.collection.abvName === 'plan c') {
       this.showContribute = true;

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -51,18 +51,20 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
       }
     });
     this.key.next(this.collection.abvName);
-    if (
-      this.collection.abvName !== 'intro_to_cyber'
-      && this.collection.abvName !== 'secure_coding_community'
-      && this.collection.abvName !== 'plan c'
-    ) {
-      this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
-    } else {
-      this.pictureLocation = null;
-    }
+
+    this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
+
     if (this.collection.abvName === 'plan c') {
       this.showContribute = true;
     }
     this.titleService.setTitle('CLARK | ' + this.collection.name);
+  }
+
+  /**
+   * If a picture is not found, the picture location is reset to null
+   * This will load the default image
+   */
+  resetPictureLocation() {
+    this.pictureLocation = null;
   }
 }


### PR DESCRIPTION
This PR adds an `(error)` statement to the img tag that would load a collections logo. If a logo is not found, the default image is used. This eliminates having to list out all the collections that do not have a logo.