### PR TITLE
Added option to show file/folder description on details page

### DIFF
--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.html
@@ -17,8 +17,8 @@
       ><i class="far fa-external-link"></i
     ></span>
   </div>
-  <div class="text-contained description" id="file-description">
-    <span>{{ file?.description }}</span>
+  <div tabindex="0" class="text-contained description" id="file-description" attr.aria-label="{{ file?.description }}">
+    <span title="{{ file?.description }}">{{ file?.description }}</span>
   </div>
   <div class="text-contained timestamp" id="file-updated" attr.aria-label="Last updated {{ timestampAge }}">
     {{ timestampAge }}

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.scss
@@ -55,6 +55,10 @@
   color: $dark-grey;
 }
 
+.description:focus {
+  white-space: initial;
+}
+
 .inline-flex {
   display: flex;
   align-items: center;

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.html
@@ -9,8 +9,8 @@
     <i class="fas fa-folder icon"></i>
     {{ folder?.getName() }}
   </div>
-  <div class="text-contained description" id="folder-description" attr.aria-label="{{ folder?. description }}">
-    <span>{{ folder?.description }}</span>
+  <div tabindex="0" class="text-contained description" id="folder-description" attr.aria-label="{{ folder?. description }}">
+    <span title="{{ folder?.description }}">{{ folder?.description }}</span>
   </div>
   <div class="text-contained timestamp" id="folder-updated" attr.aria-label="Last updated {{ timestampAge }}">
     {{ timestampAge }}

--- a/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
+++ b/src/app/shared/modules/filesystem/file-list-view/components/folder-list-item/folder-list-item.component.scss
@@ -69,6 +69,10 @@
   color: $dark-grey;
 }
 
+.description:focus {
+  white-space: initial;
+}
+
 .toggleBundle {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
For all file and folder names that are truncated a user now have an option to view the entire description.

<img width="886" alt="PR1567" src="https://user-images.githubusercontent.com/72763770/216680411-38dec81a-da66-4447-b4a1-4a02ab1b959a.png">

https://user-images.githubusercontent.com/72763770/216680435-6f397e10-09b7-4bcd-ab19-866cb6fdb938.mov


https://user-images.githubusercontent.com/72763770/216680444-5e49d34a-ca9e-4d1a-ade0-929a5b4a91c1.mov

https://user-images.githubusercontent.com/72763770/216680465-4a3cd270-6eb9-4ff4-b7e0-d0def97d01e5.mov



https://user-images.githubusercontent.com/72763770/216680479-68a7b089-6f28-42f7-8963-c3cc0bd2bec7.mov

