### PR TITLE
Implement updating the next check-date of a learning object (Clark-service)

### DIFF
--- a/src/app/admin/components/relevancy-date/relevancy-date.component.ts
+++ b/src/app/admin/components/relevancy-date/relevancy-date.component.ts
@@ -34,7 +34,7 @@ export class RelevancyDateComponent implements OnInit {
   }
 
   async setDate() {
-    await this.relevancyService.setNextCheckDate(this.learningObject.author.username, this.learningObject._id, this.selected);
+    await this.relevancyService.setNextCheckDate(this.learningObject._id, this.selected);
     this.close.emit();
   }
 

--- a/src/app/core/learning-object-module/relevancy/relevancy.routes.ts
+++ b/src/app/core/learning-object-module/relevancy/relevancy.routes.ts
@@ -3,15 +3,12 @@ import { environment } from '../../../../environments/environment';
 export const RELEVANCY_ROUTES = {
     /**
      * Request to update the next-check-date of a learning object
-     * @param username - The username of the author of the learning object
      * @param id - The id of the learning object to update
      * @auth required
      * @method PATCH
      */
-    UPDATE_RELEVANCY_CHECK_DATE(username: string, id: string) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            username
-        )}/learning-objects/${encodeURIComponent(id)}/relevancy-check`;
+    UPDATE_RELEVANCY_CHECK_DATE(id: string) {
+        return `${environment.apiURL}/learning-objects/${encodeURIComponent(id)}/relevancy-check`;
     },
     /**
      * Request to update the curricular guidelines of a learning object

--- a/src/app/core/learning-object-module/relevancy/relevancy.service.ts
+++ b/src/app/core/learning-object-module/relevancy/relevancy.service.ts
@@ -26,13 +26,12 @@ export class RelevancyService {
   /**
    * Sets the nextCheck of a learning object
    *
-   * @param username Username of the author
    * @param learningObjectId learningObjectId
    * @param date The date that nextCheck needs to updated to
    */
-  async setNextCheckDate(username: string, learningObjectId: string, date: Date): Promise<any> {
+  async setNextCheckDate(learningObjectId: string, date: Date): Promise<any> {
     return this.http
-      .patch(RELEVANCY_ROUTES.UPDATE_RELEVANCY_CHECK_DATE(username, learningObjectId),
+      .patch(RELEVANCY_ROUTES.UPDATE_RELEVANCY_CHECK_DATE(learningObjectId),
         { date },
         {
           headers: this.headers,


### PR DESCRIPTION
- Client implementations for setting the next-check date of a LO in CLARK-Service.
- Just updated the code by removing the username parameter from the route.
- Part of [Update Clark Client with Learning Object Service Changes](https://app.shortcut.com/clarkcan/story/29548/update-clark-client-with-learning-object-service-changes) story

https://github.com/Cyber4All/clark-client/assets/92770851/d2a1e05f-2103-473f-9197-e03e47ef7b80

