### PR TITLE
create redirect component and add guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.0.34",
+  "version": "5.0.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.0.34",
+      "version": "5.0.35",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.0.34",
+  "version": "5.0.35",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/clark.module.ts
+++ b/src/app/clark.module.ts
@@ -22,6 +22,8 @@ import { FormsModule } from '@angular/forms';
 import { SubscriptionComponent } from './components/subscription/subscription.component';
 import { PrimaryNavbarComponent } from './components/primary-navbar/primary-navbar.component';
 import { SecondaryNavbarComponent } from './components/secondary-navbar/secondary-navbar.component';
+import { RedirectComponent } from './redirect/redirect.component';
+
 @NgModule({
   imports: [
     BrowserModule,
@@ -43,7 +45,8 @@ import { SecondaryNavbarComponent } from './components/secondary-navbar/secondar
     UnauthorizedComponent,
     SubscriptionComponent,
     PrimaryNavbarComponent,
-    SecondaryNavbarComponent
+    SecondaryNavbarComponent,
+    RedirectComponent
   ],
   bootstrap: [ClarkComponent],
   providers: [TitleCasePipe, Title, { provide: UrlSerializer, useClass: CustomUrlSerializer }]

--- a/src/app/clark.routing.ts
+++ b/src/app/clark.routing.ts
@@ -4,6 +4,8 @@ import { UnsupportedComponent } from './unsupported.component';
 import { NotFoundComponent } from './not-found.component';
 import { AccessGroupGuard } from './core/access-group-guard';
 import { UnauthorizedComponent } from './unauthorized.component';
+import { BlogRedirectGuard } from './core/blog-redirect.guard';
+import { RedirectComponent } from './redirect/redirect.component';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const clark_routes: Routes = [
@@ -21,6 +23,7 @@ const clark_routes: Routes = [
   },
   { path: 'onion', loadChildren: () => import('app/onion/onion.module').then(m => m.OnionModule) },
   { path: 'admin', loadChildren: () => import('app/admin/admin.module').then(m => m.AdminModule) },
+  { path: 'blogs', component: RedirectComponent, canActivate: [BlogRedirectGuard], data: { externalUrl: 'https://blogs.clark.center/' }},
   { path: 'collections', loadChildren: () => import('app/collection/collection.module').then(m => m.CollectionModule)},
   { path: 'unsupported', component: UnsupportedComponent, data: { title: 'Unsupported'}},
   { path: 'not-found', component: NotFoundComponent, data: { title: 'Not Found'}},

--- a/src/app/core/blog-redirect.guard.spec.ts
+++ b/src/app/core/blog-redirect.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { BlogRedirectGuard } from './blog-redirect.guard';
+
+describe('BlogRedirectGuard', () => {
+  let guard: BlogRedirectGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(BlogRedirectGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/core/blog-redirect.guard.ts
+++ b/src/app/core/blog-redirect.guard.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BlogRedirectGuard implements CanActivate {
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    window.location.href = route.data.externalUrl;
+    return true;
+  }
+
+}

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -22,11 +22,11 @@
       <div>
         <h3>General Information</h3>
         <a aria-label= "Clickable About Us link" href="http://clark.center/about" >{{copy.ABOUT}}</a>
-        <a aria-label="Clickable Blog link" href="https://securedteam.notion.site/Featured-Blog-Posts-9ebff45f06f84a0a83c682f59472f106" target="_blank">{{copy.BLOG}}</a>
+        <a aria-label="Clickable Blog link" href="https://blogs.clark.center/about" target="_blank">{{copy.BLOG}}</a>
         <a aria-label="Clickable Meet the Team link" href="http://secured.team/team" target="_blank" rel="noopener noreferrer">{{ copy.TEAM }}</a>
         <a [routerLink]="['/press']" aria-label="Press and Media link">{{ copy.PRESS }}</a>
         <a aria-label="Newsletter Subscription modal" (activate)="toggleNewsletterBanner()">{{ copy.SUBSCRIBE }}</a>
-        
+
       </div>
     </section>
     <section class="grants">
@@ -37,7 +37,7 @@
         <div class="logo-wrapper">
           <a href="https://www.towson.edu/" target="_blank">
             <img src="assets/images/towson_logo.png" alt="Towson University Logo">
-          </a>      
+          </a>
         </div>
       </div>
     </section>

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -22,7 +22,7 @@
       <div>
         <h3>General Information</h3>
         <a aria-label= "Clickable About Us link" href="http://clark.center/about" >{{copy.ABOUT}}</a>
-        <a aria-label="Clickable Blog link" href="https://blogs.clark.center/about" target="_blank">{{copy.BLOG}}</a>
+        <a aria-label="Clickable Blog link" href="https://blogs.clark.center/" target="_blank">{{copy.BLOG}}</a>
         <a aria-label="Clickable Meet the Team link" href="http://secured.team/team" target="_blank" rel="noopener noreferrer">{{ copy.TEAM }}</a>
         <a [routerLink]="['/press']" aria-label="Press and Media link">{{ copy.PRESS }}</a>
         <a aria-label="Newsletter Subscription modal" (activate)="toggleNewsletterBanner()">{{ copy.SUBSCRIBE }}</a>

--- a/src/app/redirect/redirect.component.html
+++ b/src/app/redirect/redirect.component.html
@@ -1,0 +1,6 @@
+<div class="redirect-top">
+    <img src="../../assets/images/logo.png" class="redirect-logo" alt="CLARK logo">
+    <strong><h1 tabindex="0" class="huge">Redirecting...</h1></strong>
+    <p tabindex="0" class="message"> Please wait while we redirect you... </p>
+    <a tabindex="0" routerLink='' class="message">Back to Home</a>
+</div>

--- a/src/app/redirect/redirect.component.scss
+++ b/src/app/redirect/redirect.component.scss
@@ -1,0 +1,28 @@
+@import "../../vars";
+@import "../../globals.scss";
+.redirect-top {
+  padding: 100px;
+  justify-content: center;
+
+  .redirect-logo {
+    height: 180px;
+    display: block;
+    margin: auto;
+  }
+  .huge {
+    font-size: $largest;
+    max-width: 200px;
+    display: block;
+    margin: auto;
+    text-align: center;
+  }
+  .message {
+    padding-top: 20px;
+    max-width: 400px;
+    font-size: $normal;
+    display: block;
+    margin: auto;
+    text-align: center;
+  }
+}
+

--- a/src/app/redirect/redirect.component.spec.ts
+++ b/src/app/redirect/redirect.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RedirectComponent } from './redirect.component';
+
+describe('RedirectComponent', () => {
+  let component: RedirectComponent;
+  let fixture: ComponentFixture<RedirectComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RedirectComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RedirectComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/redirect/redirect.component.ts
+++ b/src/app/redirect/redirect.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'clark-redirect',
+  templateUrl: './redirect.component.html',
+  styleUrls: ['./redirect.component.scss']
+})
+export class RedirectComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
This PR completes [Add clark.center/blogs redirect to blogs.clark.center in clark routing](https://app.shortcut.com/clarkcan/story/22560/add-clark-center-blogs-redirect-to-blogs-clark-center-in-clark-routing) by adding a new route: `/blogs` and having it redirect to https://blogs.clark.center/

https://user-images.githubusercontent.com/72173743/234926870-ab06073b-7dde-48f0-a498-cec94c48f1a3.mov