### PR TITLE
[sc-28554] implement removing files from a los bundle

### DIFF
--- a/src/app/core/learning-object-module/bundling/bundling.routes.ts
+++ b/src/app/core/learning-object-module/bundling/bundling.routes.ts
@@ -35,10 +35,8 @@ export const BUNDLING_ROUTES = {
      * @param username - The username of the author of the learning object
      * @param learningObjectId - The id of the learning object to toggle the bundled status
      */
-    TOGGLE_BUNDLE_FILE(params: { username: string, learningObjectId: string }) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            params.username
-        )}/learning-objects/${encodeURIComponent(
+    TOGGLE_BUNDLE_FILE(params: { learningObjectId: string }) {
+        return `${environment.apiURL}/learning-objects/${encodeURIComponent(
             params.learningObjectId
         )}/files/bundle`;
     },

--- a/src/app/core/learning-object-module/learning-object/learning-object.service.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.service.ts
@@ -143,9 +143,9 @@ export class LearningObjectService {
     );
   }
 
-  toggleFilesToBundle(username: string, learningObjectId: string, selected: string[], deselected: string[]) {
+  toggleFilesToBundle(learningObjectId: string, selected: string[], deselected: string[]) {
     return this.http.patch(
-      BUNDLING_ROUTES.TOGGLE_BUNDLE_FILE({ username, learningObjectId }),
+      BUNDLING_ROUTES.TOGGLE_BUNDLE_FILE({ learningObjectId }),
       {
         selected: selected,
         deselected: deselected,

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -51,19 +51,17 @@ export class LearningObjectService {
   /**
    * Calls LO service to update the packageable status of toggled files
    *
-   * @param username The currently logged in user
    * @param learningObjectID The current learning object's ID
    * @param fileIDs An array of file IDs that need to be updated
    * @param state The new packageable property to update to
    * @returns A promise
    */
   toggleBundle(
-    username: string,
     learningObjectId: string,
     fileIDs: string[],
     state: boolean
   ) {
-    const route = BUNDLING_ROUTES.TOGGLE_BUNDLE_FILE({ username, learningObjectId });
+    const route = BUNDLING_ROUTES.TOGGLE_BUNDLE_FILE({ learningObjectId });
 
     return this.http
       .patch(

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -68,7 +68,7 @@ export class LearningObjectService {
         route,
         {
           fileIDs: fileIDs,
-          state: state
+          packagable: state
         },
         { headers: this.headers, withCredentials: true }
       )

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -435,7 +435,7 @@ export class BuilderStore {
 
     // add folder's files to fileIDs list
     folder.getFiles().forEach(file => {
-      fileIDs.push(file.id);
+      fileIDs.push(file._id);
     });
 
     // recursively check subfolders for files and do the same thing
@@ -465,7 +465,7 @@ export class BuilderStore {
         event.state
       );
     } else { // event.item is a File
-      const fileID = [event.item.id];
+      const fileID = [event.item._id];
       await this.learningObjectService.toggleBundle(
         this.learningObject.id,
         fileID,

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -856,7 +856,7 @@ export class BuilderStore {
     let index = -1;
     for (let i = 0; i < this.learningObject.materials.files.length; i++) {
       const file = this.learningObject.materials.files[i];
-      if (file.id === fileId) {
+      if (file._id === fileId) {
         index = i;
         break;
       }

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -460,7 +460,6 @@ export class BuilderStore {
     if (event.item instanceof DirectoryNode) { // event.item is a Folder
       const fileIDs = this.getAllFolderFileIDs(event.item);
       await this.learningObjectService.toggleBundle(
-        this.auth.username,
         this.learningObject.id,
         fileIDs,
         event.state
@@ -468,7 +467,6 @@ export class BuilderStore {
     } else { // event.item is a File
       const fileID = [event.item.id];
       await this.learningObjectService.toggleBundle(
-        this.auth.username,
         this.learningObject.id,
         fileID,
         event.state

--- a/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/file-manager/file-manager.component.ts
@@ -157,7 +157,7 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     };
 
     if (!(file instanceof DirectoryNode)) {
-      edit.id = file.id;
+      edit.id = file._id;
     } else {
       edit.path = file.getPath();
       edit.isFolder = true;
@@ -221,7 +221,7 @@ export class FileManagerComponent implements OnInit, OnDestroy {
     }
     let fileIds = [];
     for (const file of files) {
-      fileIds.push(file.id);
+      fileIds.push(file._id);
     }
     for (const child of children) {
       fileIds = [...fileIds, ...this.getFileIds(child)];

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -695,7 +695,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
   async handleFileDownload(file: LearningObject.Material.File) {
     const learningObject = await this.learningObject$.pipe(take(1)).toPromise();
     const loId = learningObject.id;
-    const url = FILE_ROUTES.DOWNLOAD_FILE(loId, file.id);
+    const url = FILE_ROUTES.DOWNLOAD_FILE(loId, file._id);
     window.open(url, '__blank');
   }
 

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -53,7 +53,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   file: LearningObject.Material.File;
   directoryListing = [];
 
-  toggleToolTip = `Selected items will be included in the bundle download. 
+  toggleToolTip = `Selected items will be included in the bundle download.
     Deselected items will be accessible through a download link in the PDF.`;
   accessGroups: string[];
 
@@ -186,7 +186,7 @@ export class FileListViewComponent implements OnInit, OnDestroy {
     if (elm instanceof DirectoryNode) {
       return elm.getPath();
     }
-    return elm.id || index;
+    return elm._id || index;
   }
 
   /**

--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -838,7 +838,8 @@ export namespace LearningObject {
 
   export namespace Material {
     export interface File {
-      id: string;
+      _id: string;
+      id: string; // Keeping for backward compat, may wanna remove?
       name: string;
       fileType: string;
       extension: string;

--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -839,7 +839,6 @@ export namespace LearningObject {
   export namespace Material {
     export interface File {
       _id: string;
-      id: string; // Keeping for backward compat, may wanna remove?
       name: string;
       fileType: string;
       extension: string;


### PR DESCRIPTION
Updates the implementation for toggling file bundle states on the client, see https://app.shortcut.com/clarkcan/story/28554/implement-removing-files-from-a-los-bundle-into-clark-service 

Example:
https://github.com/Cyber4All/clark-client/assets/17275723/2dd0a253-1984-4347-aefc-dac32aaf8015

