### PR TITLE
Chore/sc 30647/update toggle bundle logic in admin builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.6.6",
+  "version": "5.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.6.6",
+      "version": "5.6.7",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.6.6",
+  "version": "5.6.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/components/file-list-item/file-list-item.component.ts
@@ -73,7 +73,7 @@ export class FileListItemComponent implements OnInit {
    */
   checkAccessGroups(): boolean {
     if(this.accessGroups && this.accessGroups.length > 0) {
-      return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('curator'));
+      return this.inBuilder && (this.accessGroups.includes('admin') || this.accessGroups.includes('editor'));
     }
     return false;
   }


### PR DESCRIPTION
# Description
Editors were not able to see the "toggle bundle" option in the builder. This PR quickly addresses that issue by specifying the editor access group when we check to see if that toggle button should display or not.