### PR TITLE
fix: [sc-32405] add more allowed status changes

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -82,6 +82,10 @@ export class ChangeStatusModalComponent implements OnInit {
         break;
       case LearningObject.Status.PROOFING:
         this.statuses = [LearningObject.Status.RELEASED, LearningObject.Status.REJECTED];
+        break;
+      case LearningObject.Status.RELEASED:
+        this.statuses = [LearningObject.Status.PROOFING];
+        break;
     }
   }
 

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -82,10 +82,6 @@ export class ChangeStatusModalComponent implements OnInit {
         break;
       case LearningObject.Status.PROOFING:
         this.statuses = [LearningObject.Status.RELEASED, LearningObject.Status.REJECTED];
-        break;
-      case LearningObject.Status.RELEASED:
-        this.statuses = [LearningObject.Status.PROOFING];
-        break;
     }
   }
 

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -77,10 +77,8 @@ export class ChangeStatusModalComponent implements OnInit {
         ];
         break;
       case LearningObject.Status.ACCEPTED_MINOR:
-        this.statuses = [LearningObject.Status.WAITING];
-        break;
       case LearningObject.Status.ACCEPTED_MAJOR:
-        this.statuses = [LearningObject.Status.WAITING];
+        this.statuses = [LearningObject.Status.WAITING, LearningObject.Status.PROOFING];
         break;
       case LearningObject.Status.PROOFING:
         this.statuses = [LearningObject.Status.RELEASED, LearningObject.Status.REJECTED];


### PR DESCRIPTION
Some status changes that are allowed don't show up in the client. This isn't an exhaustive change and may be more statuses that should be allowed in the client.

See https://app.shortcut.com/clarkcan/story/32405/some-status-changes-are-not-allowed.