### PR TITLE
[sc-30912] Update the implementation for update learning object mappings

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -1,5 +1,5 @@
 <div class="dashboard-item">
-  <div class="row-item">  
+  <div class="row-item">
     <clark-checkbox [value]="selected" (action)="toggleSelect($event)"></clark-checkbox>
     <div>
       <div tabindex="0" class="status" [attr.aria-label]="'Learning Object Status: ' + learningObject.status + '. ' + statusDescription" [ngClass]="learningObject.status" [tip]="statusDescription" [tipDisabled]="!statusDescription" tipPosition="top">
@@ -47,7 +47,7 @@
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
       <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
       <li *ngIf="learningObject.status === 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
-      <li (click)="goToUrl('relevancy')"><i class="far fa-puzzle-piece"></i>Map & Tag</li>
+      <li *ngIf="learningObject.status !== 'released' && learningObject.status !== 'unreleased'" (click)="goToUrl('relevancy')"><i class="far fa-puzzle-piece"></i>Map & Tag</li>
     </ul>
   </div>
 </clark-context-menu>
@@ -84,7 +84,7 @@
   <div class="modal-container" #popupInner>
     <clark-change-author (close)="toggleChangeAuthorModal(false)" [highlightedLearningObject]="learningObject" [statusDescription]="statusDescription"></clark-change-author>
   </div>
-</clark-popup> 
+</clark-popup>
 
 <clark-popup *ngIf="showRelevancyDate" (closed)="toggleRelevancyDate(false)">
   <div class="modal-container" #popupInner>

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -111,7 +111,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
   get mapAndTag() {
     if (this.auth.user && this.auth.user.accessGroups && !this.userIsAuthor) {
-      const privileges = ['admin', 'editor', 'mapper', 'curator', 'reviewer'];
+      const privileges = ['admin', 'editor', 'mapper'];
       if (this.auth.user.accessGroups.some(priv => privileges.includes(priv))) {
         return true;
       }

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -352,7 +352,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
    * Opens the relevancy builder
    */
   mapAndTagObject() {
-    this.router.navigate([`/onion/relevancy-builder/${this.learningObject.id}`]);
+    this.router.navigate([`/onion/relevancy-builder/${this.learningObject.cuid}`]);
   }
 
   private capitalizeName(name) {

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -9,7 +9,7 @@ import {
   ChangeDetectionStrategy,
   ChangeDetectorRef
 } from '@angular/core';
-import { LearningObject } from '@entity';
+import { LearningObject } from '../../../../../entity/learning-object/learning-object';
 import { AuthService } from 'app/core/auth-module/auth.service';
 import { TOOLTIP_TEXT } from '@env/tooltip-text';
 import { Subject } from 'rxjs';
@@ -110,7 +110,9 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   }
 
   get mapAndTag() {
-    if (this.auth.user && this.auth.user.accessGroups && !this.userIsAuthor) {
+    const untaggable = this.learningObject.status === LearningObject.Status.RELEASED
+                              || this.learningObject.status === LearningObject.Status.UNRELEASED;
+    if (this.auth.user && this.auth.user.accessGroups && !this.userIsAuthor && !untaggable) {
       const privileges = ['admin', 'editor', 'mapper'];
       if (this.auth.user.accessGroups.some(priv => privileges.includes(priv))) {
         return true;


### PR DESCRIPTION
This PR introduces changes that remove curators and reviewers from accessing the Map and Tag feature in learning objects and adds some checks to ensure that appropriate access groups reach the map/tag page. See https://app.shortcut.com/clarkcan/story/30912/update-the-implementation-for-update-learning-object-mappings

Video:
https://github.com/Cyber4All/clark-client/assets/17275723/45745e64-b080-492d-9f19-c3252020a27f