### PR TITLE
bug: [sc-31788] fix incorrect child LOs being removed

### DIFF
--- a/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
+++ b/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { LearningObject } from '@entity';
-import { ADMIN_ROUTES, LEARNING_OBJECT_ROUTES, LEGACY_USER_ROUTES } from '../learning-object/learning-object.routes';
+import { ADMIN_ROUTES, LEARNING_OBJECT_ROUTES, LEGACY_USER_ROUTES, USER_ROUTES } from '../learning-object/learning-object.routes';
 import { HIERARCHY_ROUTES } from './hierarchy.routes';
 
 @Injectable({
@@ -66,7 +66,7 @@ export class HierarchyService {
    */
   async addChildren(username: string, object: any, children): Promise<any> {
     return await this.http.post(
-      LEGACY_USER_ROUTES.SET_CHILDREN(username, object),
+      USER_ROUTES.SET_CHILDREN(object),
       {
         children
       },

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -64,6 +64,12 @@ export const LEARNING_OBJECT_ROUTES = {
       }
 };
 
+export const USER_ROUTES = {
+  SET_CHILDREN(learningObjectCuid) {
+    return `${environment.apiURL}/learning-objects/${encodeURIComponent(learningObjectCuid)}/children`;
+  },
+};
+
 export const ADMIN_ROUTES = {
     ADD_HIERARCHY_OBJECT() {
         return `${environment.apiURL}/hierarchy-object`;
@@ -167,11 +173,6 @@ export const LEGACY_USER_ROUTES = {
     /** ROUTE NOT IN GATEWAY */
     VALIDATE_CAPTCHA() {
         return `${environment.apiURL}/users/validate-captcha`;
-    },
-    SET_CHILDREN(username, learningObjectName) {
-        return `${environment.apiURL}/learning-objects/${encodeURIComponent(
-            username,
-        )}/${encodeURIComponent(learningObjectName)}/children`;
     },
     GET_CHILDREN(username: string, learningObjectID: string) {
         return `${environment.apiURL}/users/${encodeURIComponent(

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -453,7 +453,7 @@ export class LearningObjectService {
       return this.http
         .patch(
           removeRoute,
-          { childObjectId: children },
+          { childObjectId: children[0] },
           { headers: this.headers, withCredentials: true, responseType: 'text' }
         )
         .pipe(

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -18,6 +18,7 @@ import {
   LEGACY_USER_ROUTES,
   LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES,
   LEARNING_OBJECT_ROUTES,
+  USER_ROUTES,
 } from '../../core/learning-object-module/learning-object/learning-object.routes';
 
 @Injectable({
@@ -443,19 +444,18 @@ export class LearningObjectService {
   }
 
   setChildren(
-    learningObjectName: string,
-    authorUsername: string,
+    learningObjectCuid: string,
     children: string[],
     remove: boolean,
   ): Promise<any> {
-    const route = LEGACY_USER_ROUTES.SET_CHILDREN(authorUsername, learningObjectName);
+    const route = USER_ROUTES.SET_CHILDREN(learningObjectCuid);
 
     if (remove) {
       return this.http
         .patch(
           route,
-          { id: children[0] },
-          { withCredentials: true, responseType: 'text' }
+          { id: children },
+          { withCredentials: true, responseType: 'text', headers: this.headers, }
         )
         .pipe(
 

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -328,7 +328,7 @@ export class BuilderStore {
     if (remove) {
       children = this.learningObject.children.filter(child => !children.includes(child._id)).map(child => child._id);
     }
-    await this.learningObjectService.setChildren(this.learningObject._id, this.learningObject.author.username, children, remove);
+    await this.learningObjectService.setChildren(this.learningObject._id, children, remove);
     this.serviceInteraction$.next(false);
   }
 

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.html
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.html
@@ -11,11 +11,11 @@
     <clark-toggle-switch *ngIf="!loadingChildrenError" identity="children" [state]="editContent" style="blue" [aria]="ariaLabel" (toggled)="toggleAddDelete()"></clark-toggle-switch>
   </div>
 </div>
-<clark-skip-link *ngIf="!editContent || learningObject?.length === 'nanomodule'" title="Skip to Builder Form" skipLocation="form"></clark-skip-link> 
+<clark-skip-link *ngIf="!editContent || learningObject?.length === 'nanomodule'" title="Skip to Builder Form" skipLocation="form"></clark-skip-link>
 <div [ngTemplateOutlet]="addChild" *ngIf="editContent || children?.length === 0"></div>
 <ng-template [ngIf]="children && children.length > 0">
   <div cdkDropList class="children-list" (cdkDropListDropped)="drop($event)">
-    <div *ngFor="let c of children; let i = index" class="child-box" cdkDragLockAxis="y" cdkDragBoundary=".children-list" cdkDrag> 
+    <div *ngFor="let c of children; let i = index" class="child-box" cdkDragLockAxis="y" cdkDragBoundary=".children-list" cdkDrag>
       <div class = "info">
         <div class = "top-row">
           <div class = "child-title" [tip]="c.name" tipPosition="top">{{c.name}}</div>
@@ -51,7 +51,7 @@
 
 <ng-template [ngIf]="children?.length === 0 && learningObject?.length !== 'nanomodule'">
   <div class= "no-children">
-    This learning object has no children  
+    This learning object has no children
   </div>
 </ng-template>
 

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
@@ -64,7 +64,7 @@ export class ScaffoldComponent implements OnInit {
     this.ariaLabel = 'Add and delete Children';
 
     // if the Learning Object can have children, attempt to load them
-    if (this.learningObject._id && this.learningObject.length !== LearningObject.Length.NANOMODULE) {
+    if (this.learningObject.length !== LearningObject.Length.NANOMODULE) {
       this.loading = true;
       this.store.getChildren().then(kiddos => {
         this.children = kiddos;

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
@@ -153,6 +153,7 @@ export class ScaffoldComponent implements OnInit {
     // set childrenIDs equal to the children array
     this.childrenIDs = [];
     this.children.forEach(kid => this.childrenIDs.push(kid._id));
+    await this.store.fetch(this.learningObject.cuid);
     await this.store.setChildren(this.childrenIDs, true);
 
     // if deleted child was last child toggle off editContent because there is no longer content to edit


### PR DESCRIPTION
See [shortcut story](https://app.shortcut.com/clarkcan/story/31788/bug-removing-children-from-learning-object-in-builder) for information on the bug.

The `#setChildren` function in the `BuilderStore` class used a list of children that was stored within that instance of `BuilderStore`. Therefore when removing a child from the list, the LO inside the builder store instance was never updated, and old data was used to update the LO. The solution was to fetch the LO again in the builder store *before* setting the children.

also yes this was a one line fix. :godmode: 