### PR TITLE
Implement an organization dropdown (only in registration, not in edit-profile) 

### DIFF
--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -14,6 +14,7 @@ import { ErrorBannerComponent } from './components/error-banner/error-banner.com
 import { RecaptchaDirective } from './register/components/recaptcha/recaptcha.directive';
 import { RegistrationProgressComponent } from './register/components/registration-progress/registration-progress.component';
 import { SharedModule } from 'app/shared/shared.module';
+import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 
 @NgModule({
   declarations: [
@@ -34,7 +35,8 @@ import { SharedModule } from 'app/shared/shared.module';
     MatInputModule,
     FormsModule,
     ReactiveFormsModule,
-    SharedModule
+    SharedModule,
+    VirtualScrollerModule,
   ]
 })
 export class AuthModule { }

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -32,12 +32,22 @@
                         [errorMsg]="fieldErrorMsg"
                     ></clark-input-field>
                     <clark-input-field 
-                        [(ngModel)]="regInfo.organization"  
+                        [(ngModel)]="infoFormGroup.organization"  
                         name="organization" 
                         #organization 
                         phold="Organization" 
                         [control]="infoFormGroup.get('organization')"
+                        (keyup)="keyup($event)"
                     ></clark-input-field>
+                    <ul
+                        *ngIf="showDropdown"
+                        (onBlur)="closeDropdown()"
+                        class="org-dropdown_list"
+                        >
+                        <ng-container
+                        *ngTemplateOutlet="loading ? loadingTemplate : resultsTemplate"
+                        ></ng-container>
+                     </ul>
                 
                     <div class="side-by-side" >
                         <button type="button" class="white" (click)="navigateHome()">Cancel</button>
@@ -124,3 +134,47 @@
         </mat-error>
     </div>
 </div>
+
+<!-- organization dropdown template -->
+<ng-template #resultsTemplate>
+    <ng-container
+      *ngIf="searchResults && searchResults.length; else noResultsTemplate"
+    >
+        <virtual-scroller
+        #scroll
+        [style.height]="scrollerHeight"
+        [bufferAmount]="5"
+        [enableUnequalChildrenSizes]="true"
+        [items]="searchResults"
+        >
+            <li
+                class="org-dropdown_list-item"
+                *ngFor="let org of scroll.viewPortItems"
+                (click)="selectOrg(org)"
+            >
+                {{ org.name }}
+            </li>
+            <div class="other-box" (click)="selectOrg()">
+                <li class="other-option">
+                Other
+                </li>
+            </div>
+        </virtual-scroller>
+    </ng-container>
+  </ng-template>
+
+  <ng-template #noResultsTemplate>
+    <div class="other-box">
+      <li class="other-option" (click)="selectOrg()">
+        Other
+      </li>
+    </div>
+  </ng-template>
+
+  <ng-template #loadingTemplate>
+    <span class="org-dropdown__message">
+      <i class="far fa-spinner-third fa-spin">
+        Loading
+      </i>
+    </span>
+  </ng-template>

--- a/src/app/auth/register/register.component.scss
+++ b/src/app/auth/register/register.component.scss
@@ -59,4 +59,37 @@
         all: unset;
         cursor: pointer;
     }
+
+    .org-dropdown_list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        position: static;
+        min-width: 200px;
+        width: 100%;
+        background: white;
+        border-radius: 2px;
+        box-shadow: 0 2px 6px 2px rgba(0, 0, 0, 0.2);
+        z-index: 3;
+      
+        virtual-scroller {
+          margin: 0px;
+          min-height: 40px;
+          li {
+            cursor: pointer;
+            padding: 10px;
+          }
+          li:hover {
+            background-color: color-gray(6);
+          }
+        }
+      }
+
+      .org-dropdown__message {
+        padding: 10px;
+        text-align: center;
+        width: 100%;
+        box-sizing: border-box;
+        display: block;
+      }
 }

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -8,7 +8,7 @@ import { MatchValidator } from 'app/shared/validators/MatchValidator';
 import { Organization } from 'entity/organization';
 import { OrganizationService } from 'app/core/organization.service';
 import { Subject, interval } from 'rxjs';
-import { takeUntil, debounce } from 'rxjs/operators';
+import { takeUntil, debounce, debounceTime } from 'rxjs/operators';
 import { environment } from '@env/environment';
 import { CookieAgreementService } from 'app/core/cookie-agreement.service';
 
