### PR TITLE
feat: [sc-29548] update route for uploading file metadata

### DIFF
--- a/src/app/core/learning-object-module/file/file.routes.ts
+++ b/src/app/core/learning-object-module/file/file.routes.ts
@@ -80,9 +80,7 @@ export const FILE_ROUTES = {
    * @param username - The username of the author
    * @param id - The id of the learning object to upload the file to
    */
-  UPLOAD_FILE_META(username: string, id: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(
-      username,
-    )}/learning-objects/${encodeURIComponent(id)}/materials/files`;
+  UPLOAD_FILE_META(id: string) {
+    return `${environment.apiURL}/learning-objects/${encodeURIComponent(id)}/materials/files`;
   },
 };

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -518,15 +518,13 @@ export class LearningObjectService {
    * @memberof LearningObjectService
    */
   addFileMeta({
-    username,
     objectId,
     files
   }: {
-    username: string;
     objectId: string;
     files: FileUploadMeta[];
   }): Promise<string[]> {
-    const route = FILE_ROUTES.UPLOAD_FILE_META(username, objectId);
+    const route = FILE_ROUTES.UPLOAD_FILE_META(objectId);
     return this.handleFileMetaRequests(files, route);
   }
 

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -694,7 +694,6 @@ export class BuilderStore {
     await this.learningObjectService
       .addFileMeta({
         files,
-        username: this.learningObject.author.username,
         objectId: this.learningObject._id
       })
       .then(() => {


### PR DESCRIPTION
**Note:** Cannot test this yet. File upload functionality seems to be broken because client is missing some data from the backend that is required to "upload" the file to S3, assuming that S3 even would work in this case.