### PR TITLE
Update client to reflect changelog refactor in clark-service

### DIFF
--- a/src/app/core/learning-object-module/changelog/changelog.routes.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.routes.ts
@@ -19,11 +19,9 @@ export const CHANGELOG_ROUTES = {
      * @auth required
      * @param learningObjectId - The id of the Learning Object
      */
-    FETCH_CHANGELOGS(params: {learningObjectCuid: string, minusRevision?: boolean }) {
+    GET_CHANGELOGS(learningObjectCuid: string) {
         return `${environment.apiURL}/learning-objects/${encodeURIComponent(
-            params.learningObjectCuid
-        )}/changelogs?minusRevision=${encodeURIComponent(
-            params.minusRevision
-        )}`;
+            learningObjectCuid
+        )}/changelogs`;
     }
 };

--- a/src/app/core/learning-object-module/changelog/changelog.routes.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.routes.ts
@@ -5,7 +5,6 @@ export const CHANGELOG_ROUTES = {
      * Request to create a new changelog for a learning object
      * @method POST
      * @auth required
-     * @param userId - The id of the learning object author
      * @param learningObjectCuid - The cuid of the learning object
      */
     CREATE_CHANGELOG(learningObjectCuid: string) {

--- a/src/app/core/learning-object-module/changelog/changelog.routes.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.routes.ts
@@ -18,9 +18,17 @@ export const CHANGELOG_ROUTES = {
      * @auth required
      * @param learningObjectId - The id of the Learning Object
      */
-    GET_CHANGELOGS(learningObjectCuid: string) {
+    GET_CHANGELOGS(
+        learningObjectCuid: string,
+        minusRevision?: boolean,
+        recent?: boolean
+    ) {
         return `${environment.apiURL}/learning-objects/${encodeURIComponent(
             learningObjectCuid
-        )}/changelogs`;
+        )}/changelogs?minusRevision=${encodeURIComponent(
+            minusRevision ?? false
+        )}&recent=${encodeURIComponent(
+            recent ?? false
+        )}`;
     }
 };

--- a/src/app/core/learning-object-module/changelog/changelog.service.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.service.ts
@@ -30,7 +30,7 @@ export class ChangelogService {
       text: changelog
     }];
     return this.http
-      .post(CHANGELOG_ROUTES.CREATE_CHANGELOG(learningObjectCuid), changelogEntries, { responseType: 'text' })
+      .post(CHANGELOG_ROUTES.CREATE_CHANGELOG(learningObjectCuid), {changelogEntries: changelogEntries}, { responseType: 'text' })
       .pipe(
         catchError(this.handleError)
       )

--- a/src/app/core/learning-object-module/changelog/changelog.service.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.service.ts
@@ -3,28 +3,35 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { CHANGELOG_ROUTES } from './changelog.routes';
 import { catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
+import { AuthService } from 'app/core/auth-module/auth.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ChangelogService {
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    private authService: AuthService
+  ) { }
 
   /**
    * Create a new changelog for the given learning object
    *
-   * @param {string} userId the id of the learning object author
    * @param {string} learningObjectId the id of the learning object
    * @param {string} changelog the text body of the changelog
    * @returns {Promise<{}>}
    * @memberof ChangelogService
    */
