### PR TITLE
Feature/sc 23829/develop ncyte statistics dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/collection/collection.module.ts
+++ b/src/app/collection/collection.module.ts
@@ -33,6 +33,7 @@ import {MatNativeDateModule} from '@angular/material/core';
 import {MatDatepickerModule} from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 @NgModule({
   declarations: [
     CollectionIndexComponent,
@@ -72,7 +73,9 @@ import {MatInputModule} from '@angular/material/input';
     MatDatepickerModule,
     MatNativeDateModule,
     MatFormFieldModule,
-    MatInputModule
+    MatInputModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
   providers: [LearningObjectService]
 })

--- a/src/app/collection/collection.module.ts
+++ b/src/app/collection/collection.module.ts
@@ -29,6 +29,10 @@ import { FeaturedComponent } from './pages/collection-502/components/featured/fe
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { NcyteDashboardComponent } from './pages/collection-ncyte/dashboard/dashboard.component';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
 @NgModule({
   declarations: [
     CollectionIndexComponent,
@@ -64,7 +68,11 @@ import { NcyteDashboardComponent } from './pages/collection-ncyte/dashboard/dash
     CubeSharedModule,
     MatSlideToggleModule,
     MatIconModule,
-    MatRadioModule
+    MatRadioModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatFormFieldModule,
+    MatInputModule
   ],
   providers: [LearningObjectService]
 })

--- a/src/app/collection/collection.module.ts
+++ b/src/app/collection/collection.module.ts
@@ -1,6 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import {MatRadioModule} from '@angular/material/radio';
 import { CollectionIndexComponent } from './pages/collection-index/collection-index.component';
 import { GenericPageComponent } from './pages/generic-page/generic-page.component';
 import { SecurityInjectionsComponent } from './pages/security-injections/security-injections.component';
@@ -62,7 +63,8 @@ import { NcyteDashboardComponent } from './pages/collection-ncyte/dashboard/dash
     SharedModule,
     CubeSharedModule,
     MatSlideToggleModule,
-    MatIconModule
+    MatIconModule,
+    MatRadioModule
   ],
   providers: [LearningObjectService]
 })

--- a/src/app/collection/collection.module.ts
+++ b/src/app/collection/collection.module.ts
@@ -27,6 +27,7 @@ import { TitleComponent } from './pages/collection-502/components/title/title.co
 import { FeaturedComponent } from './pages/collection-502/components/featured/featured.component';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
