### PR TITLE
feat: [sc-31774] Fix "Save to Library" UI flow

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -39,7 +39,9 @@ export class LibraryService {
     // this.headers.append('Content-Type', 'application/json');
   }
 
-  async getLibrary(page?: number, limit?: number): Promise<{ cartItems: LearningObject[], lastPage: number }> {
+  async getLibrary(page?: number, limit?: number,
+                    learningObjectCuid?: string,
+                    version?: number): Promise<{ cartItems: LearningObject[], lastPage: number }> {
     this.updateUser();
     if (!this.user) {
       return Promise.reject('User is undefined');
@@ -48,12 +50,14 @@ export class LibraryService {
     const query = new URLSearchParams({
       page: page ? page.toString() : '1',
       limit: limit ? limit.toString() : '10',
+      cuid: learningObjectCuid ? learningObjectCuid : '',
+      version: version ? version.toString() : '0'
     });
 
     return await this.http
       .get(LIBRARY_ROUTES.GET_USERS_LIBRARY(this.user.username, query), {
         withCredentials: true,
-        headers: this.headers
+        headers: this.headers,
       })
       .pipe(
         catchError((error) => this.handleError(error))

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -96,7 +96,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
-    await this.libraryService.getLibrary();
+    await this.libraryService.getLibrary(null, null, this.learningObject.cuid, this.learningObject.version);
     this.saved = this.libraryService.has(this.learningObject);
     this.getCollection();
     this.libraryService.loaded


### PR DESCRIPTION
This change introduces new parameters to allow clark-client to fetch a specific LO in a user's library, rather than the whole library itself. 

In a past implementation of this feature, the `page` and `limit` parameters of fetching a user's library were not functional, despite existing in the client query params. `learning-object-service` would just return most, if not all, learning objects that was saved in a user's library.

Now that the `page` and `limit` params work as intended we also need a way to fetch a learning object that exists in the users library, because the LO we want may not be returned within the requested page or limit. This PR introduces the necessary client-side fixes to fetch specific LOs.

https://app.shortcut.com/clarkcan/story/32064/fix-saving-an-lo-to-a-user-s-library