### PR TITLE
fix: bad parameters passed to `getFirstSubmission`

### DIFF
--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -266,7 +266,7 @@ export class SubmitComponent implements OnInit {
    * @param collection The selected collection
    */
   getCollectionSelected(collection: string) {
-    this.learningObjectService.getFirstSubmission(this.learningObject.author.id, this.learningObject.id, collection, true)
+    this.learningObjectService.getFirstSubmission(this.learningObject.id, collection)
       .then(val => {
         this.collection = collection;
         if (!val.isFirstSubmission) {


### PR DESCRIPTION
this fixes commit 9a1324ed since it broke the tree. there was a file that was still using the old parameters, so that was the only change needed