-  createChangelog(userId: string, learningObjectCuid: string, changelog: string): Promise<{}> {
+  createChangelog(learningObjectCuid: string, changelog: string): Promise<{}> {
+    const changelogEntries = {
+      authorId: this.authService.user.id,
+      date: new Date(),
+      text: changelog
+    };
     return this.http
-      .post(CHANGELOG_ROUTES.CREATE_CHANGELOG(learningObjectCuid), { changelogText: changelog }, { responseType: 'text' })
+      .post(CHANGELOG_ROUTES.CREATE_CHANGELOG(learningObjectCuid), changelogEntries, { responseType: 'text' })
       .pipe(
-
         catchError(this.handleError)
       )
       .toPromise();

--- a/src/app/core/learning-object-module/changelog/changelog.service.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.service.ts
@@ -24,11 +24,11 @@ export class ChangelogService {
    * @memberof ChangelogService
    */
   createChangelog(learningObjectCuid: string, changelog: string): Promise<{}> {
-    const changelogEntries = {
+    const changelogEntries = [{
       authorId: this.authService.user.id,
       date: new Date(),
       text: changelog
-    };
+    }];
     return this.http
       .post(CHANGELOG_ROUTES.CREATE_CHANGELOG(learningObjectCuid), changelogEntries, { responseType: 'text' })
       .pipe(

--- a/src/app/core/learning-object-module/changelog/changelog.service.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.service.ts
@@ -45,11 +45,18 @@ export class ChangelogService {
    * @returns {Promise<{}>}
    * @memberof ChangelogService
    */
-  getAllChangelogs(learningObjectCuid: string): Promise<any> {
+  getAllChangelogs(
+    learningObjectCuid: string,
+    minusRevision?: boolean,
+    recent?: boolean
+  ): Promise<any> {
     return this.http
-      .get(CHANGELOG_ROUTES.GET_CHANGELOGS(learningObjectCuid))
+      .get(CHANGELOG_ROUTES.GET_CHANGELOGS(
+        learningObjectCuid,
+        minusRevision,
+        recent
+      ))
       .pipe(
-
         catchError(this.handleError)
       )
       .toPromise();

--- a/src/app/core/learning-object-module/changelog/changelog.service.ts
+++ b/src/app/core/learning-object-module/changelog/changelog.service.ts
@@ -38,16 +38,9 @@ export class ChangelogService {
    * @returns {Promise<{}>}
    * @memberof ChangelogService
    */
-  fetchAllChangelogs(params: {
-    userId: string,
-    learningObjectCuid: string,
-    minusRevision?: boolean,
-  }): Promise<any> {
+  getAllChangelogs(learningObjectCuid: string): Promise<any> {
     return this.http
-      .get(CHANGELOG_ROUTES.FETCH_CHANGELOGS({
-        learningObjectCuid: params.learningObjectCuid,
-        minusRevision: params.minusRevision,
-      }))
+      .get(CHANGELOG_ROUTES.GET_CHANGELOGS(learningObjectCuid))
       .pipe(
 
         catchError(this.handleError)

--- a/src/app/core/learning-object-module/topics/topics.service.ts
+++ b/src/app/core/learning-object-module/topics/topics.service.ts
@@ -11,7 +11,7 @@ import { TOPICS_ROUTES } from './topics.routes';
 export class TopicsService {
   private headers = new HttpHeaders();
 
-  constructor(private http: HttpClient) { 
+  constructor(private http: HttpClient) {
   }
 
   /**

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -371,17 +371,9 @@ export class DetailsComponent implements OnInit, OnDestroy {
       this.loadingChangelogs = true;
       try {
         if (this.revisedVersion) {
-          this.changelogs = await this.changelogService.fetchAllChangelogs({
-            userId: this.learningObject.author.id,
-            learningObjectCuid: this.learningObject.cuid,
-            minusRevision: false,
-          });
+          this.changelogs = await this.changelogService.getAllChangelogs(this.learningObject.cuid);
         } else {
-          this.changelogs = await this.changelogService.fetchAllChangelogs({
-            userId: this.learningObject.author.id,
-            learningObjectCuid: this.learningObject.cuid,
-            minusRevision: true,
-          });
+          this.changelogs = await this.changelogService.getAllChangelogs(this.learningObject.cuid);
         }
       } catch (error) {
         let errorMessage;

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { LearningObject, User } from '@entity';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LearningObjectService } from 'app/core/learning-object-module/learning-object/learning-object.service';
-import { takeUntil } from 'rxjs/operators';
+import { min, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { Title } from '@angular/platform-browser';
 import { UserService } from 'app/core/user-module/user.service';
@@ -371,9 +371,15 @@ export class DetailsComponent implements OnInit, OnDestroy {
       this.loadingChangelogs = true;
       try {
         if (this.revisedVersion) {
-          this.changelogs = await this.changelogService.getAllChangelogs(this.learningObject.cuid);
+          this.changelogs = await this.changelogService.getAllChangelogs(
+            this.learningObject.cuid,
+            false, //minusRevision
+          );
         } else {
-          this.changelogs = await this.changelogService.getAllChangelogs(this.learningObject.cuid);
+          this.changelogs = await this.changelogService.getAllChangelogs(
+            this.learningObject.cuid,
+            true, //minusRevision
+          );
         }
       } catch (error) {
         let errorMessage;

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { LearningObject, User } from '@entity';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LearningObjectService } from 'app/core/learning-object-module/learning-object/learning-object.service';
-import { min, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { Title } from '@angular/platform-browser';
 import { UserService } from 'app/core/user-module/user.service';

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -279,11 +279,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (!this.openChangelogModal) {
       this.loadingChangelogs = true;
       try {
-        this.changelogs = await this.changelogService.fetchAllChangelogs({
-          userId: notification.attributes.learningObjectAuthorID,
-          learningObjectCuid: notification.attributes.cuid,
-          minusRevision: true,
-        });
+        this.changelogs = await this.changelogService.getAllChangelogs(notification.attributes.cuid);
       } catch (error) {
         let errorMessage;
 

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -279,7 +279,10 @@ export class LibraryComponent implements OnInit, OnDestroy {
     if (!this.openChangelogModal) {
       this.loadingChangelogs = true;
       try {
-        this.changelogs = await this.changelogService.getAllChangelogs(notification.attributes.cuid);
+        this.changelogs = await this.changelogService.getAllChangelogs(
+          notification.attributes.cuid,
+          true, // minusRevision
+        );
       } catch (error) {
         let errorMessage;
 

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -53,7 +53,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   loadingChangelogs: boolean;
   changelogLearningObject: LearningObject;
   changelogs: [];
-  learningObjects: LearningObject[];
+  learningObjects: any[];
 
   // submission
   submitToCollection: boolean;
@@ -270,7 +270,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.openChangelogModal = true;
     this.loadingChangelogs = true;
     this.learningObjects = this.workingLearningObjects.concat(this.releasedLearningObjects);
-    this.changelogLearningObject = this.learningObjects.find(learningObject => learningObject._id === learningObjectId);
+    this.changelogLearningObject = this.learningObjects.find(learningObject => learningObject.id === learningObjectId);
     try {
       this.changelogs = await this.changelogService.getAllChangelogs(this.changelogLearningObject.cuid);
     } catch (error) {

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -278,10 +278,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.learningObjects = this.workingLearningObjects.concat(this.releasedLearningObjects);
     this.changelogLearningObject = this.learningObjects.find(learningObject => learningObject._id === learningObjectId);
     try {
-      this.changelogs = await this.changelogService.fetchAllChangelogs({
-        userId: this.changelogLearningObject.author.username,
-        learningObjectCuid: this.changelogLearningObject.cuid,
-      });
+      this.changelogs = await this.changelogService.getAllChangelogs(this.changelogLearningObject.cuid);
     } catch (error) {
       let errorMessage;
 

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -183,7 +183,6 @@ export class ChangeStatusModalComponent implements OnInit {
    */
   async createChangelog(): Promise<{}> {
     return this.changelogService.createChangelog(
-      this.builderStore.learningObjectEvent.getValue().author.username,
       this.builderStore.learningObjectEvent.getValue().cuid,
       this.changelog,
     );

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -79,7 +79,6 @@ export class SubmitComponent implements OnInit {
       this.loading.push(true);
       this.changelogService
         .createChangelog(
-          this.learningObject.author.username,
           this.learningObject.cuid,
           this.changelog
         )


### PR DESCRIPTION
# Description
This PR updates the creating and getting changelogs implementation for the client to reflect changes made in clark-service. The `getAllChangelogs` method in the service parameters were updated to remove the userId. The `createChangelog` method was updated to remove the userId parameter, the changelogEntries type was created at the service level, as for this is what clark-service is now expecting.

# TESTING COULD NOT BE COMPLETED AT THIS POINT IN TIME
Changelogs requires the changes in the author dashboard to be fully implemented in order to properly test this route. I verified that gateway is updated and that the client will pass the right parameters to clark-service 