### PR TITLE
Implement updating the collection of a learning object (Clark-service)

### DIFF
--- a/src/app/admin/components/change-collection/change-collection.component.ts
+++ b/src/app/admin/components/change-collection/change-collection.component.ts
@@ -40,7 +40,7 @@ export class ChangeCollectionComponent implements OnInit {
    * Confirms the object's new submitted collection
    */
   confirm() {
-    this.adminCollectionService.updateSubmittedCollection(this.object.author.username, this.object.cuid, this.selectedCollection)
+    this.adminCollectionService.updateSubmittedCollection(this.object.cuid, this.selectedCollection)
       .then(() => this.object.collection = this.selectedCollection)
       .catch(() => this.toaster.error('Error', 'There was an error changing collections, please try again later.'))
       .finally(() => this.close.emit());

--- a/src/app/admin/core/collection.service.ts
+++ b/src/app/admin/core/collection.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { LEGACY_COLLECTIONS_ROUTES } from 'app/core/learning-object-module/learning-object/learning-object.routes';
+import { LEARNING_OBJECT_ROUTES } from 'app/core/learning-object-module/learning-object/learning-object.routes';
 
 @Injectable({
   providedIn: 'root'
@@ -18,7 +18,7 @@ export class CollectionService {
    */
   async updateSubmittedCollection(cuid: string, collection: string) {
     await this.http.patch(
-      LEGACY_COLLECTIONS_ROUTES.UPDATE_LEARNING_OBJECT_COLLECTION(cuid),
+      LEARNING_OBJECT_ROUTES.UPDATE_LEARNING_OBJECT_COLLECTION(cuid),
       { collection }, { withCredentials: true, responseType: 'text' }
     ).toPromise();
   }

--- a/src/app/admin/core/collection.service.ts
+++ b/src/app/admin/core/collection.service.ts
@@ -16,9 +16,9 @@ export class CollectionService {
    * @param cuid The cuid of the object
    * @param collection The collection changing to
    */
-  async updateSubmittedCollection(username: string, cuid: string, collection: string) {
+  async updateSubmittedCollection(cuid: string, collection: string) {
     await this.http.patch(
-      LEGACY_COLLECTIONS_ROUTES.UPDATE_LEARNING_OBJECT_COLLECTION(username, cuid),
+      LEGACY_COLLECTIONS_ROUTES.UPDATE_LEARNING_OBJECT_COLLECTION(cuid),
       { collection }, { withCredentials: true, responseType: 'text' }
     ).toPromise();
   }

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -21,6 +21,18 @@ export const LEARNING_OBJECT_ROUTES = {
     },
 
     /**
+     * Request to update the collection of a learning object
+     * @method PATCH
+     * @auth required
+     * @param learningObjectCuid - The cuid of the learning object to update
+     */
+        UPDATE_LEARNING_OBJECT_COLLECTION(learningObjectCuid: string) {
+            return `${environment.apiURL}/learning-objects/${encodeURIComponent(
+                learningObjectCuid
+            )}/collection`;
+        },
+
+    /**
      * Path to create a new learning object
      * @returns LearningObject
      */
@@ -64,18 +76,6 @@ export const LEGACY_COLLECTIONS_ROUTES = {
     ADD_LEARNING_OBJECT_TO_COLLECTION(learningObjectId: string) {
         return `${environment.apiURL}/learning-objects/${encodeURIComponent(learningObjectId)}/collections`;
     },
-    /**
-     * Request to update the collection of a learning object
-     * @method PATCH
-     * @auth required
-     * @param learningObjectCuid - The cuid of the learning object to update
-     */
-    UPDATE_LEARNING_OBJECT_COLLECTION(learningObjectCuid: string) {
-        return `${environment.apiURL}/learning-objects/${encodeURIComponent(
-            learningObjectCuid
-        )}/collection`;
-    },
-
     GET_COLLECTION_CURATORS(name: string) {
         return `${environment.apiURL}/users/curators/${encodeURIComponent(name)}`;
     },

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -68,13 +68,10 @@ export const LEGACY_COLLECTIONS_ROUTES = {
      * Request to update the collection of a learning object
      * @method PATCH
      * @auth required
-     * @param username - The username of the author of the learning object
      * @param learningObjectCuid - The cuid of the learning object to update
      */
-    UPDATE_LEARNING_OBJECT_COLLECTION(username: string, learningObjectCuid: string) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            username
-        )}/learning-objects/${encodeURIComponent(
+    UPDATE_LEARNING_OBJECT_COLLECTION(learningObjectCuid: string) {
+        return `${environment.apiURL}/learning-objects/${encodeURIComponent(
             learningObjectCuid
         )}/collection`;
     },


### PR DESCRIPTION
- Client implementation for updating the collection of a LO in CLARK-Service.
- Removed the username parameter from the route.
- Part of [Update Clark Client with Learning Object Service Changes](https://app.shortcut.com/clarkcan/story/29548/update-clark-client-with-learning-object-service-changes) story

https://github.com/Cyber4All/clark-client/assets/92770851/3cb13c38-400e-4c1b-85a7-81150cd6fc57

