### PR TITLE
changed submission route for resubmitting an object from accepted major/minor

### DIFF
--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -230,17 +230,21 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.currentlySubmittingObject = event;
       this.submitToCollection = true;
     } else {
-      this.learningObjectService.changeStatus({
-        username: event.author.username,
-        objectId: event.id,
-        status: LearningObject.Status.REVIEW,
+      this.collectionService.submit({
+        learningObjectId: event.id,
+        userId: event.author.id,
+        collectionName: event.collection,
       })
-        .then(() => {
-          this.notificationService.success('Done!', 'Learning Object Resubmitted for Review!');
-          event.status = LearningObject.Status.REVIEW;
-        })
-        .catch(() => this.notificationService.error('Error!',
-          'There was an issue resubmitting the learning object, please try again later!'));
+      .then(() => {
+        this.notificationService.success('Done!', 'Learning Object Resubmitted for Review!');
+        event.status = LearningObject.Status.WAITING;
+      })
+      .catch(e => {
+        this.notificationService.error(
+          'Error!',
+          `There was an issue resubmitting the learning object, please try again later...`,
+        );
+      });
     }
   }
 


### PR DESCRIPTION
This PR updates the `accepted_major`/`accepted_minor` submission logic on clark-client to move the object back to a waiting state. This will also regenerate a shortcut story for the content team by hitting this route.