### PR TITLE
Mfranz1/clark reports fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.6.5",
+      "version": "5.6.6",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.6.5",
+  "version": "5.6.6",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/collection.service.ts
+++ b/src/app/core/collection.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 
 import { USER_ROUTES, PUBLIC_LEARNING_OBJECT_ROUTES, COLLECTIONS_ROUTES } from '../../environments/route';
 import { BehaviorSubject, throwError } from 'rxjs';
@@ -19,6 +19,7 @@ export interface Collection {
 export class CollectionService {
   private collections: Collection[];
   private loading$ = new BehaviorSubject<boolean>(true);
+  private headers: HttpHeaders = new HttpHeaders();
   darkMode502 = new BehaviorSubject<boolean>(true);
   constructor(private http: HttpClient) {
     this.fetchCollections()
@@ -242,7 +243,8 @@ export class CollectionService {
           {
             email,
             name
-          }
+          },
+          { headers: this.headers, withCredentials: true }
         )
         .pipe(
           catchError(this.handleError)


### PR DESCRIPTION
# Description
Two issues occurred:
1. The lambda went ideal due to lack of use.
2. It seems at some point authorization was droped and/or added to this route resulting in the 401 being thrown

Fixes:
* Lambda was restarted
* Event bridge rule to hit the service
* Added authorization headers through client api request