### PR TITLE
Add NCyTe statistics dashboard button

### DIFF
--- a/src/app/collection/pages/collection-ncyte/components/header/header.component.html
+++ b/src/app/collection/pages/collection-ncyte/components/header/header.component.html
@@ -1,8 +1,12 @@
 <section class="hero">
     <div class="inner">
-       <img src="../../../../../../assets/collections/ncyte/ncyte_full_name.png" alt="NCyTE Center Logo" class="logo">
-       <div class="buttons">
-        <button class="button neutral" aria-label='Browse Collection' (activate)="navigateToBrowse()">Browse Collection</button>
-    </div>
+        <img src="../../../../../../assets/collections/ncyte/ncyte_full_name.png" alt="NCyTE Center Logo" class="logo">
+        <div class="buttons">
+            <button class="button neutral" aria-label='Browse Collection' (activate)="navigateToBrowse()">Browse
+                Collection</button>
+            <button *ngIf="isUserAuthorized" class="button neutral" aria-label='Statistics Dashboard'
+                (activate)="navigateToStatistics()">
+                Statistics Dashboard</button>
+        </div>
     </div>
 </section>

--- a/src/app/collection/pages/collection-ncyte/components/header/header.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-
+import { AuthService } from 'app/core/auth.service';
 @Component({
   selector: 'clark-ncyte-header',
   templateUrl: './header.component.html',
@@ -8,16 +8,22 @@ import { Router } from '@angular/router';
 })
 export class HeaderComponent implements OnInit {
 
-  @Input () collectionAbv: string;
+  @Input() collectionAbv: string;
+  isUserAuthorized: boolean = false;
   constructor(
     private router: Router,
+    private auth: AuthService,
   ) { }
 
   ngOnInit(): void {
+    this.isUserAuthorized = this.auth.accessGroups.includes('curator@ncyte') || this.auth.accessGroups.includes('admin') || this.auth.accessGroups.includes('editor@ncyte');
   }
 
   navigateToBrowse() {
-    this.router.navigate(['/browse'], { queryParams: { collection: this.collectionAbv, currPage: 1 }});
+    this.router.navigate(['/browse'], { queryParams: { collection: this.collectionAbv, currPage: 1 } });
   }
 
+  navigateToStatistics() {
+    this.router.navigate(['/collections/ncyte/dashboard']);
+  }
 }


### PR DESCRIPTION
This implements a 'statistics dashboard' button on the NCyTE page that is only visible to admins, ncyte e
<img width="925" alt="Screenshot 2023-10-23 at 4 13 30 PM" src="https://github.com/Cyber4All/clark-client/assets/92770851/a7ff2800-aa42-4030-9eaf-0067cf7ba178">
ditors and curators.