### PR TITLE
Fixed tab showing wrong collection for 502 project, NICE and NCyTE

### DIFF
--- a/src/app/collection/pages/collection-502/collection-502.component.ts
+++ b/src/app/collection/pages/collection-502/collection-502.component.ts
@@ -4,7 +4,7 @@ import { NavbarService } from '../../../core/navbar.service';
 import { LearningObjectService } from '../../../cube/learning-object.service';
 import { Query } from '../../../interfaces/query';
 import { CollectionService } from '../../../core/collection.service';
-
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'clark-502-collection-index',
@@ -25,12 +25,14 @@ export class Collection502Component implements OnInit {
   constructor(
     private navbarService: NavbarService,
     private learningObjectService: LearningObjectService,
-    private collectionService: CollectionService
+    private collectionService: CollectionService,
+    private titleService: Title
   ) { }
 
   async ngOnInit() {
     this.navbarService.show();
     await this.fetchLearningObjects(this.query);
+    this.titleService.setTitle('CLARK | The 502 Project');
 
     const toggleSwitch = document.querySelector('mat-slide-toggle input[type="checkbox"]');
 

--- a/src/app/collection/pages/collection-ncyte/collection-ncyte.component.ts
+++ b/src/app/collection/pages/collection-ncyte/collection-ncyte.component.ts
@@ -3,7 +3,7 @@ import { Collection, LearningObject } from '@entity';
 import { CollectionService } from 'app/core/collection.service';
 import { FeaturedObjectsService } from 'app/core/featuredObjects.service';
 import { NavbarService } from '../../../core/navbar.service';
-
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'clark-collection-ncyte',
@@ -19,6 +19,7 @@ export class CollectionNcyteComponent implements OnInit, OnDestroy {
   constructor(
     private navbarService: NavbarService,
     private collectionService: CollectionService,
+    private titleService: Title,
     private featureService: FeaturedObjectsService) { }
 
   async ngOnInit() {
@@ -28,6 +29,7 @@ export class CollectionNcyteComponent implements OnInit, OnDestroy {
 
     this.learningObjects = await this.featureService.getCollectionFeatured(this.abvCollection);
 
+    this.titleService.setTitle('CLARK | ' + this.collection.name);
   }
 
   ngOnDestroy(): void {

--- a/src/app/collection/pages/nice-challenge/nice-challenge.component.ts
+++ b/src/app/collection/pages/nice-challenge/nice-challenge.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { NavbarService } from 'app/core/navbar.service';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'clark-nice-challenge',
@@ -8,10 +9,14 @@ import { NavbarService } from 'app/core/navbar.service';
 })
 export class NiceChallengeComponent implements OnInit {
 
-  constructor(private navbarService: NavbarService) { }
+  constructor(
+    private navbarService: NavbarService,
+    private titleService: Title) { }
 
   ngOnInit(): void {
     this.navbarService.show();
+
+    this.titleService.setTitle('CLARK | NICE Challenge');
   }
 
 }


### PR DESCRIPTION
This resolves the issue where the tab name would not update when visiting custom collections pages (502 Project, NCyTE, NICE) after viewing other collections. It would still shows the name of the previous collection you visited.

**Before**

https://github.com/Cyber4All/clark-client/assets/92770851/380807d0-226f-4d87-afa5-33c2b5458e31

**After**

https://github.com/Cyber4All/clark-client/assets/92770851/a596c342-f441-4ad8-97be-fe74bc3c4b97
