### PR TITLE
bug: [sc-32305] fix frameworks search query not being passed properly

### DIFF
--- a/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
@@ -1,4 +1,5 @@
 import { environment } from '@env/environment';
+import * as querystring from 'querystring';
 
 export const STANDARD_GUIDELINES_ROUTES = {
     /**
@@ -34,7 +35,7 @@ export const STANDARD_GUIDELINES_ROUTES = {
      * @returns list of frameworks
      */
     SEARCH_FRAMEWORKS(query: any) {
-        return `${environment.apiURL}/frameworks/?${query}`;
+        return `${environment.apiURL}/frameworks/?${querystring.stringify(query)}`;
     },
     /**
      * Request to retrieve a list of guidelines


### PR DESCRIPTION
This PR fixes an issue where the query params were not stringified before sending the request to the frameworks endpoint. 

https://app.shortcut.com/clarkcan/story/32305/client-route-for-frameworks-is-sending-an-object-instead-of-id