### PR TITLE
Action panel not reloading between parent -> child detail pages

### DIFF
--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -162,7 +162,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
           owners.push(this.releasedLearningObject.author.username);
 
           this.learningObjectOwners = owners;
-          // this.hasRevision = !!this.releasedLearningObject.revisionUri;
+          this.hasRevision = !!this.releasedLearningObject.revisionUri;
           this.learningObject = this.releasedLearningObject;
           // Set page title
           this.titleService.setTitle('CLARK | '+ this.learningObject.name);

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -183,6 +183,8 @@ export class DetailsComponent implements OnInit, OnDestroy {
           if (this.learningObject.revisionUri) {
             this.hasRevision = true;
             await this.loadRevisedLearningObject();
+          } else {
+            this.revisedLearningObject = null;
           }
         } else {
           if (object instanceof HttpErrorResponse) {


### PR DESCRIPTION
-Added an "else" statement, so if the revised learning object is not true it's set to null.
Screenshot below of the child detail page before it got reloaded to show it works.
Previously, the action panel would have "edit revision" instead of "create revision", because it was pointing at the parents detail page.
<img width="1430" alt="Screenshot 2023-02-21 at 4 18 35 PM" src="https://user-images.githubusercontent.com/92770851/220466807-ed174dd9-2461-4275-8a7d-2007804c8dcd.png">
