### PR TITLE
Adding Instagram logo to clark footer & Updating other logos

### DIFF
--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -66,6 +66,9 @@
     </div>
   </div>
   <div class="share-icons">
+    <a href="https://www.instagram.com/clark_secured/" class="button icon-only instagram" id="instagram" aria-label="Go to CLARK Instagram page">
+      <i class="fab fa-instagram"></i>
+    </a>
     <a href="https://twitter.com/theclarkcyber" class="button icon-only twitter" id="twitter" aria-label="Go to CLARK Twitter page">
       <i class="fab fa-twitter"></i>
     </a>

--- a/src/app/cube/shared/footer/footer.component.scss
+++ b/src/app/cube/shared/footer/footer.component.scss
@@ -86,7 +86,7 @@ footer {
 
   .share-icons {
     text-align: center;
-    padding: 0px;
+    padding: 0;
     margin: 0;
   
     & > a {

--- a/src/app/cube/shared/footer/footer.component.scss
+++ b/src/app/cube/shared/footer/footer.component.scss
@@ -86,26 +86,19 @@ footer {
 
   .share-icons {
     text-align: center;
-    padding: 0;
+    padding: 0px;
     margin: 0;
   
     & > a {
-      background: $blue-accent;
+      background: none;
       color: white !important;
       transform: scale(1);
       cursor: pointer;
       margin-left: 10px;
+      font-size: 40px;
   
       &:active:hover {
         transform: scale(0.95);
-      }
-  
-      &.twitter {
-        background: #1da1f2;
-      }
-  
-      &.linkedin {
-        background: #0077b5;
       }
     }
   }

--- a/src/app/cube/shared/footer/footer.component.scss
+++ b/src/app/cube/shared/footer/footer.component.scss
@@ -95,7 +95,7 @@ footer {
       transform: scale(1);
       cursor: pointer;
       margin-left: 10px;
-      font-size: 40px;
+      font-size: 25px;
   
       &:active:hover {
         transform: scale(0.95);


### PR DESCRIPTION
## What this PR does / why we need it

Adds Instagram logo linked to CLARK instagram to CLARK footer and updates other logos. Other logos updated due to instagram background color being too dark.

## Changes proposed in this pull request:

### Added

- Instagram Logo linked to CLARK instagram

### Changed

- Twitter and LinkedIn logo background and size

### Removed

- Solid color background on Twitter and LinkedIn logo

### Fixed

- N/A

### Security

- N/A

## Acceptance Criteria Met

- [x] Doc changes if needed
- [x] Testing changes if needed
- [x] All review conversations resolved
- [x] All workflow checks passing (automatically enforced)

<img width="1403" alt="Screenshot 2024-03-12 at 12 31 56 PM" src="https://github.com/Cyber4All/clark-client/assets/150100412/a0b42eb0-e6ee-4f8b-b0ac-4bbd6ad58c3b">

Story details: https://app.shortcut.com/clarkcan/story/29246

**Special notes for your reviewer**: