### PR TITLE
Bug/sc 32299/lo builder mistakes first submission as a

### DIFF
--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -270,7 +270,9 @@ export class SubmitComponent implements OnInit {
       .then(val => {
         this.collection = collection;
         if (!val.isFirstSubmission) {
-          this.needsChangelog = true;
+          // if this is a first submission there is no need for a change log
+          this.needsChangelog = false;
+          console.log(val.isFirstSubmission)
         }
       });
   }

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -272,7 +272,7 @@ export class SubmitComponent implements OnInit {
         if (!val.isFirstSubmission) {
           // if this is a first submission there is no need for a change log
           this.needsChangelog = false;
-          console.log(val.isFirstSubmission)
+          console.log(val.isFirstSubmission);
         }
       });
   }


### PR DESCRIPTION
This PR addresses the changelog user input request after a user submits a LO for the first time. This should not happen since it is the first submission, it should not ask for the changes that were made. 

needsChangelog was set to false in 'isFirstSubmission' to fix this.

# This is not a priority at the moment, just creating this PR for someone to pick up after I leave.