### PR TITLE
Feature/sc 18779/fix banner on clark to work with secured

### DIFF
--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -38,11 +38,11 @@ export class AdminComponent implements OnInit, OnDestroy {
     private messagesService: MessagesService
   ) {}
 
-  ngOnInit() {
+  async ngOnInit() {
     // hide CLARK navbar
     this.navbarService.hide();
 
-    if (this.messagesService.getStatus()) {
+    if (!!(await this.messagesService.getDowntime()).message) {
       // the message banner is down, adjust UI to account for it
       setTimeout(() => {
         this.topAdjustment = document.querySelector('clark-message .wrapper').getBoundingClientRect().height;

--- a/src/app/clark.component.html
+++ b/src/app/clark.component.html
@@ -1,11 +1,14 @@
-<ng-container [ngTemplateOutlet]="isUnderMaintenance !== undefined ? finishedLoadingTemplate : loadingTemplate"></ng-container>
+<ng-container [ngTemplateOutlet]="downtime.isDown !== undefined ? finishedLoadingTemplate : loadingTemplate"></ng-container>
 
 <ng-template #finishedLoadingTemplate>
-  <ng-container [ngTemplateOutlet]="isUnderMaintenance ? maintenanceTemplate : clarkBodyTemplate"></ng-container>
+  <ng-container [ngTemplateOutlet]="downtime.isDown ? maintenanceTemplate : clarkBodyTemplate"></ng-container>
 </ng-template>
 
 <ng-template #clarkBodyTemplate>
-  <clark-message></clark-message>
+  <clark-message
+    [downtime]="downtime"
+    [showBanner]="!!downtime.message"
+  ></clark-message>
   <clark-primary-navbar></clark-primary-navbar>
   <clark-secondary-navbar></clark-secondary-navbar>
   <router-outlet></router-outlet>

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -8,7 +8,7 @@ import { Title } from '@angular/platform-browser';
 import { HistoryService } from './core/history.service';
 import { filter } from 'rxjs/operators';
 import { LearningObject } from '../entity/learning-object/learning-object';
-import { MessagesService } from './core/messages.service';
+import { Downtime, MessagesService } from './core/messages.service';
 import { environment } from '@env/environment';
 import { ToastrOvenService } from './shared/modules/toaster/notification.service';
 import { CookieAgreementService } from './core/cookie-agreement.service';
@@ -57,7 +57,8 @@ export class ClarkComponent implements OnInit {
   hidingOutlines = true;
   learningObject: LearningObject;
 
-  isUnderMaintenance: boolean;
+  showBannerMessage = false;
+  downtime: Downtime = new Downtime(false, '');
 
   @HostListener('window:click', ['$event'])
   @HostListener('window:keyup', ['$event'])
@@ -86,8 +87,6 @@ export class ClarkComponent implements OnInit {
     private subscriptionAgreement: SubscriptionAgreementService,
     private cookies: CookieService,
   ) {
-    this.isUnderMaintenance = false;
-
     this.isSupportedBrowser = !(/msie\s|trident\/|edge\//i.test(window.navigator.userAgent));
     !this.isSupportedBrowser ? this.router.navigate(['/unsupported']) :
       this.authService.isLoggedIn.subscribe(val => {
@@ -118,13 +117,15 @@ export class ClarkComponent implements OnInit {
 
   ngOnInit(): void {
     if (environment.production) {
-      this.messages.getMaintenance().then(message => {
-        this.isUnderMaintenance = message;
+      this.messages.getMaintenance().then(down => {
+        this.downtime = down;
+        this.showBannerMessage = !!down.message;
       });
       // Determine if the application is currently under maintenance
       setInterval(async () => {
-        this.messages.getMaintenance().then(message => {
-          this.isUnderMaintenance = message;
+        this.messages.getMaintenance().then(down => {
+          this.downtime = down;
+          this.showBannerMessage = !!down.message;
         });
       }, 300000); // 5 min interval
       // check to see if the current version is behind the latest verison

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -117,13 +117,13 @@ export class ClarkComponent implements OnInit {
 
   ngOnInit(): void {
     if (environment.production) {
-      this.messages.getMaintenance().then(down => {
+      this.messages.getDowntime().then(down => {
         this.downtime = down;
         this.showBannerMessage = !!down.message;
       });
       // Determine if the application is currently under maintenance
       setInterval(async () => {
-        this.messages.getMaintenance().then(down => {
+        this.messages.getDowntime().then(down => {
           this.downtime = down;
           this.showBannerMessage = !!down.message;
         });

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -57,7 +57,6 @@ export class ClarkComponent implements OnInit {
   hidingOutlines = true;
   learningObject: LearningObject;
 
-  showBannerMessage = false;
   downtime: Downtime = new Downtime(false, '');
 
   @HostListener('window:click', ['$event'])
@@ -119,13 +118,11 @@ export class ClarkComponent implements OnInit {
     if (environment.production) {
       this.messages.getDowntime().then(down => {
         this.downtime = down;
-        this.showBannerMessage = !!down.message;
       });
       // Determine if the application is currently under maintenance
       setInterval(async () => {
         this.messages.getDowntime().then(down => {
           this.downtime = down;
-          this.showBannerMessage = !!down.message;
         });
       }, 300000); // 5 min interval
       // check to see if the current version is behind the latest verison

--- a/src/app/components/message/message.component.html
+++ b/src/app/components/message/message.component.html
@@ -1,7 +1,5 @@
 <div class="wrapper warning" *ngIf="showBanner">
   <div class="inner-wrapper">
-    <div aria-live="assertive">{{ message.message }} </div>
-    <!-- <a *ngIf="!downtime" class="status-link" [routerLink]="['/onion/learning-object-builder/info']" aria-label="Create a learning object" target="_blank"> Create a Learning Object</a> -->
-    <a *ngIf="downtime" class="status-link" [routerLink]="['/system/status']" aria-label="Clickable System Outages link" target="_blank"> View Status</a>
+    <div aria-live="assertive">{{ downtime.message }} </div>
   </div>
 </div>

--- a/src/app/components/message/message.component.ts
+++ b/src/app/components/message/message.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { MessagesService, Message} from '../../core/messages.service';
+import { Component, Input, OnInit } from '@angular/core';
+import { Downtime } from 'app/core/messages.service';
 
 @Component({
   selector: 'clark-message',
@@ -8,27 +8,12 @@ import { MessagesService, Message} from '../../core/messages.service';
 })
 export class MessageComponent implements OnInit {
 
-  showBanner = false;
-  downtime = false;
-  message: Message;
+  @Input() showBanner = false;
+  @Input() downtime: Downtime;
 
-  constructor(private messages: MessagesService) { }
+  constructor() { }
 
   ngOnInit() {
-    this.getMessage();
-    setInterval(async () => {
-      this.getMessage();
-    }, 300000); // 5 min interval
   }
 
-  getMessage() {
-    this.messages.getStatus().then(message => {
-      this.message = message;
-      this.showBanner = false;
-    })
-    .catch ( _ => {
-      /** Suppress the error because it is being handled in Gateway.
-      If an error does occur there is not reason to show anything because a user doesn't know the request is being made. */
-    });
-  }
 }

--- a/src/app/core/messages.service.ts
+++ b/src/app/core/messages.service.ts
@@ -4,28 +4,28 @@ import { MISC_ROUTES } from '@env/route';
 import { throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 
-export class Message {
-  constructor(public isUnderMaintenance: boolean, public message: string) { }
+export class Downtime {
+  constructor(public isDown: boolean, public message: string) { }
 }
 @Injectable()
 export class MessagesService {
   /**
    * Format for banner message
    *
-   * new Message(true, 'The CLARK team will conduct regular maintenance of the CLARK system on Wednesday February'+
+   * new downtime(true, 'The CLARK team will conduct regular maintenance of the CLARK system on Wednesday February'+
   ' 22, 2023 from 6:00AM-8:00AM EST. CLARK will be available but some users might see downgraded performance');
    */
-  private _message: Message;
+  private _downtime: Downtime;
 
   get message() {
-    return this._message;
+    return this._downtime;
   }
 
   constructor(private http: HttpClient) { }
 
-  getStatus(): Promise<Message> {
-    if (this._message) {
-      return Promise.resolve(this._message);
+  getStatus(): Promise<Downtime> {
+    if (this._downtime) {
+      return Promise.resolve(this._downtime);
     } else {
       return this.http.get(MISC_ROUTES.CHECK_STATUS, { withCredentials: true })
         .pipe(
@@ -33,21 +33,21 @@ export class MessagesService {
           catchError(this.handleError)
         )
         .toPromise()
-        .then((val: Message) => {
-          this._message = new Message(val.isUnderMaintenance, val.message);
-          return this._message;
+        .then((val: Downtime) => {
+          this._downtime = new Downtime(val.isDown, val.message);
+          return this._downtime;
         });
     }
   }
 
-    getMaintenance() {
+    getMaintenance(): Promise<Downtime> {
         return this.http.get(MISC_ROUTES.CHECK_MAINTENANCE, { withCredentials: true })
         .pipe(
             retry(3),
             catchError(this.handleError)
         )
         .toPromise()
-        .then((val: boolean) => {
+        .then((val: Downtime) => {
             return val;
         });
     }

--- a/src/app/core/messages.service.ts
+++ b/src/app/core/messages.service.ts
@@ -22,26 +22,8 @@ export class MessagesService {
   }
 
   constructor(private http: HttpClient) { }
-
-  getStatus(): Promise<Downtime> {
-    if (this._downtime) {
-      return Promise.resolve(this._downtime);
-    } else {
-      return this.http.get(MISC_ROUTES.CHECK_STATUS, { withCredentials: true })
-        .pipe(
-          retry(3),
-          catchError(this.handleError)
-        )
-        .toPromise()
-        .then((val: Downtime) => {
-          this._downtime = new Downtime(val.isDown, val.message);
-          return this._downtime;
-        });
-    }
-  }
-
-    getMaintenance(): Promise<Downtime> {
-        return this.http.get(MISC_ROUTES.CHECK_MAINTENANCE, { withCredentials: true })
+    getDowntime(): Promise<Downtime> {
+        return this.http.get(MISC_ROUTES.CHECK_DOWNTIME, { withCredentials: true })
         .pipe(
             retry(3),
             catchError(this.handleError)

--- a/src/app/onion/learning-object-builder/components/column-wrapper/column-wrapper.component.ts
+++ b/src/app/onion/learning-object-builder/components/column-wrapper/column-wrapper.component.ts
@@ -28,7 +28,7 @@ export class ColumnWrapperComponent implements OnInit, AfterViewInit, OnDestroy 
 
   async ngOnInit() {
     try {
-      this.messageBar = !!(await this.messagesService.getStatus());
+      this.messageBar = !!(await this.messagesService.getDowntime()).message;
     } catch (error) {
       // FIXME this suppresses the error resulting in the lambda function for messages being disabled
     }

--- a/src/app/onion/relevancy-builder/components/column-wrapper/column-wrapper.component.ts
+++ b/src/app/onion/relevancy-builder/components/column-wrapper/column-wrapper.component.ts
@@ -26,7 +26,7 @@ export class ColumnWrapperComponent implements OnInit {
 
   async ngOnInit() {
     try {
-      this.messageBar = !!(await this.messagesService.getStatus());
+      this.messageBar = !!(await this.messagesService.getDowntime()).message;
     } catch (error) {
       // FIXME this suppresses the error resulting in the lambda function for messages being disabled
     }

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -513,8 +513,7 @@ export const RATING_ROUTES = {
   }
 };
 export const MISC_ROUTES = {
-  CHECK_STATUS: `${environment.apiURL}/status`,
-  CHECK_MAINTENANCE: `${environment.apiURL}/maintenance`
+  CHECK_DOWNTIME: `${environment.apiURL}/downtime?service=clark`,
 };
 
 export const STATS_ROUTES = {


### PR DESCRIPTION
This PR completes [Fix Banner on CLARK to work with SecurEd Downtime lambda](https://app.shortcut.com/clarkcan/story/18779/fix-banner-on-clark-to-work-with-secured-downtime-lambda) by implementing the new secured downtime service allowing a downtime banner to be added without a deployment of the entire client.

Demo where interval for hitting the service is 10 seconds:

https://user-images.githubusercontent.com/72173743/222810225-0d32c066-36e7-4923-8f07-7ddd1653c9a3.mov

