### PR TITLE
fix: add temporary else block for fetching LOs by ID 

### DIFF
--- a/src/app/core/learning-object-module/uri-retriever.service.ts
+++ b/src/app/core/learning-object-module/uri-retriever.service.ts
@@ -211,6 +211,9 @@ export class UriRetrieverService {
       route = LEGACY_USER_ROUTES.GET_LEARNING_OBJECT(params.cuidInfo.cuid);
     } else if (params.cuidInfo) {
       route = LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES.GET_PUBLIC_LEARNING_OBJECT(params.cuidInfo.cuid, params.cuidInfo.version);
+    } else if (params.id) {
+      // TODO: Update this to use CUID only.
+      route = LEGACY_USER_ROUTES.GET_LEARNING_OBJECT(params.id);
     } else {
       const err = this.userError(params);
       throw err;


### PR DESCRIPTION
some pages in the client like relevancy builder will fetch LOs by IDs, not by CUID. this prevents these pages from loading because they won't have an LO to load anyway.

this was a blocking issue for stories revolving around the relevancy builder, and might affect other places too.