@@ -114,10 +114,20 @@ export class RegisterComponent implements OnInit, OnDestroy{
   usernameInUse = false;
   loading = false;
 
+  organizationInput$: Subject<string> = new Subject<string>();
+  showDropdown = false;
+  closeDropdown = () => {
+    this.showDropdown = false;
+  };
+  searchResults: Array<Organization> = [];
+  selectedOrg = '';
+  scrollerHeight = '100px';
+
   constructor(
     public authValidation: AuthValidationService,
     private auth: AuthService,
     private router: Router,
+    private orgService: OrganizationService,
     private cookieAgreement: CookieAgreementService,
     private route: ActivatedRoute,
   ) {
@@ -137,6 +147,20 @@ export class RegisterComponent implements OnInit, OnDestroy{
     this.toggleRegisterButton();
     this.validateEmail();
     this.validateUsername();
+    this.organizationInput$.pipe(debounceTime(650))
+    .subscribe( async (value: string) => {
+      this.searchResults = (await this.orgService.searchOrgs(value.trim()));
+      this.loading = false;
+    });
+    this.organizationInput$
+      .subscribe((value: string) => {
+        if (value && value !== '') {
+          this.showDropdown = true;
+          this.loading = true;
+        } else {
+          this.showDropdown = false;
+        }
+      });
   }
 
   /**
@@ -341,6 +365,26 @@ export class RegisterComponent implements OnInit, OnDestroy{
       });
     }
   }
+
+  selectOrg(org?: Organization) {
+    if(org) {
+      this.regInfo.organization = org.name;
+      this.infoFormGroup.get('organization')!.setValue(org.name);
+    } else {
+      this.selectedOrg = '602ae2a038e2aaa1059f3c39';
+      this.infoFormGroup.get('organization')!.setValue('Other');
+    }
+    this.closeDropdown();
+  }
+
+    /**
+   * Registers typing events from the organization input
+   *
+   * @param event The typing event
+   */
+    keyup(event: any) {
+      this.organizationInput$.next(event.target.value);
+    }
 
   ngOnDestroy(): void {
     this.ngUnsubscribe.next();

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -377,7 +377,7 @@ export class RegisterComponent implements OnInit, OnDestroy{
     this.closeDropdown();
   }
 
-    /**
+  /**
    * Registers typing events from the organization input
    *
    * @param event The typing event

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -5,6 +5,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { AuthValidationService } from 'app/core/auth-validation.service';
 import { AuthService } from 'app/core/auth.service';
 import { MatchValidator } from 'app/shared/validators/MatchValidator';
+import { Organization } from 'entity/organization';
+import { OrganizationService } from 'app/core/organization.service';
 import { Subject, interval } from 'rxjs';
 import { takeUntil, debounce } from 'rxjs/operators';
 import { environment } from '@env/environment';

--- a/src/app/core/organization.service.ts
+++ b/src/app/core/organization.service.ts
@@ -1,10 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { retry } from 'rxjs';
+import { retry } from 'rxjs/internal/operators/retry';
 import { Organization } from '../../entity/organization';
 import { ORGANIZATION_ROUTES } from '@env/route';
 import { AuthService } from './auth.service';
-
 @Injectable({
   providedIn: 'root'
 })
@@ -32,3 +31,4 @@ export class OrganizationService {
     });
   }
 }
+

--- a/src/app/core/organization.service.ts
+++ b/src/app/core/organization.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { retry } from 'rxjs';
+import { Organization } from '../../entity/organization';
+import { ORGANIZATION_ROUTES } from '@env/route';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrganizationService {
+
+  constructor(
+    private http: HttpClient,
+    private auth: AuthService
+  ) {}
+
+  async searchOrgs(query: string): Promise<Array<Organization>> {
+    return new Promise((resolve, reject) => {
+      this.http
+        .get(ORGANIZATION_ROUTES.SEARCH_ORGANIZATIONS(query))
+        .pipe(retry(3))
+        .toPromise()
+        .then(
+          (res: any) => {
+            resolve(res);
+          },
+          (err) => {
+            reject(err);
+          }
+        );
+    });
+  }
+}

--- a/src/entity/organization.ts
+++ b/src/entity/organization.ts
@@ -1,0 +1,6 @@
+export interface Organization {
+    _id: string,
+    name: string,
+    type: string,
+    verified: boolean
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -17,6 +17,7 @@ export const environment = {
   cognitoRegion: 'us-east-1',
   cognitoIdentityPoolId: 'us-east-1:08c3533f-4e0b-4014-9bfe-12a347cb6272',
   cognitoAdminIdentityPoolId: 'us-east-1:eed740a1-fea5-474d-8f57-0036b1871693',
+  cardOrganizationUrl: 'https://api-gateway.caeresource.directory/organizations?type=&verified=verified&mine=&sort='
 };
 
 export enum LearningObjectStatus {

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -347,6 +347,12 @@ export const USER_ROUTES = {
   }
 };
 
+export const ORGANIZATION_ROUTES = {
+  SEARCH_ORGANIZATIONS(queryString: string) {
+      return `${environment.cardOrganizationUrl}&text=${queryString}`;
+  }
+};
+
 export const PUBLIC_LEARNING_OBJECT_ROUTES = {
   GET_PUBLIC_LEARNING_OBJECTS: `${environment.apiURL}/learning-objects`,
   GET_PUBLIC_LEARNING_OBJECTS_WITH_FILTER(query) {


### PR DESCRIPTION
<img width="1406" alt="Screenshot 2023-05-12 at 3 22 31 PM" src="https://github.com/Cyber4All/clark-client/assets/92770851/a2672b01-4da8-4057-9f3f-602610f547d3">
<img width="1085" alt="Screenshot 2023-05-12 at 3 23 19 PM" src="https://github.com/Cyber4All/clark-client/assets/92770851/bd49cc96-b067-4528-a1a6-6c6c6a371543">
I replaced the text field for the organization in the registration page with a drop down menu that includes all the organizations. 
*I could not replace the text field in edit-profile with the drop down because of an authentication bug. I will be creating a shortcut story on it soon.
