### PR TITLE
Changes for the app that shall not be named

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.6.10",
+  "version": "5.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.6.10",
+      "version": "5.7.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.6.10",
+  "version": "5.7.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/secondary-navbar/secondary-navbar.component.html
+++ b/src/app/components/secondary-navbar/secondary-navbar.component.html
@@ -26,7 +26,7 @@
             <i class="fa fa-chevron-up"></i>
         </span>
     </div>
-    <div class="item resources" #resourcesAnchor (click)="dropdowns.toggleResourcesDropdown()" tabindex="0">Resources
+    <div class="item resources" #resourcesAnchor (click)="dropdowns.toggleResourcesDropdown()" tabindex="0">Tools
         <span *ngIf="!resourcesDropdown">
             <i class="fa fa-chevron-down"></i>
         </span>

--- a/src/app/core/navBarDropdown.service.ts
+++ b/src/app/core/navBarDropdown.service.ts
@@ -31,6 +31,7 @@ export class NavbarDropdownService {
     public showNavbars = new BehaviorSubject<boolean>(true);
 
     public externalResources = [
+    {name: 'CARD', link: 'https://caeresource.directory'},
     {name: 'Standard Guidelines', link: 'https://standard-guidelines.clark.center'},
     {name: 'Task Tool', link: 'https://tasktool.clark.center'},
     {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},

--- a/src/app/core/navBarDropdown.service.ts
+++ b/src/app/core/navBarDropdown.service.ts
@@ -31,7 +31,7 @@ export class NavbarDropdownService {
     public showNavbars = new BehaviorSubject<boolean>(true);
 
     public externalResources = [
-    {name: 'CARD', link: 'https://caeresource.directory'},
+    {name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.directory'},
     {name: 'Standard Guidelines', link: 'https://standard-guidelines.clark.center'},
     {name: 'Task Tool', link: 'https://tasktool.clark.center'},
     {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},

--- a/src/app/core/navBarDropdown.service.ts
+++ b/src/app/core/navBarDropdown.service.ts
@@ -32,7 +32,7 @@ export class NavbarDropdownService {
 
     public externalResources = [
     {name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.directory'},
-    {name: 'Standard Guidelines', link: 'https://standard-guidelines.clark.center'},
+    {name: 'Standard Guidelines Tool', link: 'https://standard-guidelines.clark.center'},
     {name: 'Task Tool', link: 'https://tasktool.clark.center'},
     {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},
     {name: 'CPNC Competency Constructor', link: 'https://cybercompetencies.com'}

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -22,7 +22,7 @@
         <div class="results-options" id="results-options">
           <button *ngIf="isMobile" #filterMenuButtonElement aria-label="Filter search results" class="button sort" (activate)="toggleFilters()">{{ copy.FILTERS }} <i class="far fa-sliders-h"></i></button>
           <button *ngIf="showClearSort" aria-label="Clear sort selection" tip="Clear sorting criteria" tipPosition="bottom" (activate)="clearSort($event)" class="clear"><i class="far fa-times"></i></button>
-          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/home/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text !== ''">Search for non-curricular resources</a>
+          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/home/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text?.length > 0">Search for non-curricular resources</a>
           <button #sortMenuButtonElement aria-label="Sort Search Results" class="button sort" (activate)="toggleSortMenu(true)">Sort By: {{ sortText }}<i class="far fa-angle-down"></i></button>
         </div>
         <!-- Filter Context Menu -->

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -22,7 +22,7 @@
         <div class="results-options" id="results-options">
           <button *ngIf="isMobile" #filterMenuButtonElement aria-label="Filter search results" class="button sort" (activate)="toggleFilters()">{{ copy.FILTERS }} <i class="far fa-sliders-h"></i></button>
           <button *ngIf="showClearSort" aria-label="Clear sort selection" tip="Clear sorting criteria" tipPosition="bottom" (activate)="clearSort($event)" class="clear"><i class="far fa-times"></i></button>
-          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/home/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text !== ''">Search with CARD</a>
+          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/home/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text !== ''">Search for non-curricular resources</a>
           <button #sortMenuButtonElement aria-label="Sort Search Results" class="button sort" (activate)="toggleSortMenu(true)">Sort By: {{ sortText }}<i class="far fa-angle-down"></i></button>
         </div>
         <!-- Filter Context Menu -->

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -22,7 +22,7 @@
         <div class="results-options" id="results-options">
           <button *ngIf="isMobile" #filterMenuButtonElement aria-label="Filter search results" class="button sort" (activate)="toggleFilters()">{{ copy.FILTERS }} <i class="far fa-sliders-h"></i></button>
           <button *ngIf="showClearSort" aria-label="Clear sort selection" tip="Clear sorting criteria" tipPosition="bottom" (activate)="clearSort($event)" class="clear"><i class="far fa-times"></i></button>
-          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/home/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text?.length > 0">Search for non-curricular resources</a>
+          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/browse?q={{ query?.text }}" target=_blank *ngIf="query?.text?.length > 0">Search for non-curricular resources</a>
           <button #sortMenuButtonElement aria-label="Sort Search Results" class="button sort" (activate)="toggleSortMenu(true)">Sort By: {{ sortText }}<i class="far fa-angle-down"></i></button>
         </div>
         <!-- Filter Context Menu -->


### PR DESCRIPTION
# Description 
This fixes some small bugs on the browse to CARD link. 
# What this fixes 
1. Changes Search on CARD to Search for non-curricular resources
2. Changes /home/browse in the CARD link to /browse so the q is not lost on navigation
3. Changes the Resources dropdown to Tools per the Drs 
4. Adds CARD back to the resources dropdown 
<img width="1284" alt="Screenshot 2024-06-27 at 9 55 52 AM" src="https://github.com/Cyber4All/clark-client/assets/43140629/b94a14e7-5109-4878-a504-1b47a2c9c710">
<img width="493" alt="Screenshot 2024-06-27 at 9 56 13 AM" src="https://github.com/Cyber4All/clark-client/assets/43140629/2146f783-4cf2-480c-b1a4-0123aff5c570">
<img width="388" alt="Screenshot 2024-06-27 at 9 59 32 AM" src="https://github.com/Cyber4All/clark-client/assets/43140629/15291241-ace6-40d8-ae2f-da99e93238a0">

