### PR TITLE
Removing Evaluator Functionality and Fixing Double Map and Tag

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.html
@@ -43,12 +43,10 @@
       <li (click)="goToUrl('contact')"><i class="far fa-user"></i>View Author Contact</li>
       <li (click)="goToUrl('details')"><i class="far fa-cube"></i>View details</li>
       <li (click)="toggleRelevancyDate(true)"><i class="fal fa-history"></i>Mark Next Check Date</li>
-      <li (click)="toggleAddEvaluatorModal(true)"><i class="fal fa-user-plus"></i>Assign Evaluators</li>
       <li *ngIf="hasParents === false" (click)="toggleChangeAuthorModal(true)"><i class="far fa-user"></i>Change Author</li>
       <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleChangeCollectionModal(true)"><i class="fal fa-exchange"></i>Change Collection</li>
       <li *ngIf="learningObject.status === 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor'))" (click)="toggleUnreleaseConfirm(true)"><i class="far fa-eye-slash"></i>Unrelease</li>
       <li *ngIf="learningObject.status !== 'released' && (auth.user.accessGroups.includes('admin') || auth.user.accessGroups.includes('editor') || auth.user.accessGroups.includes('mapper') )" (click)="goToUrl('relevancy')"><i class="far fa-puzzle-piece"></i>Map & Tag</li>
-      <li *ngIf="learningObject.status !== 'released' && learningObject.status !== 'unreleased'" (click)="goToUrl('relevancy')"><i class="far fa-puzzle-piece"></i>Map & Tag</li>
     </ul>
   </div>
 </clark-context-menu>
@@ -72,12 +70,6 @@
       <button (click)="closeUnreleaseModal(true)" class="button bad">Yes</button>
       <button (click)="closeUnreleaseModal(false)" class="button good">No</button>
     </div>
-  </div>
-</clark-popup>
-
-<clark-popup *ngIf="showAddEvaluator" (closed)="toggleAddEvaluatorModal(false)">
-  <div class="modal-container" #popupInner>
-    <clark-add-evaluator (close)="toggleAddEvaluatorModal(false)" [learningObject]="learningObject"></clark-add-evaluator>
   </div>
 </clark-popup>
 

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -55,7 +55,6 @@ export class LearningObjectListItemComponent implements OnChanges {
   statusDescription: string;
 
   showChangeAuthor: boolean;
-  showAddEvaluator: boolean;
   showUnreleaseConfirm: boolean;
   showRelevancyDate: boolean;
   showDeleteRevisionConfirmation: boolean;
@@ -77,7 +76,6 @@ export class LearningObjectListItemComponent implements OnChanges {
     private cd: ChangeDetectorRef,
     private http: HttpClient,
     private toaster: ToastrOvenService,
-    private router: Router,
     private hierarchyService: HierarchyService,
     private loService: LearningObjectService,
     private refactoredLearningObjectService: RefactoredLearningObjectService
@@ -116,15 +114,6 @@ export class LearningObjectListItemComponent implements OnChanges {
    */
   toggleChangeAuthorModal(value: boolean) {
     this.showChangeAuthor = value;
-  }
-
-  /**
-   * Toggles the add evaluator modal from showing/hiding
-   *
-   * @param value True if showing, false otherwise
-   */
-  toggleAddEvaluatorModal(value: boolean) {
-    this.showAddEvaluator = value;
   }
 
   /**

--- a/src/app/core/user-module/user.service.ts
+++ b/src/app/core/user-module/user.service.ts
@@ -91,7 +91,7 @@ export class UserService {
           (val: any) => {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             const user_res = val;
-            // this matches the _id attribute returned from the service to the client expected userId attribute 
+            // this matches the _id attribute returned from the service to the client expected userId attribute
             user_res.userId = user_res._id;
             return user_res ? new User(user_res) : null;
           },


### PR DESCRIPTION
This PR removes the Evaluator functionality option from the admin dashboard and also fixes and issue with Map and Tag appearing twice for learning objects in certain statuses. 