### PR TITLE
fix: [sc-32358] Use proper object notation when sending materials updates

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -733,7 +733,7 @@ export class BuilderStore {
       this.learningObject.materials.urls[index] = url;
       this.learningObjectEvent.next(this.learningObject);
       this.saveObject({
-        'materials.urls': this.learningObject.materials.urls
+        materials: { urls: this.learningObject.materials.urls }
       });
     }
   }
@@ -750,7 +750,7 @@ export class BuilderStore {
     }
     this.learningObjectEvent.next(this.learningObject);
     this.saveObject({
-      'materials.urls': this.learningObject.materials.urls
+      materials: { urls: this.learningObject.materials.urls }
     });
   }
 
@@ -764,7 +764,7 @@ export class BuilderStore {
   private updateNotes(notes: string): void {
     this.learningObject.materials.notes = notes;
     this.learningObjectEvent.next(this.learningObject);
-    this.saveObject({ 'materials.notes': notes });
+    this.saveObject({ materials: { notes: notes } });
   }
 
   /**
@@ -818,8 +818,8 @@ export class BuilderStore {
     }
     this.learningObjectEvent.next(this.learningObject);
     this.saveObject({
-      'materials.folderDescriptions': this.learningObject.materials
-        .folderDescriptions
+      materials: { folderDescriptions: this.learningObject.materials
+        .folderDescriptions }
     });
   }
 


### PR DESCRIPTION
This fix changes the way materials are sent to the backend by using proper object notation instead of stringified dot notation. [See Paige's comment.](https://github.com/Cyber4All/clark-service/pull/172/files/912d958e59998ac7059b7743bdfae543756e7f6c#r1692970875)

Story details: https://app.shortcut.com/clarkcan/story/32358