### PR TITLE
bug/sc-26697/cannot-change-status-of-learning-object-while

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -77,10 +77,10 @@ export class ChangeStatusModalComponent implements OnInit {
         ];
         break;
       case LearningObject.Status.ACCEPTED_MINOR:
-        this.statuses = [LearningObject.Status.REVIEW];
+        this.statuses = [LearningObject.Status.WAITING];
         break;
       case LearningObject.Status.ACCEPTED_MAJOR:
-        this.statuses = [LearningObject.Status.REVIEW];
+        this.statuses = [LearningObject.Status.WAITING];
         break;
       case LearningObject.Status.PROOFING:
         this.statuses = [LearningObject.Status.RELEASED, LearningObject.Status.REJECTED];


### PR DESCRIPTION
This PR updates the client to make a valid status change from `ACCEPTED_MAJOR` and `ACCEPTED_MINOR` to be `WAITING` not `REVIEW`