### PR TITLE
Update Learning Object Bug Fix

### DIFF
--- a/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.ts
+++ b/src/app/admin/components/add-evaluator/components/object-dropdown/object-dropdown.component.ts
@@ -79,12 +79,12 @@ export class ObjectDropdownComponent implements OnInit, OnDestroy {
       await this.learningObjectService
         .getLearningObjects({text: query})
         .then( (results: {learningObjects: LearningObject[], total: number}) => {
-          const assignedIds = this.assignedObjects.map(obj => obj._id);
+          const assignedIds = this.assignedObjects.map(obj => obj.id);
           const filteredObjects: LearningObject[] = [];
 
           // Filters out already selected objects
           results.learningObjects.forEach( (obj: LearningObject) => {
-            if (!assignedIds.includes(obj._id) && (Array.isArray(obj.assigned) && !obj.assigned.includes(this.user.id))) {
+            if (!assignedIds.includes(obj.id) && (Array.isArray(obj.assigned) && !obj.assigned.includes(this.user.id))) {
               filteredObjects.push(obj);
             }
           });

--- a/src/app/admin/components/change-author/change-author.component.ts
+++ b/src/app/admin/components/change-author/change-author.component.ts
@@ -38,7 +38,7 @@ export class ChangeAuthorComponent implements OnInit {
 
 
   async ngOnInit() {
-    const childrenUri = LEARNING_OBJECT_ROUTES.GET_CHILDREN(this.highlightedLearningObject._id);
+    const childrenUri = LEARNING_OBJECT_ROUTES.GET_CHILDREN(this.highlightedLearningObject.id);
     this.http.get(
       childrenUri,
       { headers: this.headers, withCredentials: true }
@@ -94,7 +94,7 @@ export class ChangeAuthorComponent implements OnInit {
     const author: User = await this.userService.getUser(this.highlightedLearningObject.author.username, 'username');
     this.authorshipService.changeAuthorship(
       author,
-      this.highlightedLearningObject._id,
+      this.highlightedLearningObject.id,
       this.selectedAuthor.id).then(
         () => {
           this.toaster.success('Success!', 'Learning Object Author changed.');

--- a/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
+++ b/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
@@ -35,7 +35,7 @@ export class HierarchyBuilderComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.TREE_DATA[0] = { _id: this.parent._id, name: this.parent.name, length: this.parent.length, showForm: false, children: [] };
+    this.TREE_DATA[0] = { _id: this.parent.id, name: this.parent.name, length: this.parent.length, showForm: false, children: [] };
     this.contributors = this.parent.contributors.map(contrib => {
       return contrib.username;
     });
@@ -98,12 +98,12 @@ export class HierarchyBuilderComponent implements OnInit {
     const childrenIds = [];
     for await (const child of node.children) {
       const obj = JSON.parse(await this.createLearningObjects(child));
-      childrenIds.push(obj._id);
+      childrenIds.push(obj.id);
     }
-    let parentId = this.parent._id;
+    let parentId = this.parent.id;
     if (node.name !== this.parent.name) {
       const obj = JSON.parse(await this.hierarchyService.addHierarchyObject(this.parent.author.username, node));
-      parentId = obj._id;
+      parentId = obj.id;
     }
     const newNode = await this.setParents(parentId, childrenIds);
     if (node.name === this.parent.name) {

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -165,7 +165,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   unreleaseLearningObject() {
     this.refactoredLearningObjectService
       .updateLearningObjectStatus(
-        this.learningObject._id,
+        this.learningObject.id,
         LearningObject.Status.PROOFING
       )
       .then(() => {
@@ -188,7 +188,7 @@ export class LearningObjectListItemComponent implements OnChanges {
     const parentUri = `${environment.apiURL}/users/${encodeURIComponent(
       this.learningObject.author.username
     )}/learning-objects/${encodeURIComponent(
-      this.learningObject._id
+      this.learningObject.id
     )}/parents`;
 
     await this.http.get(
@@ -208,7 +208,7 @@ export class LearningObjectListItemComponent implements OnChanges {
    * Checks if the learning object has any children
    */
   async checkForChildren() {
-    this.hasChildren = await this.loService.doesLearningObjectHaveChildren(this.learningObject._id);
+    this.hasChildren = await this.loService.doesLearningObjectHaveChildren(this.learningObject.id);
   }
 
   /**
@@ -229,7 +229,7 @@ export class LearningObjectListItemComponent implements OnChanges {
 
   goToUrl(url) {
     if (url === 'builder') {
-      window.open(`/onion/learning-object-builder/${this.learningObject._id}`, '_blank');
+      window.open(`/onion/learning-object-builder/${this.learningObject.id}`, '_blank');
     } else if (url === 'contact') {
       window.open(`/users/${this.learningObject.author.username}`);
     } else if (url === 'details') {
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
 
   releaseHierarchy() {
     this.toggleReleasingHierarchy(true);
-    this.hierarchyService.releaseHierarchy(this.learningObject._id)
+    this.hierarchyService.releaseHierarchy(this.learningObject.id)
       .then(() => {
         this.toggleReleasingHierarchy(false);
         location.reload();

--- a/src/app/admin/components/relevancy-date/relevancy-date.component.ts
+++ b/src/app/admin/components/relevancy-date/relevancy-date.component.ts
@@ -34,7 +34,7 @@ export class RelevancyDateComponent implements OnInit {
   }
 
   async setDate() {
-    await this.relevancyService.setNextCheckDate(this.learningObject._id, this.selected);
+    await this.relevancyService.setNextCheckDate(this.learningObject.id, this.selected);
     this.close.emit();
   }
 

--- a/src/app/admin/pages/featured/featured.component.html
+++ b/src/app/admin/pages/featured/featured.component.html
@@ -52,10 +52,10 @@
                 class="row-items"
                 (cdkDropListDropped)="drop($event)"
                 >
-                <div *ngFor="let l of learningObjects"  cdkDrag [cdkDragDisabled]="mutationError || featureService.featuredObjectIds?.includes(l._id)">
+                <div *ngFor="let l of learningObjects"  cdkDrag [cdkDragDisabled]="mutationError || featureService.featuredObjectIds?.includes(l.id)">
                     <clark-draggable-dashboard-item
                       [learningObject]="l"
-                      [disabled]="featureService.featuredObjectIds?.includes(l._id)"
+                      [disabled]="featureService.featuredObjectIds?.includes(l.id)"
                       ></clark-draggable-dashboard-item>
                     <div class="drag-preview" *cdkDragPreview>
                       <clark-draggable-learning-object [learningObject]="l" [preview]="true" (delete)="removeFeatured($event)" learningObjectCard></clark-draggable-learning-object>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -39,7 +39,7 @@
               *ngFor="let l of learningObjects"
               [learningObject]="l"
               [status]="l.status"
-              [selected]="this.selected.get(l._id) !== undefined"
+              [selected]="this.selected.get(l.id) !== undefined"
               (select)="toggleSelect(l, $event, i)"
               (viewUser)="getUserLearningObjects($event)"
               (changeStatus)="openChangeStatusModal($event)"

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -322,7 +322,7 @@ export class LearningObjectsComponent
     if (this.allSelected) {
       this.selected = new Map(
         // @ts-ignore
-        this.learningObjects.map((learningObject) => [learningObject._id, learningObject])
+        this.learningObjects.map((learningObject) => [learningObject.id, learningObject])
       );
       this.selectedLearningObjects = this.learningObjects;
       this.cd.detectChanges();
@@ -348,7 +348,7 @@ export class LearningObjectsComponent
      * @param l Learning Object to be selected
      */
   selectLearningObject(l: LearningObject) {
-    this.selected.set(l._id, l);
+    this.selected.set(l.id, l);
     this.selectedLearningObjects.push(l);
     this.cd.detectChanges();
 
@@ -366,7 +366,7 @@ export class LearningObjectsComponent
    * @param l Learning Object to be deselected
    */
   deselectLearningObject(l: LearningObject) {
-    this.selected.delete(l._id);
+    this.selected.delete(l.id);
     const index = this.selectedLearningObjects.indexOf(l);
     if (index > -1) {
       this.selectedLearningObjects.splice(index, 1);

--- a/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
+++ b/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
@@ -28,7 +28,7 @@ export class FeatureCardsComponent implements OnInit {
     this.setColorScheme();
     const hierarchy = await this.attributeService.getHierarchy(
       this.learningObject.author.username,
-      this.learningObject._id
+      this.learningObject.id
     );
     this.parents = hierarchy.parents;
     this.children = hierarchy.children;

--- a/src/app/core/feature-module/featured.service.ts
+++ b/src/app/core/feature-module/featured.service.ts
@@ -105,7 +105,7 @@ export class FeaturedObjectsService {
   filterOutFeaturedObjects() {
     this.featuredObjectIds = [];
     this.featuredStore.featured.forEach((object) => {
-      this.featuredObjectIds.push(object._id);
+      this.featuredObjectIds.push(object.id);
     });
   }
 
@@ -122,7 +122,7 @@ export class FeaturedObjectsService {
   removeFeaturedObject(featured) {
     this.featuredStore.featured = this.featuredStore.featured.filter(
       (object) => {
-        return object._id !== featured._id;
+        return object.id !== featured.id;
       },
     );
     this.filterOutFeaturedObjects();

--- a/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
+++ b/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
@@ -67,7 +67,7 @@ export class HierarchyService {
    */
   async addChildren(username: string, object: any, children): Promise<any> {
     return await this.http.post(
-      LEARNING_OBJECT_ROUTES.UPDATE_CHILDREN(object._id),
+      LEARNING_OBJECT_ROUTES.UPDATE_CHILDREN(object.id),
       {
         children
       },

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -139,7 +139,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     }
     if (download) {
       this.download(
-        this.learningObject._id
+        this.learningObject.id
       );
     }
     try {
@@ -171,7 +171,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
    */
   async toggleBundle() {
     this.toaster.alert('Ready to Bundle...', 'This learning object is queued for bundling.');
-    await this.learningObjectService.triggerBundle(this.learningObject._id);
+    await this.learningObjectService.triggerBundle(this.learningObject.id);
   }
 
 
@@ -183,7 +183,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   downloadRevised(download?: boolean) {
     if (download) {
       this.download(
-        this.learningObject._id
+        this.learningObject.id
       );
     }
   }
@@ -275,7 +275,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
   }
 
   removeFromLibrary() {
-    this.libraryService.removeFromLibrary(this.learningObject._id);
+    this.libraryService.removeFromLibrary(this.learningObject.id);
   }
 
   private buildLocation(encoded?: boolean) {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -72,9 +72,9 @@ export class EditorialActionPadComponent implements OnInit {
   editLearningObject() {
     const userOrAdminRoute = (this.userIsAuthor) ? 'onion' : 'admin';
     if (this.revisedLearningObject) {
-      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.revisedLearningObject._id]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.revisedLearningObject.id]);
     } else {
-      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.learningObject._id]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.learningObject.id]);
     }
   }
 

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -238,7 +238,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
     this.currentIndex = index;
     this.downloading[index] = true;
     this.showDownloadModal = true;
-    this.libraryService.downloadBundle(BUNDLING_ROUTES.DOWNLOAD_BUNDLE(object._id));
+    this.libraryService.downloadBundle(BUNDLING_ROUTES.DOWNLOAD_BUNDLE(object.id));
     this.downloading[index] = false;
   }
 

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -357,7 +357,7 @@ export class LearningObjectService {
    */
   submit(learningObject: LearningObject, collection: string): Promise<{}> {
     const route = SUBMISSION_ROUTES.SUBMIT_LEARNING_OBJECT({
-      learningObjectId: learningObject._id,
+      learningObjectId: learningObject.id,
     });
     return this.http
       .post(

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -104,6 +104,7 @@ export class LearningObjectService {
       )
       .toPromise()
       .then((res: any) => {
+        res.id = res._id;
         return new LearningObject(res);
       });
     // TODO: Verify this response gives the learning object name

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -101,7 +101,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
     this.parents = await this.parentNames();
     this.children = await this.objectChildrenNames();
     this.hasChildren = await this.appLOService.doesLearningObjectHaveChildren(
-      this.learningObject._id
+      this.learningObject.id
     );
     this.cd.detectChanges();
   }
@@ -223,7 +223,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
    */
   async parentNames() {
     const parents = [];
-    return this.learningObjectService.fetchParents(this.learningObject.author.username, this.learningObject._id).then(returners => {
+    return this.learningObjectService.fetchParents(this.learningObject.author.username, this.learningObject.id).then(returners => {
       returners.forEach(parent => {
         parents.push(parent.name);
       });

--- a/src/app/onion/dashboard/components/list/list.component.ts
+++ b/src/app/onion/dashboard/components/list/list.component.ts
@@ -80,7 +80,7 @@ export class ListComponent {
     if (this.allSelected) {
       this.selected = new Map(
         // @ts-ignore
-        this.learningObjects.map((learningObject) => [learningObject._id, learningObject])
+        this.learningObjects.map((learningObject) => [learningObject.id, learningObject])
       );
       this.cd.detectChanges();
     } else {
@@ -108,7 +108,7 @@ export class ListComponent {
    * @param l Learning Object to be selected
    */
   selectLearningObject(l: LearningObject) {
-    this.selected.set(l._id, l );
+    this.selected.set(l.id, l );
     this.cd.detectChanges();
 
     if (
@@ -125,7 +125,7 @@ export class ListComponent {
    * @param l Learning Object to be deselected
    */
   deselectLearningObject(l: LearningObject) {
-    this.selected.delete(l._id);
+    this.selected.delete(l.id);
     this.cd.detectChanges();
 
     if (this.selected.size < this.learningObjects.length && this.allSelected) {

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -224,7 +224,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.submitToCollection = true;
     } else {
       this.submissionService.submit({
-        learningObjectId: event._id,
+        learningObjectId: event.id,
         collectionName: event.collection,
       })
         .then(() => {
@@ -247,7 +247,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
    */
   cancelSubmission(l: LearningObject): Promise<void> {
     return this.submissionService.unsubmit(
-      l._id,
+      l.id,
       ).then(async () => {
       l.status = LearningObject.Status.UNRELEASED;
       this.cd.detectChanges();

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -292,7 +292,7 @@ export class BuilderStore {
    */
   fetchMaterials(): void {
     this.learningObjectService
-      .getMaterials(this.learningObject.author.username, this.learningObject._id)
+      .getMaterials(this.learningObject.author.username, this.learningObject.id)
       .then(materials => {
         this.learningObject.materials = materials;
         this.learningObjectEvent.next(this.learningObject);
@@ -326,9 +326,9 @@ export class BuilderStore {
   async setChildren(children: string[], remove: boolean = false) {
     this.serviceInteraction$.next(true);
     if (remove) {
-      children = this.learningObject.children.filter(child => !children.includes(child._id)).map(child => child._id);
+      children = this.learningObject.children.filter(child => !children.includes(child.id)).map(child => child.id);
     }
-    await this.learningObjectService.setChildren(this.learningObject._id, children, remove);
+    await this.learningObjectService.setChildren(this.learningObject.id, children, remove);
     this.serviceInteraction$.next(false);
   }
 
@@ -460,14 +460,14 @@ export class BuilderStore {
     if (event.item instanceof DirectoryNode) { // event.item is a Folder
       const fileIDs = this.getAllFolderFileIDs(event.item);
       await this.learningObjectService.toggleBundle(
-        this.learningObject._id,
+        this.learningObject.id,
         fileIDs,
         event.state
       );
     } else { // event.item is a File
       const fileID = [event.item._id];
       await this.learningObjectService.toggleBundle(
-        this.learningObject._id,
+        this.learningObject.id,
         fileID,
         event.state
       );
@@ -491,7 +491,7 @@ export class BuilderStore {
 
   private async changeStatus(status: LearningObject.Status, reason?: string) {
     await this.refactoredLearningObjectService.updateLearningObjectStatus(
-      this.learningObject._id,
+      this.learningObject.id,
       status,
       reason,
     );
@@ -691,7 +691,7 @@ export class BuilderStore {
     await this.learningObjectService
       .addFileMeta({
         files,
-        objectId: this.learningObject._id
+        objectId: this.learningObject.id
       })
       .then(() => {
         this.fetchMaterials();
@@ -781,7 +781,7 @@ export class BuilderStore {
     this.learningObjectService
       .updateFileDescription(
         this.learningObject.author.username,
-        this.learningObject._id,
+        this.learningObject.id,
         fileId,
         description
       )
@@ -879,7 +879,7 @@ export class BuilderStore {
   public cancelSubmission(): void {
     this.submissionService
       .unsubmit(
-        this.learningObject._id,
+        this.learningObject.id,
       )
       .then(() => {
         this.learningObject.status = LearningObject.Status.UNRELEASED;
@@ -942,7 +942,7 @@ export class BuilderStore {
       // if value is undefined here, this means we've called this function without a delay and there aren't any cached values
       // in this case we'll use the current data instead
       value = value || data;
-      if (!this.learningObject._id) {
+      if (!this.learningObject.id) {
         this.createLearningObject(value);
       } else {
         // this is an existing object and we can save it (has a saveable name)
@@ -1002,7 +1002,7 @@ export class BuilderStore {
   private updateLearningObject(object: Partial<LearningObject>) {
     this.serviceInteraction$.next(true);
     this.learningObjectService
-      .save(this.learningObject._id, object)
+      .save(this.learningObject.id, object)
       .then(() => {
         this.serviceInteraction$.next(false);
       })
@@ -1093,7 +1093,7 @@ export class BuilderStore {
     }
 
     this.outcomeService
-      .addLearningOutcome(this.learningObject._id, newOutcome)
+      .addLearningOutcome(this.learningObject.id, newOutcome)
       .then((serviceId: string) => {
         this.serviceInteraction$.next(false);
         // delete the id from the newOutcomes map so that the next time it's modified, we know to save it instead of creating it
@@ -1136,7 +1136,7 @@ export class BuilderStore {
     delete updateValue.serviceId;
     this.serviceInteraction$.next(true);
     this.learningObjectService
-      .saveOutcome(this.learningObject._id, updateValue as any)
+      .saveOutcome(this.learningObject.id, updateValue as any)
       .then(() => {
         this.serviceInteraction$.next(false);
       })

--- a/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
+++ b/src/app/onion/learning-object-builder/components/builder-navbar/builder-navbar.component.ts
@@ -169,14 +169,14 @@ export class BuilderNavbarComponent implements OnDestroy {
       this.toasterService.alert('Ready to Bundle...', 'This learning object is queued for bundling.');
     }
     // Trigger new PDF generation
-    Promise.all(await this.learningObjectService.updateReadme(this.learningObject._id));
+    Promise.all(await this.learningObjectService.updateReadme(this.learningObject.id));
     // Remove outcomes that have null text
     this.store.removeEmptyOutcomes();
     // Enforcing all files/folders are uploaded prior to leaving the builder (upload = 'true')
     if (this.store.upload !== undefined && this.store.upload !== 'false' && this.store.upload !== 'secondClickBack') {
       // If any data has be changed on the LO, then we need to rebundle
       if (this.store.touched) {
-        this.learningObjectService.triggerBundle(this.learningObject._id);
+        this.learningObjectService.triggerBundle(this.learningObject.id);
       }
       if (leaveBuilder) {
         this.historySnapshot.rewind('/onion/dashboard');

--- a/src/app/onion/learning-object-builder/components/content-upload/app/services/file-management.service.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/services/file-management.service.ts
@@ -516,7 +516,7 @@ export class FileManagementService {
   delete(learningObject: LearningObject, fileId: string): Promise<{}> {
     const route = FILE_ROUTES.DELETE_FILE({
       username: learningObject.author.username,
-      learningObjectId: learningObject._id,
+      learningObjectId: learningObject.id,
       fileId
     });
 

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -201,7 +201,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
         if (object) {
           this.learningObjectCuid = object.cuid;
           this.notes = object.materials.notes;
-          this.bucketUploadPath = `${object.author.username}/${object._id}`;
+          this.bucketUploadPath = `${object.author.username}/${object.id}`;
           this.files$.next(object.materials.files);
           this.folderMeta$.next(object.materials.folderDescriptions);
           this.solutionUpload = false;
@@ -690,7 +690,7 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   async handleFileDownload(file: LearningObject.Material.File) {
     const learningObject = await this.learningObject$.pipe(take(1)).toPromise();
-    const loId = learningObject._id;
+    const loId = learningObject.id;
     const url = FILE_ROUTES.DOWNLOAD_FILE(loId, file._id);
     window.open(url, '__blank');
   }

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -93,7 +93,7 @@ export class ChangeStatusModalComponent implements OnInit {
   private moveToMapAndTag() {
     // Set a small timeout before navigating so that the change in status applies
     setTimeout(() => {
-      this.router.navigate(['onion', 'relevancy-builder', this.learningObject._id, 'outcomes']);
+      this.router.navigate(['onion', 'relevancy-builder', this.learningObject.id, 'outcomes']);
     }, 1000);
   }
 

--- a/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
@@ -53,12 +53,12 @@ export class AddChildComponent implements OnInit, OnDestroy {
   async getLearningObjects(filters?: any, query?: string): Promise<LearningObject[]> {
     this.loading = true;
     return this.learningObjectService
-      .getLearningObjects(this.child.author.username, {...filters, text: query, childId: this.child._id } )
+      .getLearningObjects(this.child.author.username, {...filters, text: query, childId: this.child.id } )
       .then((children: LearningObject[]) => {
         this.loading = false;
         const indx = this.lengths.indexOf(this.child.length);
         const childrenLengths = this.lengths.slice(0, indx);
-        children = children.filter(child => (!this.currentChildren.includes(child._id) && childrenLengths.includes(child.length)));
+        children = children.filter(child => (!this.currentChildren.includes(child.id) && childrenLengths.includes(child.length)));
         return children;
       });
   }

--- a/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/scaffold.component.ts
@@ -68,7 +68,7 @@ export class ScaffoldComponent implements OnInit {
       this.loading = true;
       this.store.getChildren().then(kiddos => {
         this.children = kiddos;
-        this.children.forEach(kid => this.childrenIDs.push(kid._id));
+        this.children.forEach(kid => this.childrenIDs.push(kid.id));
         this.loading = false;
       }).catch(error => {
         this.loading = false;
@@ -88,7 +88,7 @@ export class ScaffoldComponent implements OnInit {
       this.children.unshift(child);
 
       // add child to the childrenIDs array
-      this.childrenIDs.unshift(child._id);
+      this.childrenIDs.unshift(child.id);
     } else {
       // if we DO NOT already have a children array defined
 
@@ -96,7 +96,7 @@ export class ScaffoldComponent implements OnInit {
       this.children = [child];
 
       // add child to the childrenIDs array
-      this.childrenIDs = [child._id];
+      this.childrenIDs = [child.id];
     }
 
 
@@ -115,7 +115,7 @@ export class ScaffoldComponent implements OnInit {
 
     this.childrenIDs = [];
     // get the ids of the children in children array
-    this.children.forEach(kid => this.childrenIDs.push(kid._id));
+    this.children.forEach(kid => this.childrenIDs.push(kid.id));
 
     // set the ids of children to the same order as the childrenIDs
     this.store.setChildren(this.childrenIDs);
@@ -152,7 +152,7 @@ export class ScaffoldComponent implements OnInit {
 
     // set childrenIDs equal to the children array
     this.childrenIDs = [];
-    this.children.forEach(kid => this.childrenIDs.push(kid._id));
+    this.children.forEach(kid => this.childrenIDs.push(kid.id));
     await this.store.fetch(this.learningObject.cuid);
     await this.store.setChildren(this.childrenIDs, true);
 

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -150,7 +150,7 @@ export class LearningObjectBuilderComponent implements OnInit, OnDestroy {
                 this.router.navigate(['onion/dashboard']);
               } else if (revision) {
                 this.learningObjectService.getLearningObjectRevision(
-                  learningObject.author.username, learningObject._id, learningObject.version);
+                  learningObject.author.username, learningObject.id, learningObject.version);
               } else {
                 this.setBuilderMode(learningObject);
               }

--- a/src/app/onion/relevancy-builder/builder-store.service.ts
+++ b/src/app/onion/relevancy-builder/builder-store.service.ts
@@ -137,10 +137,10 @@ export class BuilderStore {
    */
   async save() {
     try {
-      await this.relevancyService.updateObjectTopics(this._learningObject._id, this._topics);
+      await this.relevancyService.updateObjectTopics(this._learningObject.id, this._topics);
       for (let i = 0; i < this.outcomes.length; i++) {
         await this.relevancyService.updateLearningOutcomeMappings(
-          this._learningObject._id,
+          this._learningObject.id,
           this.outcomes[i].id,
           this.outcomes[i].mappings.map(g => g.guidelineId)
         );

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -187,7 +187,7 @@ export class SubmitComponent implements OnInit {
     if (proceed) {
       this.loading.push(true);
       if (this.isHierarchySubmission) {
-        this.hierarchyService.submitHierarchy(this.learningObject._id, this.collection)
+        this.hierarchyService.submitHierarchy(this.learningObject.id, this.collection)
           .then(() => {
             this.closeModal(true);
             this.loading.pop();
@@ -216,7 +216,7 @@ export class SubmitComponent implements OnInit {
       } else {
         this.submissionService
           .submit({
-            learningObjectId: this.learningObject._id,
+            learningObjectId: this.learningObject.id,
             collectionName: this.collection,
             submissionReason: this.submissionReason,
             selectedAuthorizations: this.selectedAuthorizations,
@@ -264,7 +264,7 @@ export class SubmitComponent implements OnInit {
    * @param collection The selected collection
    */
   getCollectionSelected(collection: string) {
-    this.submissionService.getFirstSubmission(this.learningObject._id, collection)
+    this.submissionService.getFirstSubmission(this.learningObject.id, collection)
       .then(val => {
         this.collection = collection;
         if (!val.isFirstSubmission) {

--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -16,12 +16,12 @@ const MAX_NAME_LENGTH = 170;
  * @class
  */
 export class LearningObject {
-  get _id(): string {
-    return this.__id;
+  get id(): string {
+    return this._id;
   }
-  set _id(id: string) {
-    if (!this.__id) {
-      this.__id = id;
+  set id(id: string) {
+    if (!this._id) {
+      this._id = id;
     } else {
       throw new EntityError(LEARNING_OBJECT_ERRORS.ID_SET, 'id');
     }
@@ -338,7 +338,7 @@ export class LearningObject {
     this._constructed = true;
   }
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  private __id: string;
+  private _id: string;
   private _author: User;
   private _name!: string;
   private _description!: string;
@@ -638,8 +638,8 @@ export class LearningObject {
    * @memberof LearningObject
    */
   private copyObject(object: Partial<LearningObject>): void {
-    if (object._id) {
-      this._id = object._id;
+    if (object.id) {
+      this._id = object.id;
     }
 
     if (object.cuid) {
@@ -746,7 +746,7 @@ export class LearningObject {
    */
   public toPlainObject(): Partial<LearningObject> {
     const object: Partial<LearningObject> = {
-      _id: this.__id,
+      id: this._id,
       cuid: this.cuid,
       author: this.author.toPlainObject() as User,
       name: this.name,


### PR DESCRIPTION
## What this PR fixes

the _id field in the client was not being properly sent throughout the client. This PR transforms the _id field on a learning object entity in the clark-client to id and updates all implementations. It fixes the logic that decided when to post/patch a learning object, so updating a learning object works now. It also may have fixed additional routes that were throwing 404s "Learning Obj not found" such as GET /children due to the id field not being populated.


https://github.com/user-attachments/assets/fc9ea36e-cf18-403b-9d43-d75a73961bdd


## After Further Testing...

I noticed the id field when creating a learning object, after the POST is hit, the id was not being properly set, causing the post to hit due to the logic dictating post/patch based of the if id exists.  **It's fixed now**


https://github.com/user-attachments/assets/d937f7e8-9d68-480d-a8bc-e96bc6233df9


