### PR TITLE
added margin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.1.11",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.1.11",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.1.11",
+  "version": "5.2.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -67,6 +67,7 @@ a:visited {
     .icon {
       margin-left: 0;
     }
+    margin: 0px 5px 10px;
   }
 
   &.good {


### PR DESCRIPTION
This PR adds margin between icons to share a LO in details page.

## Before
<img width="302" alt="clark-client-icons-space" src="https://github.com/Cyber4All/clark-client/assets/72763770/b4240b83-cf8d-47a3-82cf-5a8f9c0a3d6d"><br>

## Now
<img width="303" alt="clark-client-icons-now" src="https://github.com/Cyber4All/clark-client/assets/72763770/b2eb3894-a2d8-4a35-be18-b419f9b7ca2b">
