### PR TITLE
add competency constructor link to resources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.6.4",
+      "version": "5.6.5",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/navBarDropdown.service.ts
+++ b/src/app/core/navBarDropdown.service.ts
@@ -34,7 +34,7 @@ export class NavbarDropdownService {
     {name: 'Standard Guidelines', link: 'https://standard-guidelines.clark.center'},
     {name: 'Task Tool', link: 'https://tasktool.clark.center'},
     {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},
-    {name: 'Competency Constructor', link: 'https://cybercompetencies.com'}
+    {name: 'CPNC Competency Constructor', link: 'https://cybercompetencies.com'}
     ];
     public topics = new BehaviorSubject<Topic[]>([]);
     public topicSelection = new BehaviorSubject<Topic>({_id: '', name: ''});

--- a/src/app/core/navBarDropdown.service.ts
+++ b/src/app/core/navBarDropdown.service.ts
@@ -33,7 +33,8 @@ export class NavbarDropdownService {
     public externalResources = [
     {name: 'Standard Guidelines', link: 'https://standard-guidelines.clark.center'},
     {name: 'Task Tool', link: 'https://tasktool.clark.center'},
-    {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'}
+    {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},
+    {name: 'Competency Constructor', link: 'https://cybercompetencies.com'}
     ];
     public topics = new BehaviorSubject<Topic[]>([]);
     public topicSelection = new BehaviorSubject<Topic>({_id: '', name: ''});


### PR DESCRIPTION
# Description
This PR quickly adds a link to competency constructor in the resources tab of clark
<img width="1510" alt="image" src="https://github.com/Cyber4All/clark-client/assets/55514493/e225ec59-a325-4c4f-b8d7-2cc8fe63aff5">
