### PR TITLE
Implemented default sort on browse page to be newest - oldest

### DIFF
--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -33,8 +33,8 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     guidelines: [],
     level: [],
     standardOutcomes: [],
-    orderBy: undefined,
-    sortType: undefined,
+    orderBy: OrderBy.Date,
+    sortType: -1,
     collection: '',
     topics: [],
     fileTypes: [],
@@ -311,6 +311,13 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
    */
   makeQuery(params: any) {
     const paramKeys = Object.keys(params);
+
+    // no sort applied for text search
+    if (paramKeys.includes('text')) {
+      this.query.orderBy = undefined;
+      this.query.sortType = undefined;
+    }
+
     // iterate params object
     for (let i = 0, l = paramKeys.length; i < l; i++) {
       const key = paramKeys[i];


### PR DESCRIPTION
This PR includes 
1. When a user enters the browse page without a text search the results are ordered newest to oldest.
<img width="1439" alt="PR#1566 1" src="https://user-images.githubusercontent.com/72763770/216123132-8c5711b9-448c-4eb9-9094-f09367e8c6fe.png">

2. When a user enters the browse page with a text search the results are order with the text search and no sort is applied.
<img width="1439" alt="PR#1166 2" src="https://user-images.githubusercontent.com/72763770/216124007-4c4dd7f7-f837-4f2f-a36e-08bb17abd5d0.png">

3. When a user enters the browse page with a filter (topic, collection, guidelines, etc.) the results are sorted from newest to oldest.
<img width="1438" alt="PR#1166 3" src="https://user-images.githubusercontent.com/72763770/216124535-bc9da9ec-1013-46cf-a94a-07c3715d0135.png">

4. When a user enters a keyword search and the sort option is not selected by them the results are ordered by the keyword search.
<img width="1438" alt="PR#1166 4" src="https://user-images.githubusercontent.com/72763770/216125447-f91b4a81-752c-40ed-8c00-58ad904e52ca.png">
