### PR TITLE
[sc-30887] Remove NSA logos

### DIFF
--- a/src/app/cube/collection-details/collection-details.component.html
+++ b/src/app/cube/collection-details/collection-details.component.html
@@ -30,7 +30,7 @@
     <cube-featured [collection]="key"></cube-featured>
     <div class="faq-section" *ngIf="collection?.faq">
       <div class="header">Frequently Asked Questions</div>
-      <clark-faq-section [faq]="collection?.faq"></clark-faq-section>      
+      <clark-faq-section [faq]="collection?.faq"></clark-faq-section>
     </div>
   </section>
 </div>

--- a/src/app/cube/collection-details/collection-details.component.ts
+++ b/src/app/cube/collection-details/collection-details.component.ts
@@ -54,6 +54,10 @@ export class CollectionDetailsComponent implements OnInit, OnDestroy {
 
     this.pictureLocation = '../../../assets/images/collections/' + this.collection.abvName + '.png';
 
+    if (this.collection.abvName === 'nccp') {
+      this.resetPictureLocation();
+    }
+
     if (this.collection.abvName === 'plan c') {
       this.showContribute = true;
     }

--- a/src/app/cube/shared/footer/footer.component.html
+++ b/src/app/cube/shared/footer/footer.component.html
@@ -31,9 +31,6 @@
     <section class="grants">
       <div class="images">
         <div class="logo-wrapper">
-          <img alt="National Security Agency Logo" src="assets/images/nsa.png" />
-        </div>
-        <div class="logo-wrapper">
           <a href="https://www.towson.edu/" target="_blank">
             <img src="assets/images/towson_logo.png" alt="Towson University Logo">
           </a>
@@ -57,12 +54,12 @@
         <a href="https://502project.org" target="_blank" aria-label="The 502 Project">
           <img src="assets/images/502_project_white.png" class="project_502" alt="The 502 Project">
         </a>
-      </div>  
+      </div>
       <div class="logo-wrapper">
         <a href="https://www.gula.tech/" target="_blank" aria-label="GULA Tech">
           <img src="assets/images/gula_logo.png" class="gula" alt="GULA Tech">
         </a>
-      </div> 
+      </div>
     </div>
   </div>
   <div class="share-icons">

--- a/src/app/cube/shared/learning-object/learning-object.component.html
+++ b/src/app/cube/shared/learning-object/learning-object.component.html
@@ -79,7 +79,7 @@
           15 WEEKS
         </div>
       </div>
-    
+
     <div class="details">
       <span class="author">
         {{ learningObject.contributors[0]?.name | titlecase }} at

--- a/src/app/cube/shared/learning-object/learning-object.component.ts
+++ b/src/app/cube/shared/learning-object/learning-object.component.ts
@@ -144,6 +144,7 @@ export class LearningObjectListingComponent implements OnInit, OnChanges, OnDest
       this.learningObject.collection !== 'plan c' &&
       this.learningObject.collection !== 'max_power' &&
       this.learningObject.collection !== 'Drafts' &&
+      this.learningObject.collection !== 'nccp' &&
       this.learningObject.collection !== ''
     ) {
       this.pictureLocation =

--- a/src/app/cube/usage-stats/usage-stats.component.html
+++ b/src/app/cube/usage-stats/usage-stats.component.html
@@ -8,11 +8,11 @@
   <div class="charts top">
     <cube-distribution-chart [ariaLabel]="outcomeDistributionChartAria" class="chart" [chart]="outcomeDistributionChart" [moreInfoLink]="outcomeLearnMoreLink"
       (chartNotHovered)="handleChartNotHovered()"></cube-distribution-chart>
-    <cube-distribution-chart [ariaLabel]="lengthBreakdownChartAria" class="chart" [chart]="lengthDistributionChart" [moreInfoLink]="lengthLearnMoreLink"
+    <cube-distribution-chart [ariaLabel]="lengthBreakdownChartAria" class="chart" [chart]="lengthDistributionChart"
       (chartNotHovered)="handleChartNotHovered()"></cube-distribution-chart>
   </div>
   <div class="charts bottom">
-    <cube-distribution-chart [ariaLabel]="organizationBreakdownChartAria" class="chart" [chart]="organizationBreakdownChart" 
+    <cube-distribution-chart [ariaLabel]="organizationBreakdownChartAria" class="chart" [chart]="organizationBreakdownChart"
       (chartNotHovered)="handleChartNotHovered()"></cube-distribution-chart>
     <clark-top-downloads [learningObjects]="learningObjects" [loading]="loading"></clark-top-downloads>
   </div>

--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -55,7 +55,6 @@ export class UsageStatsComponent implements OnInit {
   outcomeLearnMoreLink = 'https://cft.vanderbilt.edu/guides-sub-pages/blooms-taxonomy';
 
   lengthDistributionChart: PieChart;
-  lengthLearnMoreLink = 'http://about.clark.center/tutorial/#Uploading';
 
   counterStats: CounterStat[] = [];
 

--- a/src/app/shared/components/collection-card/collection-card.component.ts
+++ b/src/app/shared/components/collection-card/collection-card.component.ts
@@ -19,7 +19,8 @@ export class CollectionCardComponent implements OnInit {
       this.collection.abvName !== 'intro_to_cyber' &&
       this.collection.abvName !== 'secure_coding_community' &&
       this.collection.abvName !== 'plan c' &&
-      this.collection.abvName !== 'max_power'
+      this.collection.abvName !== 'max_power' &&
+      this.collection.abvName !== 'nccp'
     ) {
       this.pictureLocation =
         '/assets/images/collections/' +


### PR DESCRIPTION
This removes the National Security Agency's logo across the site. See screenshots for places where logo was removed.
This also removes a dead link in the system usage page

https://app.shortcut.com/clarkcan/story/30887/remove-nsa-logo-from-clark

Footer:
<img width="1129" alt="image" src="https://github.com/Cyber4All/clark-client/assets/17275723/35859b48-3c60-4104-972e-5283443c5f6a">

Home:
<img width="1033" alt="image" src="https://github.com/Cyber4All/clark-client/assets/17275723/52613bf3-d903-4d66-8b50-2e6d9fd8bb37">

Collection page:
<img width="507" alt="image" src="https://github.com/Cyber4All/clark-client/assets/17275723/f7f5b53d-0596-4827-ae31-ca1bf257cc27">

Features collections:
<img width="1160" alt="image" src="https://github.com/Cyber4All/clark-client/assets/17275723/431ce379-b0ed-495e-8408-4c8d81575f7a">

Learning object items:
<img width="1406" alt="image" src="https://github.com/Cyber4All/clark-client/assets/17275723/7cc738b3-7e7f-4824-9dd7-4c3c17fd4497">
