### PR TITLE
Bug/sc 32355/delete lo from library

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -118,7 +118,6 @@ export class LibraryService {
     const cartId = this.cartItems
     .filter(cart => cart.learningObject && cart.learningObject._id === learningObjectId)
     .map(cart => cart._id)[0];
-    console.log(cartId);
     this.http
       .delete(
         LIBRARY_ROUTES.REMOVE_LEARNING_OBJECT_FROM_LIBRARY(


### PR DESCRIPTION
this PR addresses the inability to delete LOs from user library. This was first thought to be a service issue but after further investigation we found that the error was coming from the client side. By filtering the cart items, we were able to successfully pull the correct id to be sent to our API for deletion. 

# Please look at these links for the changes I made:
https://github.com/Cyber4All/clark-client/commit/99eafd0ae3cb1a2fd244bef03ad244109837cf4c

https://github.com/Cyber4All/clark-client/commit/b77c7034e642828997b4ab4f9386e408e016c91a

I accidentally pushed these changes to the base client-service-refactor.. sorry

deleted objects below:

<img width="842" alt="Screenshot 2024-07-30 at 5 00 54 PM" src="https://github.com/user-attachments/assets/f7bb050b-2c2b-4f2b-a6a6-011c882b2335">

All changes I made to clark-service have been reverted to its original implementation. Please check this branch from the service.

https://github.com/Cyber4All/clark-service/pull/171#issue-2430621431


