### PR TITLE
fixed currPage=NaN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.0.33",
+  "version": "5.0.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.0.33",
+      "version": "5.0.34",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.0.33",
+  "version": "5.0.34",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -97,7 +97,7 @@ export class LearningObjectsComponent
     this.route.queryParams.subscribe(params => {
       this.query = {
         ...params,
-        currPage: parseInt(params.currPage, 10)
+        currPage: (params.currPage && !isNaN(params.currPage)) ? parseInt(params.currPage, 10) : 1,
        };
     });
 

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -144,7 +144,9 @@ export class LearningObjectsComponent
 
   changePage(pageNum) {
     this.listElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start'});
-    this.query.currPage = pageNum;
+    this.query = {
+      currPage: pageNum
+    };
     this.getLearningObjects();
   }
 


### PR DESCRIPTION
The admin dashboard page query param currPage=NaN is resolved. But we have an issue.

Currently the query parameter won't update, but it works.

https://user-images.githubusercontent.com/72763770/230166278-9621af1a-40b5-4b76-8640-9520ea1f0dbc.mov

But if we have
```diff
-     this.query.currPage = pageNum;
+    this.query = {
+            currPage: pageNum;
+    }
```
in line [147](https://github.com/Cyber4All/clark-client/commit/b66748b9bf74d6435dc3369b2a2ad41aa6808fc3#diff-2fd4bd2324265dd5e8d85292421d4c9d9f6107cf48f47106b768e7e06c6aab28L147), It would update the query param but It won't scroll up.

https://user-images.githubusercontent.com/72763770/230166417-d0c86b4e-3da2-4f43-94b1-ecc39ca4ec59.mov

