### PR TITLE
feat: [sc-29055] implement creating a hierarchy object

### DIFF
--- a/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
+++ b/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
@@ -92,17 +92,18 @@ export class HierarchyBuilderComponent implements OnInit {
    */
 
   async createLearningObjects(node: any) {
-
     if (node.children.length === 0) {
       return this.hierarchyService.addHierarchyObject(this.parent.author.username, node);
     }
     const childrenIds = [];
     for await (const child of node.children) {
-      childrenIds.push(await this.createLearningObjects(child));
+      const obj = JSON.parse(await this.createLearningObjects(child));
+      childrenIds.push(obj._id);
     }
     let parentId = this.parent.id;
     if (node.name !== this.parent.name) {
-      parentId = await this.hierarchyService.addHierarchyObject(this.parent.author.username, node);
+      const obj = JSON.parse(await this.hierarchyService.addHierarchyObject(this.parent.author.username, node));
+      parentId = obj._id;
     }
     const newNode = await this.setParents(parentId, childrenIds);
     if (node.name === this.parent.name) {

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -1,7 +1,6 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { LearningObject } from '@entity';
-import { LEGACY_ADMIN_ROUTES } from '../../core/learning-object-module/learning-object/learning-object.routes';
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/revisions.routes';

--- a/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
+++ b/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { LearningObject } from '@entity';
-import { LEGACY_ADMIN_ROUTES, LEGACY_USER_ROUTES } from '../learning-object/learning-object.routes';
+import { ADMIN_ROUTES, LEGACY_USER_ROUTES } from '../learning-object/learning-object.routes';
 import { HIERARCHY_ROUTES } from './hierarchy.routes';
 
 @Injectable({
@@ -14,7 +14,7 @@ export class HierarchyService {
 
   async addHierarchyObject(username: string, object: any): Promise<any> {
     return await this.http.post(
-      LEGACY_ADMIN_ROUTES.ADD_HIERARCHY_OBJECT(),
+      ADMIN_ROUTES.ADD_HIERARCHY_OBJECT(),
       { object, username }, { withCredentials: true, responseType: 'text' }
     ).toPromise();
   }

--- a/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
+++ b/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
@@ -14,8 +14,8 @@ export class HierarchyService {
 
   async addHierarchyObject(username: string, object: any): Promise<any> {
     return await this.http.post(
-      LEGACY_ADMIN_ROUTES.ADD_HIERARCHY_OBJECT(username),
-      { object }, { withCredentials: true, responseType: 'text' }
+      LEGACY_ADMIN_ROUTES.ADD_HIERARCHY_OBJECT(),
+      { object, username }, { withCredentials: true, responseType: 'text' }
     ).toPromise();
   }
 

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -38,7 +38,7 @@ export const LEARNING_OBJECT_ROUTES = {
     },
 };
 
-export const LEGACY_ADMIN_ROUTES = {
+export const ADMIN_ROUTES = {
     ADD_HIERARCHY_OBJECT() {
         return `${environment.apiURL}/hierarchy-object`;
     },

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -39,10 +39,8 @@ export const LEARNING_OBJECT_ROUTES = {
 };
 
 export const LEGACY_ADMIN_ROUTES = {
-    ADD_HIERARCHY_OBJECT(username) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            username,
-        )}/hierarchy-object`;
+    ADD_HIERARCHY_OBJECT() {
+        return `${environment.apiURL}/hierarchy-object`;
     },
 };
 


### PR DESCRIPTION
This implements the changed needed to create a hierachy object in clark-client.

This was initially pushed back because it was blocked by [this story](https://app.shortcut.com/clarkcan/story/29061/implement-updating-the-children-of-a-learning-object), and because it was low priority but now works as intended.

Video:
https://github.com/Cyber4All/clark-client/assets/17275723/eead3125-b55d-406a-b062-6eaa49e2d055