### PR TITLE
feature/sc-26611/change-remove-specific-dates-checkbox-in

### DIFF
--- a/src/environments/strings.ts
+++ b/src/environments/strings.ts
@@ -15,9 +15,10 @@ export const CHANGE_AUTHORIZATION_LIST = [
       'Our team will review and make necessary corrections to enhance the overall quality of the content.',
   },
   {
-    permission: 'Remove Specific Dates',
+    permission: 'Remove Course Specific Information',
     description:
-      'We will eliminate any specific dates related to assignments or schedules, promoting timeless and adaptable material.',
+      'We will eliminate any specific dates related to assignments or schedules as well as school specific information, to ' +
+      'promote timeliness and adaptability.',
   },
   {
     permission: 'Remove Identifying Information',


### PR DESCRIPTION
This PR changes the wording of a permission request to change course specific information.

**New Modal**

<img width="892" alt="Screenshot 2023-10-05 at 11 44 23 AM" src="https://github.com/Cyber4All/clark-client/assets/72763770/d1bbda54-4333-417f-a542-745c4a764944">
