### PR TITLE
'evaluation' correctional on editorial page

### DIFF
--- a/src/app/cube/content-pages/editorial-process/copy.ts
+++ b/src/app/cube/content-pages/editorial-process/copy.ts
@@ -9,7 +9,7 @@ export const sections = {
 						question: 'Why must my curriculum be evaluated?',
 						answer: 'Since all released curricula fall under Creative Commons, all types of curricula must be evaluated' +
                         ' to ensure educational quality, adaptability, and accountability in the learning process. Any curriculum to be' +
-                        ' released on CLARK must comply with all of the characteristics mentioned in our evaluation procress. '
+                        ' released on CLARK must comply with all of the characteristics mentioned in our evaluation process. '
 					},
 					{
 						question: 'How is the curriculum evaluated?',

--- a/src/app/cube/content-pages/editorial-process/copy.ts
+++ b/src/app/cube/content-pages/editorial-process/copy.ts
@@ -9,7 +9,7 @@ export const sections = {
 						question: 'Why must my curriculum be evaluated?',
 						answer: 'Since all released curricula fall under Creative Commons, all types of curricula must be evaluated' +
                         ' to ensure educational quality, adaptability, and accountability in the learning process. Any curriculum to be' +
-                        ' released on CLARK must comply with all of the characteristics mentioned in our evaluatuion procress. '
+                        ' released on CLARK must comply with all of the characteristics mentioned in our evaluation procress. '
 					},
 					{
 						question: 'How is the curriculum evaluated?',


### PR DESCRIPTION

<img width="932" alt="Screenshot 2024-07-11 at 5 59 09 AM" src="https://github.com/Cyber4All/clark-client/assets/110073931/4f6cb775-8f82-4f0a-aefe-4183261bd082">
['evaluation' correctional on editorial page](https://github.com/Cyber4All/clark-client/pull/1769/commits/92529469ddf38095766034686d5602a789bbc542)