### PR TITLE
bug: [sc-32272] add back `id` field to learning object

### DIFF
--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -27,6 +27,10 @@ export class LearningObject {
     }
   }
 
+  get id(): string {
+    return this.__id;
+  }
+
   private _cuid?: string;
 
   /**
@@ -638,8 +642,10 @@ export class LearningObject {
    * @memberof LearningObject
    */
   private copyObject(object: Partial<LearningObject>): void {
-    if (object._id) {
-      this._id = object._id;
+    if (object.id) {
+      this.__id = object.id;
+    } else if (object._id) {
+      this.__id = object._id;
     }
 
     if (object.cuid) {


### PR DESCRIPTION
Some routes in clark-service return the ID field as `id` instead of the standard `_id`. Changing these would take a bit, so I added the `id` field to the frontend as a "quick fix".

This fixes multiple issues in some routes where the `id` field does not exist when calling `__id` or `_id`. 

As far as the Shortcut story goes, the problem has been addressed including possibly many other issues.