+import { NcyteDashboardComponent } from './pages/collection-ncyte/dashboard/dashboard.component';
 @NgModule({
   declarations: [
     CollectionIndexComponent,
@@ -45,7 +46,8 @@ import { MatIconModule } from '@angular/material/icon';
     HeaderInfo502Component,
     CuratorCardComponent,
     TitleComponent,
-    FeaturedComponent
+    FeaturedComponent,
+    NcyteDashboardComponent
   ],
   schemas: [
     NO_ERRORS_SCHEMA,

--- a/src/app/collection/collection.routing.ts
+++ b/src/app/collection/collection.routing.ts
@@ -5,6 +5,7 @@ import { NiceChallengeComponent } from './pages/nice-challenge/nice-challenge.co
 import { CollectionNcyteComponent } from './pages/collection-ncyte/collection-ncyte.component';
 import { Collection502Component } from './pages/collection-502/collection-502.component';
 import { NotFoundComponent } from 'app/not-found.component';
+import { NcyteDashboardComponent } from './pages/collection-ncyte/dashboard/dashboard.component';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 const collection_routes: Routes = [
@@ -20,6 +21,10 @@ const collection_routes: Routes = [
     {
         path: 'ncyte',
         component: CollectionNcyteComponent
+    },
+    {
+        path: 'ncyte/dashboard',
+        component: NcyteDashboardComponent
     },
     {
         path: '502-project',

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
@@ -39,6 +39,15 @@
                     Collection Author<span *ngIf="authorCollection !== 1">s</span>
                 </p>
             </div>
+            <div class="stat">
+                <div class="stat__icon saves">
+                    <i class="far fa-university"></i>
+                </div>
+                <div class="num">{{ objSaved }}</div>
+                <p>
+                    Save<span *ngIf="objSaved !== 1">s</span>
+                </p>
+            </div>
         </div>
     </div>
 </div>

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.scss
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.scss
@@ -39,6 +39,7 @@
                 align-items: center;
                 margin: 15px;
                 min-height: 250px;
+                min-width: 200px;
                 
                 .stat__icon {
                     font-size: 30px;
@@ -62,6 +63,10 @@
                     &.authors {
                         background-color: lighten(rebeccapurple, 35);
                         color: rebeccapurple;
+                    }
+                    &.saves {
+                        background-color: lighten($color: $success-green, $amount: 35);
+                        color: $success-green;
                     }
                 }
             }

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -14,6 +14,7 @@ export class StatsComponent implements OnInit {
   objDownload: number;
   objReview: number;
   objReleased: number;
+  objSaved: number;
   authorCollection: number;
 
   constructor(private collectionService: CollectionService) { }
@@ -30,6 +31,7 @@ export class StatsComponent implements OnInit {
 
     await this.collectionService.getCollectionMetricsData(this.collectionName).then((res: any ) => {
       this.objDownload = res.metrics.downloads;
+      this.objSaved = res.metrics.saves;
       this.objReleased = res.metrics.statusMetrics[0].released;
       const num = res.metrics.statusMetrics[0].waiting + res.metrics.statusMetrics[0].peerReview + res.metrics.statusMetrics[0].proofing;
       this.objReview = num;

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,0 +1,1 @@
+<p>dashboard works!</p>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,1 +1,3 @@
-<p>dashboard works!</p>
+<div class="container">
+  <h1 class="header">NCyTE Statistics Dashboard</h1>
+</div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -8,17 +8,17 @@
     <i class="fas fa-question-circle fa-1x"></i>
   </span>
   <label>When: </label>
-  <mat-radio-group aria-label="Select an option" [(ngModel)]="when" (change)="onRadioChange($event)">
+  <mat-radio-group aria-label="Select an option" (change)="onRadioChange($event)">
     <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
     <mat-radio-button value="Date Range">Date Range</mat-radio-button>
   </mat-radio-group> <br >
   <mat-form-field *ngIf="when === 'Date Range'">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [rangePicker]="picker">
-      <input matStartDate placeholder="Start date">
-      <input matEndDate placeholder="End date">
+    <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
+      <input matStartDate formControlName="start" placeholder="Start date">
+      <input matEndDate formControlName="end" placeholder="End date">
     </mat-date-range-input>
-    <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
+    <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-date-range-picker #picker></mat-date-range-picker>
   </mat-form-field> <br>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -4,10 +4,23 @@
   <clark-ncyte-stats [collectionName]="'ncyte'"></clark-ncyte-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
+  <span tip="Define how you would like to limit the data of the individual Learning Objects.">
+    <i class="fas fa-question-circle fa-1x"></i>
+  </span>
   <label>When: </label>
-  <mat-radio-group aria-label="Select an option" [(ngModel)]="when" (change)="onChange($event)">
+  <mat-radio-group aria-label="Select an option" [(ngModel)]="when" (change)="onRadioChange($event)">
     <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
     <mat-radio-button value="Date Range">Date Range</mat-radio-button>
   </mat-radio-group> <br >
+  <mat-form-field *ngIf="when === 'Date Range'">
+    <mat-label>Enter a date range</mat-label>
+    <mat-date-range-input [rangePicker]="picker">
+      <input matStartDate placeholder="Start date">
+      <input matEndDate placeholder="End date">
+    </mat-date-range-input>
+    <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-date-range-picker #picker></mat-date-range-picker>
+  </mat-form-field> <br>
   <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -2,4 +2,12 @@
   <h1 class="header">NCyTE Statistics Dashboard</h1>
 
   <clark-ncyte-stats [collectionName]="'ncyte'"></clark-ncyte-stats>
+
+  <h2 class="downloads-header">Individual Learning Objects</h2>
+  <label>When: </label>
+  <mat-radio-group aria-label="Select an option" [(ngModel)]="when" (change)="onChange($event)">
+    <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
+    <mat-radio-button value="Date Range">Date Range</mat-radio-button>
+  </mat-radio-group> <br >
+  <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -22,6 +22,11 @@
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-date-range-picker #picker disabled="false"></mat-date-range-picker>
   </mat-form-field> <br>
-  <input type="text" [(ngModel)]="email" placeholder="Enter an email..."><br>
+  <clark-input-field
+    phold="Enter an email..."
+    fControlType="email"
+    errorMsg="Email is required"
+    [control]="email"
+  ></clark-input-field>
   <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -4,34 +4,41 @@
   <clark-ncyte-stats [collectionName]="'ncyte'"></clark-ncyte-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
-  <span tip="Define how you would like to limit the data of the individual Learning Objects.">
-    <i class="fas fa-question-circle fa-1x"></i>
-  </span>
-  <label>When: </label>
-  <mat-radio-group aria-label="Select an option" [(ngModel)]="when">
-    <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
-    <mat-radio-button value="Date Range">Date Range</mat-radio-button>
-  </mat-radio-group> <br >
-  <mat-form-field *ngIf="when === 'Date Range'">
-    <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [formGroup]="range" [rangePicker]="picker" disabled>
-      <input matStartDate formControlName="start" placeholder="Start date">
-      <input matEndDate formControlName="end" placeholder="End date">
-    </mat-date-range-input>
-    <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-date-range-picker #picker disabled="false"></mat-date-range-picker>
-  </mat-form-field> <br>
-  <clark-input-field
-    phold="Enter an email..."
-    fControlType="email"
-    errorMsg="Email is required"
-    [control]="email"
-  ></clark-input-field>
-  <clark-input-field
-    phold="Enter a name..."
-    errorMsg="Name is required"
-    [control]="name"
-  ></clark-input-field>
-  <button (click)="onDownload()">Download</button>
+  <div class="downloads-body">
+    <div class="date">
+      <span class="tip" tip="Define how you would like to limit the data of the individual Learning Objects.">
+        <i class="fas fa-question-circle fa-1x"></i>
+      </span>
+      <label>When: </label>
+      <mat-radio-group aria-label="Select an option" [(ngModel)]="when">
+        <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
+        <mat-radio-button value="Date Range">Date Range</mat-radio-button>
+      </mat-radio-group>
+    </div>
+    <mat-form-field *ngIf="when === 'Date Range'">
+      <mat-label>Enter a date range</mat-label>
+      <mat-date-range-input [formGroup]="range" [rangePicker]="picker" disabled>
+        <input matStartDate formControlName="start" placeholder="Start date">
+        <input matEndDate formControlName="end" placeholder="End date">
+      </mat-date-range-input>
+      <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-date-range-picker #picker disabled="false"></mat-date-range-picker>
+    </mat-form-field>
+    <div class="input-group">
+      <clark-input-field
+        phold="Enter an email..."
+        fControlType="email"
+        errorMsg="Email is required"
+        [control]="email"
+      ></clark-input-field>
+      <clark-input-field
+        phold="Enter a name..."
+        errorMsg="Name is required"
+        [control]="name"
+      ></clark-input-field>
+    </div>
+    <button (click)="onDownload()">Download a CSV of All Individual Learning Objects</button>
+  </div>
 </div>
+<cube-footer></cube-footer>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,3 +1,5 @@
 <div class="container">
   <h1 class="header">NCyTE Statistics Dashboard</h1>
+
+  <clark-ncyte-stats [collectionName]="'ncyte'"></clark-ncyte-stats>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -8,7 +8,7 @@
     <i class="fas fa-question-circle fa-1x"></i>
   </span>
   <label>When: </label>
-  <mat-radio-group aria-label="Select an option" (change)="onRadioChange($event)">
+  <mat-radio-group aria-label="Select an option" [(ngModel)]="when">
     <mat-radio-button value="All-time" checked="true">All-time</mat-radio-button>
     <mat-radio-button value="Date Range">Date Range</mat-radio-button>
   </mat-radio-group> <br >
@@ -22,5 +22,6 @@
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-date-range-picker #picker disabled="false"></mat-date-range-picker>
   </mat-form-field> <br>
+  <input type="text" [(ngModel)]="email" placeholder="Enter an email..."><br>
   <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -28,5 +28,10 @@
     errorMsg="Email is required"
     [control]="email"
   ></clark-input-field>
+  <clark-input-field
+    phold="Enter a name..."
+    errorMsg="Name is required"
+    [control]="name"
+  ></clark-input-field>
   <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -14,13 +14,13 @@
   </mat-radio-group> <br >
   <mat-form-field *ngIf="when === 'Date Range'">
     <mat-label>Enter a date range</mat-label>
-    <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
+    <mat-date-range-input [formGroup]="range" [rangePicker]="picker" disabled>
       <input matStartDate formControlName="start" placeholder="Start date">
       <input matEndDate formControlName="end" placeholder="End date">
     </mat-date-range-input>
     <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-date-range-picker #picker></mat-date-range-picker>
+    <mat-date-range-picker #picker disabled="false"></mat-date-range-picker>
   </mat-form-field> <br>
   <button (click)="onDownload()">Download</button>
 </div>

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
@@ -1,4 +1,5 @@
 @import "vars.scss";
+@import '../../../collection-globals.scss';
 
 .container {
   padding: 20px 50px;
@@ -10,4 +11,11 @@
   font-size: $largest;
   color: $darker-grey;
   font-weight: 500;
+}
+
+.downloads-header {
+  color: $ncyte-blue;
+  font-size: $largest;
+  font-weight: 600;
+  text-align: center;
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
@@ -1,0 +1,13 @@
+@import "vars.scss";
+
+.container {
+  padding: 20px 50px;
+  background-color: white;
+}
+
+.header {
+  margin-bottom: 25px;
+  font-size: $largest;
+  color: $darker-grey;
+  font-weight: 500;
+}

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
@@ -19,3 +19,42 @@
   font-weight: 600;
   text-align: center;
 }
+
+.downloads-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .date {
+    .tip {
+      margin-right: 10px;
+    }
+
+    label {
+      margin-right: 5px;
+    }
+
+    mat-radio-group mat-radio-button {
+      margin-right: 10px;
+    }
+  }
+
+  button {
+    padding: 16px 27px;
+    background-color: $homepage-light-blue;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    box-shadow: 0px 6px 12px -6px $homepage-light-blue;
+    width: fit-content;
+
+    &:hover {
+        opacity: 80%;
+    }
+
+    &:active {
+        opacity: 100%;
+    }
+  }
+}

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
@@ -43,6 +43,10 @@
     }
   }
 
+  mat-form-field {
+    margin: 10px 0;
+  }
+
   button {
     padding: 16px 27px;
     background-color: $homepage-light-blue;

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.scss
@@ -2,8 +2,12 @@
 @import '../../../collection-globals.scss';
 
 .container {
+  min-height: 100vh;
   padding: 20px 50px;
   background-color: white;
+
+  display: flex;
+  flex-direction: column;
 }
 
 .header {

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -31,7 +31,7 @@ export class NcyteDashboardComponent implements OnInit {
   }
 
   onDownload(): void {
-    if(this.email.errors) {
+    if(this.email.errors || this.name.errors) {
       this.toaster.error('Error!', 'Please fill out the required fields.');
       return;
     }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -49,6 +49,6 @@ export class NcyteDashboardComponent implements OnInit {
       this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value, { start: start, end: end });
     }
 
-    this.toaster.alert('We\'re working on it!', 'Please check your email for a report of all individual Learning Objects.');
+    this.toaster.alert('We\'re working on it!', 'Please check your email in a few minutes for your report.');
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewContainerRef } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatRadioChange } from '@angular/material/radio';
 import { AuthValidationService } from 'app/core/auth-validation.service';
+import { CollectionService } from 'app/core/collection.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 
 @Component({
@@ -16,11 +17,13 @@ export class NcyteDashboardComponent implements OnInit {
     end: new FormControl(null),
   });
   email = this.authValidationService.getInputFormControl('email');
+  name = this.authValidationService.getInputFormControl('text');
 
   constructor(
     private toaster: ToastrOvenService,
     private view: ViewContainerRef,
-    private authValidationService: AuthValidationService
+    private authValidationService: AuthValidationService,
+    private collectionService: CollectionService
   ) { }
 
   ngOnInit(): void {
@@ -39,13 +42,11 @@ export class NcyteDashboardComponent implements OnInit {
     }
 
     if(this.when === 'All-time') {
-      console.log('Email: ', this.email.value);
+      this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value);
     } else {
-      console.log('Email: ', this.email.value);
-      // eslint-disable-next-line max-len
-      console.log(`Start Date: ${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`);
-      // eslint-disable-next-line max-len
-      console.log(`End Date: ${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`);
+      const start = `${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`;
+      const end = `${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`;
+      this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value, { start: start, end: end });
     }
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'clark-ncyte-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class NcyteDashboardComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewContainerRef } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { MatRadioChange } from '@angular/material/radio';
+import { AuthValidationService } from 'app/core/auth-validation.service';
+import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 
 @Component({
   selector: 'clark-ncyte-dashboard',
@@ -13,28 +15,37 @@ export class NcyteDashboardComponent implements OnInit {
     start: new FormControl(null),
     end: new FormControl(null),
   });
-  email = '';
+  email = this.authValidationService.getInputFormControl('email');
 
-  constructor() { }
+  constructor(
+    private toaster: ToastrOvenService,
+    private view: ViewContainerRef,
+    private authValidationService: AuthValidationService
+  ) { }
 
   ngOnInit(): void {
+    this.toaster.init(this.view);
   }
 
   onDownload(): void {
-    console.log(this.when);
-    console.log(this.range.value);
+    if(this.email.errors) {
+      this.toaster.error('Error!', 'Please fill out the required fields.');
+      return;
+    }
 
-    // const date = new Date()
+    if(this.when === 'Date Range' && !this.range.value.start && !this.range.value.end) {
+      this.toaster.error('Error!', 'Please enter a date range.');
+      return;
+    }
 
-    // const start = date.
-
-    // const start: Date = this.range.value.start;
-    // console.log(start);
-
-    // console.log(start.getMonth());
-    // console.log(start.getFullYear());
-    // console.log(start.getDate());
-
-    console.log(this.email);
+    if(this.when === 'All-time') {
+      console.log('Email: ', this.email.value);
+    } else {
+      console.log('Email: ', this.email.value);
+      // eslint-disable-next-line max-len
+      console.log(`Start Date: ${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`);
+      // eslint-disable-next-line max-len
+      console.log(`End Date: ${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`);
+    }
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -18,7 +18,7 @@ export class NcyteDashboardComponent implements OnInit {
     console.log(this.when);
   }
 
-  onChange(event: MatRadioChange) {
+  onRadioChange(event: MatRadioChange) {
     this.when = event.value;
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -48,5 +48,7 @@ export class NcyteDashboardComponent implements OnInit {
       const end = `${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`;
       this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value, { start: start, end: end });
     }
+
+    this.toaster.alert('We\'re working on it!', 'Please check your email for a report of all individual Learning Objects.');
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatRadioChange } from '@angular/material/radio';
 
 @Component({
   selector: 'clark-ncyte-dashboard',
@@ -6,10 +7,18 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./dashboard.component.scss']
 })
 export class NcyteDashboardComponent implements OnInit {
+  when = 'All-time';
 
   constructor() { }
 
   ngOnInit(): void {
   }
 
+  onDownload(): void {
+    console.log(this.when);
+  }
+
+  onChange(event: MatRadioChange) {
+    this.when = event.value;
+  }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -13,6 +13,7 @@ export class NcyteDashboardComponent implements OnInit {
     start: new FormControl(null),
     end: new FormControl(null),
   });
+  email = '';
 
   constructor() { }
 
@@ -22,9 +23,18 @@ export class NcyteDashboardComponent implements OnInit {
   onDownload(): void {
     console.log(this.when);
     console.log(this.range.value);
-  }
 
-  onRadioChange(event: MatRadioChange) {
-    this.when = event.value;
+    // const date = new Date()
+
+    // const start = date.
+
+    // const start: Date = this.range.value.start;
+    // console.log(start);
+
+    // console.log(start.getMonth());
+    // console.log(start.getFullYear());
+    // console.log(start.getDate());
+
+    console.log(this.email);
   }
 }

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 import { MatRadioChange } from '@angular/material/radio';
 
 @Component({
@@ -8,6 +9,10 @@ import { MatRadioChange } from '@angular/material/radio';
 })
 export class NcyteDashboardComponent implements OnInit {
   when = 'All-time';
+  range = new FormGroup({
+    start: new FormControl(null),
+    end: new FormControl(null),
+  });
 
   constructor() { }
 
@@ -16,6 +21,7 @@ export class NcyteDashboardComponent implements OnInit {
 
   onDownload(): void {
     console.log(this.when);
+    console.log(this.range.value);
   }
 
   onRadioChange(event: MatRadioChange) {

--- a/src/app/core/collection.service.ts
+++ b/src/app/core/collection.service.ts
@@ -226,7 +226,6 @@ export class CollectionService {
       start: string,
       end: string
     }) {
-    console.log(collections.length);
     if(collections.length > 0) {
       const route = COLLECTIONS_ROUTES.GET_COLLECTION_REPORT(collections, date);
       this.http

--- a/src/app/core/collection.service.ts
+++ b/src/app/core/collection.service.ts
@@ -238,7 +238,8 @@ export class CollectionService {
         )
         .pipe(
           catchError(this.handleError)
-        );
+        )
+        .toPromise();
     }
   }
 }

--- a/src/app/core/collection.service.ts
+++ b/src/app/core/collection.service.ts
@@ -217,4 +217,29 @@ export class CollectionService {
       this.darkMode502.next(status);
     }
   }
+
+  async generateCollectionReport(
+    collections: string[],
+    email: string,
+    name: string,
+    date?: {
+      start: string,
+      end: string
+    }) {
+    console.log(collections.length);
+    if(collections.length > 0) {
+      const route = COLLECTIONS_ROUTES.GET_COLLECTION_REPORT(collections, date);
+      this.http
+        .post(
+          route,
+          {
+            email,
+            name
+          }
+        )
+        .pipe(
+          catchError(this.handleError)
+        );
+    }
+  }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -8,6 +8,7 @@ export const environment = {
   contentManagerURLAdmin: 'https://api-file-upload.clark.center',
   adminAppUrl: 'https://admin.clark.center',
   utilityWebsocket: 'wss://api-utilities.clark.center',
+  clarkReportsUrl: '',
   s3Bucket: 'clark-prod-file-uploads',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -7,7 +7,6 @@ export const environment = {
   contentManagerURL: 'localhost',
   contentManagerURLAdmin: 'localhost',
   adminAppUrl: 'https://admin.clark.center',
-  clarkReportsUrl: '',
   s3Bucket: 'clark-prod-file-uploads-backup',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -7,6 +7,7 @@ export const environment = {
   contentManagerURL: 'localhost',
   contentManagerURLAdmin: 'localhost',
   adminAppUrl: 'https://admin.clark.center',
+  clarkReportsUrl: '',
   s3Bucket: 'clark-prod-file-uploads-backup',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,6 +12,7 @@ export const environment = {
   contentManagerURLAdmin: 'http://localhost:5100',
   adminAppUrl: 'http://localhost:4100',
   utilityWebsocket: 'ws://localhost:9000',
+  clarkReportsUrl: 'http://localhost:9001',
   s3Bucket: 'clark-dev-file-uploads',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -73,7 +73,7 @@ export const COLLECTIONS_ROUTES = {
     return `${environment.apiURL}/users/curators/${encodeURIComponent(name)}`;
   },
   GET_COLLECTION_REPORT(collections: string[], date?: { start: string, end: string }) {
-    let route = `${environment.clarkReportsUrl}?output=csv&collection=${collections.join(',')}`;
+    let route = `${environment.apiURL}/reports?output=csv&collection=${collections.join(',')}`;
 
     if(date) {
       route += `&start=${date.start}&end=${date.end}`;

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -72,8 +72,14 @@ export const COLLECTIONS_ROUTES = {
   GET_COLLECTION_CURATORS(name: string ) {
     return `${environment.apiURL}/users/curators/${encodeURIComponent(name)}`;
   },
-  GET_COLLECTION_REPORT(collections: string[]) {
-    return `${environment.clarkReportsUrl}?output=csv&collection=${collections.join(',')}`;
+  GET_COLLECTION_REPORT(collections: string[], date?: { start: string, end: string }) {
+    let route = `${environment.clarkReportsUrl}?output=csv&collection=${collections.join(',')}`;
+
+    if(date) {
+      route += `&start=${date.start}&end=${date.end}`;
+    }
+
+    return route;
   }
 };
 

--- a/src/environments/route.ts
+++ b/src/environments/route.ts
@@ -71,6 +71,9 @@ export const COLLECTIONS_ROUTES = {
   },
   GET_COLLECTION_CURATORS(name: string ) {
     return `${environment.apiURL}/users/curators/${encodeURIComponent(name)}`;
+  },
+  GET_COLLECTION_REPORT(collections: string[]) {
+    return `${environment.clarkReportsUrl}?output=csv&collection=${collections.join(',')}`;
   }
 };
 


### PR DESCRIPTION
[23829](https://app.shortcut.com/clarkcan/story/23829/develop-ncyte-statistics-dashboard)

Implements the NCyTE statistics dashboard.

Notes:
- The pie charts aren't implemented in this iteration. I didn't see a route that took statistics of bloom outcomes and learning object sizes by collection.

## Demo

https://github.com/Cyber4All/clark-client/assets/93054689/1025993d-7483-4d45-97a5-4a0d53899461

![Screenshot 2023-07-14 at 11 58 59 AM](https://github.com/Cyber4All/clark-client/assets/93054689/709fa8da-9788-496c-96bc-173c826d91d4)

[_tmp_ncyte-report-2016-01-01to2023-07-14.csv](https://github.com/Cyber4All/clark-client/files/12052030/_tmp_ncyte-report-2016-01-01to2023-07-14.csv)

## Views

### Tablet

https://github.com/Cyber4All/clark-client/assets/93054689/f65ddbec-475e-48b7-906b-0af1687e474b

### 4K

https://github.com/Cyber4All/clark-client/assets/93054689/c86d2f47-ef07-4f1b-8792-8ec537f625a2

