### PR TITLE
bug/sc-32353/editing-lo-from-admin-dashboard-searches

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -230,7 +230,7 @@ export class LearningObjectListItemComponent implements OnChanges {
 
   goToUrl(url) {
     if (url === 'builder') {
-      window.open(`/onion/learning-object-builder/${this.learningObject.id}`, '_blank');
+      window.open(`/onion/learning-object-builder/${this.learningObject.cuid}`, '_blank');
     } else if (url === 'contact') {
       window.open(`/users/${this.learningObject.author.username}`);
     } else if (url === 'details') {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -72,9 +72,9 @@ export class EditorialActionPadComponent implements OnInit {
   editLearningObject() {
     const userOrAdminRoute = (this.userIsAuthor) ? 'onion' : 'admin';
     if (this.revisedLearningObject) {
-      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.revisedLearningObject.id]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.revisedLearningObject.cuid]);
     } else {
-      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.learningObject.id]);
+      this.router.navigate([userOrAdminRoute, 'learning-object-builder', this.learningObject.cuid]);
     }
   }
 


### PR DESCRIPTION
## What this PR fixes

When editing a learning object from the admin dashboard, the builder route was hit with learning object Id. I corrected it to use the cuid instead.

I also noticed another builder re-route that was still using learning object id for editors, so I changed that as well.


https://github.com/user-attachments/assets/f01d3f60-db20-45c2-81cb-52b814808d66



<img width="1295" alt="Screenshot 2024-07-25 at 1 48 28 PM" src="https://github.com/user-attachments/assets/6dcbc5bc-49f1-40bb-90c9-72d55176ef3f">
