### PR TITLE
Feature/sc-29015/add-link-to-standard-guidelines-in-lo-builder

### DIFF
--- a/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.html
+++ b/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.html
@@ -11,6 +11,9 @@
   <div class="results">
     <ng-container [ngTemplateOutlet]="listTemplate" [ngTemplateOutletContext]="{ items: searchStringValue !== '' ? searchResults : suggestions }"></ng-container>
   </div>
+<div class="standard-guidelines-link">
+    <a href="https://standard-guidelines.clark.center/guidelines" target="_blank">Want to view all guidelines? Click
+        here!</a>
 </div>
 <clark-skip-link title="Go back to Learning Outcome" skipLocation="outcome"></clark-skip-link>
 <clark-skip-link title="Go to Add New Learning Outcome" skipLocation="form"></clark-skip-link>

--- a/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.scss
+++ b/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.scss
@@ -78,3 +78,10 @@
     margin-bottom: 10px;
   }
 }
+
+.standard-guidelines-link {
+  margin-top: 10px;
+  width:100%;
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
This PR adds a link to standard guidlines link at the `Curricular Guidelines` component.
<img width="373" alt="Screenshot 2024-02-21 at 3 00 39 PM" src="https://github.com/Cyber4All/clark-client/assets/72763770/21f445e4-bf15-4bbf-bcd0-04cabc96452d">
