### PR TITLE
fix: [sc-32474] Some learning object details page won't load

### DIFF
--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -631,7 +631,7 @@ export class DetailsComponent implements OnInit, OnDestroy {
       const u = this.auth.username;
       if (this.ratings && this.ratings.length) {
         for (let i = 0, l = this.ratings.length; i < l; i++) {
-          if (u === ratings[i].user.username) {
+          if (u === this.ratings[i].user.username) {
             // this is the user's rating
             // we deep copy this to prevent direct modification from component subtree
             this.userRating = Object.assign({}, ratings[i]);


### PR DESCRIPTION
This was an issue with loading the ratings. One liner fix to use `this.ratings` instead of `ratings`.

https://github.com/user-attachments/assets/a2ad47c4-082f-41ad-863f-5b3f131a4fef

