### PR TITLE
Feature/sc 32286/implement getting a learning object parent

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -24,6 +24,7 @@ import { LearningObjectService } from 'app/core/learning-object-module/learning-
 import {
   LearningObjectService as RefactoredLearningObjectService
 } from 'app/core/learning-object-module/learning-object/learning-object.service';
+import { LEARNING_OBJECT_ROUTES } from 'app/core/learning-object-module/learning-object/learning-object.routes';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -185,14 +186,8 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   async checkForParents() {
-    const parentUri = `${environment.apiURL}/users/${encodeURIComponent(
-      this.learningObject.author.username
-    )}/learning-objects/${encodeURIComponent(
-      this.learningObject._id
-    )}/parents`;
-
     await this.http.get(
-      parentUri,
+      LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(this.learningObject._id),
       { headers: this.headers, withCredentials: true }
     ).pipe(
       take(1),

--- a/src/app/collection/shared/included/collection-feature/core/attribute.service.ts
+++ b/src/app/collection/shared/included/collection-feature/core/attribute.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import {
+  LEARNING_OBJECT_ROUTES,
   LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES,
   LEGACY_USER_ROUTES
 } from '../../../../../core/learning-object-module/learning-object/learning-object.routes';
@@ -14,8 +15,7 @@ export class AttributeService {
 
   async getHierarchy(username: string, objectId: string): Promise<{ parents: any, children: any }> {
     const parents = await this.http.get(
-      LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(
-        username,
+      LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(
         objectId
       ))
       .toPromise();

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -12,6 +12,15 @@ export const LEARNING_OBJECT_ROUTES = {
     },
 
     /**
+     *
+     * @param id id of a children learning object
+     * @returns Promise<FullLearningObject[]>
+     */
+    GET_LEARNING_OBJECT_PARENTS(id: string) {
+        return `${environment.apiURL}/learning-objects/${id}/parents`;
+    },
+
+    /**
      * Path to update the status of a learning object
      * @param learningObjectId the id of the learning object
      * @returns void
@@ -191,18 +200,6 @@ export const LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES = {
     GET_PUBLIC_LEARNING_OBJECTS: `${environment.apiURL}/learning-objects`,
     GET_PUBLIC_LEARNING_OBJECTS_WITH_FILTER(query) {
         return `${environment.apiURL}/learning-objects?${query}`;
-    },
-    GET_PUBLIC_LEARNING_OBJECT(cuid: string, version?: number) {
-        let uri = `${environment.apiURL}/learning-objects/${encodeURIComponent(cuid)}`;
-
-        if (version !== undefined) {
-            uri += '?version=' + version.toString();
-        }
-
-        return uri;
-    },
-    GET_LEARNING_OBJECT_PARENTS(username: string, id: string) {
-        return `${environment.apiURL}/users/${username}/learning-objects/${id}/parents`;
     },
     DOWNLOAD_FILE(params: {
         username: string;

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -211,6 +211,15 @@ export const LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES = {
     GET_PUBLIC_LEARNING_OBJECTS_WITH_FILTER(query) {
         return `${environment.apiURL}/learning-objects?${query}`;
     },
+    GET_PUBLIC_LEARNING_OBJECT(cuid: string, version?: number) {
+        let uri = `${environment.apiURL}/learning-objects/${encodeURIComponent(cuid)}`;
+
+        if (version !== undefined) {
+            uri += '?version=' + version.toString();
+        }
+
+        return uri;
+    },
     DOWNLOAD_FILE(params: {
         username: string;
         loId: string;

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -16,7 +16,7 @@ export const LEARNING_OBJECT_ROUTES = {
      * @param id id of a children learning object
      * @returns Promise<FullLearningObject[]>
      */
-    GET_LEARNING_OBJECT_PARENTS(id: string) {
+    GET_LEARNING_OBJECT_PARENTS(learningObjectId: string) {
         return `${environment.apiURL}/learning-objects/${id}/parents`;
     },
 

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -17,7 +17,7 @@ export const LEARNING_OBJECT_ROUTES = {
      * @returns Promise<FullLearningObject[]>
      */
     GET_LEARNING_OBJECT_PARENTS(learningObjectId: string) {
-        return `${environment.apiURL}/learning-objects/${id}/parents`;
+        return `${environment.apiURL}/learning-objects/${learningObjectId}/parents`;
     },
 
     /**

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -498,8 +498,8 @@ export class LearningObjectService {
    *
    * @param id of learning object
    */
-  fetchParents(username: string, id: string) {
-    const route = LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(username, id);
+  fetchParents(id: string) {
+    const route = LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(id);
     return this.http.get<LearningObject[]>(route, { withCredentials: true }).toPromise().then(parents => {
       return parents;
     });

--- a/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
+++ b/src/app/onion/dashboard/components/dashboard-item/dashboard-item.component.ts
@@ -223,7 +223,7 @@ export class DashboardItemComponent implements OnInit, OnChanges {
    */
   async parentNames() {
     const parents = [];
-    return this.learningObjectService.fetchParents(this.learningObject.author.username, this.learningObject._id).then(returners => {
+    return this.learningObjectService.fetchParents(this.learningObject._id).then(returners => {
       returners.forEach(parent => {
         parents.push(parent.name);
       });


### PR DESCRIPTION
Updates the routes of the parent route

https://app.shortcut.com/clarkcan/story/32286/implement-getting-a-learning-object-parent-in-clark-service


https://github.com/user-attachments/assets/a5d67311-8bc7-4205-90bd-a6ad96616be9

