### PR TITLE
bug: [sc-32078] fix broken client version check function

### DIFF
--- a/src/app/core/utility-module/utility.service.ts
+++ b/src/app/core/utility-module/utility.service.ts
@@ -39,10 +39,10 @@ export class UtilityService {
    */
   async checkClientVersion(): Promise<void | Partial<{ message: string }>> {
     // Application version information
-    const clientVersion = require('../../../../package.json');
+    const { version } = require('../../../../package.json');
     try {
       await this.http
-        .get(UTILITY_ROUTES.GET_CLIENT_VERSION(clientVersion), {
+        .get(UTILITY_ROUTES.GET_CLIENT_VERSION(version), {
           withCredentials: true,
           responseType: 'text',
         })


### PR DESCRIPTION
The client would send the entire package object to the `/clientversion` API route instead of the version. This PR fixes that so the version is send from the `package.json` file.

https://app.shortcut.com/clarkcan/story/32078/client-version-in-api-request-incorrect

![image](https://github.com/user-attachments/assets/1a2f4fc0-5e28-4e70-ae65-cc3cf5e3e3e8)

