### PR TITLE
feat: [sc-32064] Change library saving to send LO cuid and version

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -39,19 +39,18 @@ export class LibraryService {
     // this.headers.append('Content-Type', 'application/json');
   }
 
-  async getLibrary(page?: number, limit?: number,
-                    learningObjectCuid?: string,
-                    version?: number): Promise<{ cartItems: LearningObject[], lastPage: number }> {
+  async getLibrary(opts?: { learningObjectCuid?: string, version?: number,
+                  page?: number, limit?: number }): Promise<{ cartItems: LearningObject[], lastPage: number }> {
     this.updateUser();
     if (!this.user) {
       return Promise.reject('User is undefined');
     }
 
     const query = new URLSearchParams({
-      page: page ? page.toString() : '1',
-      limit: limit ? limit.toString() : '10',
-      cuid: learningObjectCuid ? learningObjectCuid : '',
-      version: version ? version.toString() : '0'
+      page: opts.page ? opts.page.toString() : '1',
+      limit: opts.limit ? opts.limit.toString() : '10',
+      cuid: opts.learningObjectCuid ? opts.learningObjectCuid : '',
+      version: opts.version ? opts.version.toString() : '0'
     });
 
     return await this.http

--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -39,7 +39,9 @@ export class LibraryService {
     // this.headers.append('Content-Type', 'application/json');
   }
 
-  async getLibrary(page?: number, limit?: number): Promise<{ cartItems: LearningObject[], lastPage: number }> {
+  async getLibrary(page?: number, limit?: number,
+                    learningObjectCuid?: string,
+                    version?: number): Promise<{ cartItems: LearningObject[], lastPage: number }> {
     this.updateUser();
     if (!this.user) {
       return Promise.reject('User is undefined');
@@ -48,12 +50,14 @@ export class LibraryService {
     const query = new URLSearchParams({
       page: page ? page.toString() : '1',
       limit: limit ? limit.toString() : '10',
+      cuid: learningObjectCuid ? learningObjectCuid : '',
+      version: version ? version.toString() : '0'
     });
 
     return await this.http
       .get(LIBRARY_ROUTES.GET_USERS_LIBRARY(this.user.username, query), {
         withCredentials: true,
-        headers: this.headers
+        headers: this.headers,
       })
       .pipe(
         catchError((error) => this.handleError(error))

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -96,7 +96,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
-    await this.libraryService.getLibrary();
+    await this.libraryService.getLibrary(null, null, this.learningObject.cuid, this.learningObject.version);
     this.saved = this.libraryService.has(this.learningObject);
     this.getCollection();
     this.libraryService.loaded

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -96,7 +96,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
-    await this.libraryService.getLibrary(null, null, this.learningObject.cuid, this.learningObject.version);
+    await this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid, version: this.learningObject.version});
     this.saved = this.libraryService.has(this.learningObject);
     this.getCollection();
     this.libraryService.loaded

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -125,7 +125,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   async loadLibrary() {
     try {
       this.loading = true;
-      const libraryItemInformation = await this.libraryService.getLibrary(this.currentPageNumber, 10);
+      const libraryItemInformation = await this.libraryService.getLibrary({page: this.currentPageNumber, limit: 10});
       this.libraryItems = libraryItemInformation.cartItems;
       this.lastPageNumber = libraryItemInformation.lastPage;
       this.libraryItems.map(async (libraryItem: LearningObject) => {
@@ -226,7 +226,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   async removeItem() {
     try {
       await this.libraryService.removeFromLibrary(this.libraryItemToDelete.id);
-      this.libraryItems = (await this.libraryService.getLibrary(1, 10)).cartItems;
+      this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).cartItems;
       this.changeLibraryItemPage(this.currentPageNumber);
       this.showDeleteLibraryItemModal = false;
     } catch (e) {
@@ -311,7 +311,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async changeLibraryItemPage(pageNumber: number) {
     this.topOfList.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const libraryItemInformation = await this.libraryService.getLibrary(pageNumber, 10);
+    const libraryItemInformation = await this.libraryService.getLibrary({page: pageNumber, limit: 10});
     this.libraryItems = libraryItemInformation.cartItems;
     this.lastPageNumber = libraryItemInformation.lastPage;
     this.currentPageNumber = pageNumber;


### PR DESCRIPTION
This change introduces new parameters to allow clark-client to fetch a specific LO in a user's library, rather than the whole library itself. 

In a past implementation of this feature, the `page` and `limit` parameters of fetching a user's library were not functional, despite existing in the client query params. `learning-object-service` would just return most, if not all, learning objects that was saved in a user's library.

Now that the `page` and `limit` params work as intended we also need a way to fetch a learning object that exists in the users library, because the LO we want may not be returned within the requested page or limit. This PR introduces the necessary client-side fixes to fetch specific LOs.

https://app.shortcut.com/clarkcan/story/32064/fix-saving-an-lo-to-a-user-s-library