### PR TITLE
Bug/sc 32418/metrics throwing 404 error on details page

### DIFF
--- a/src/app/core/metric-module/metric.routes.ts
+++ b/src/app/core/metric-module/metric.routes.ts
@@ -14,7 +14,7 @@ export const METRIC_ROUTES = {
    * @returns metrics for one learning object or all released learning objects
    */
   GET_LEARNING_OBJECT_METRICS(cuid?: string) {
-    return `${environment.apiURL}/learning-objects/metrics?cuid=${cuid}`;
+    return `${environment.apiURL}/learning-objects/metrics?${querystring.stringify({cuid: cuid})}`;
   },
 
   /**

--- a/src/app/core/metric-module/metric.routes.ts
+++ b/src/app/core/metric-module/metric.routes.ts
@@ -13,8 +13,8 @@ export const METRIC_ROUTES = {
    * Gets learning object metrics
    * @returns metrics for one learning object or all released learning objects
    */
-  GET_LEARNING_OBJECT_METRICS() {
-    return `${environment.apiURL}/learning-objects/metrics`;
+  GET_LEARNING_OBJECT_METRICS(cuid?: string) {
+    return `${environment.apiURL}/learning-objects/metrics?cuid=${cuid}`;
   },
 
   /**

--- a/src/app/core/metric-module/metric.service.ts
+++ b/src/app/core/metric-module/metric.service.ts
@@ -4,7 +4,7 @@ import { METRIC_ROUTES } from './metric.routes';
 import { catchError } from 'rxjs/operators';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { throwError } from 'rxjs';
-import { LearningObjectStats, UserMetrics } from 'app/cube/shared/types/usage-stats';
+import { LearningObjectMetrics, LearningObjectStats, UserMetrics } from 'app/cube/shared/types/usage-stats';
 
 @Injectable({
   providedIn: 'root'
@@ -39,6 +39,20 @@ export class MetricService {
         )
         .toPromise();
     return stats as LearningObjectStats;
+  }
+
+  /**
+   * Gets metrics for one learning object or all released learning objects
+   * @param cuid - The cuid of the learning object to get metrics for
+   * @returns metrics for one learning object or all released learning objects
+   */
+  async getLearningObjectMetrics(cuid?: string) {
+    return this.http
+    .get<LearningObjectMetrics>(METRIC_ROUTES.GET_LEARNING_OBJECT_METRICS(cuid))
+      .pipe(
+        catchError(this.handleError)
+      )
+      .toPromise();
   }
 
   /**

--- a/src/app/cube/shared/types/usage-stats.ts
+++ b/src/app/cube/shared/types/usage-stats.ts
@@ -27,6 +27,17 @@ export interface LearningObjectStats {
   collections: { number: number };
 }
 
+export interface LearningObjectMetrics {
+  saves: number;
+  downloads: number;
+  topDownloads?: LearningObjectDownloads[];
+}
+
+export interface LearningObjectDownloads {
+  cuid: string;
+  downloads: number;
+}
+
 export interface UserMetrics {
   accounts: number;
   organizations: number;


### PR DESCRIPTION
## Description

Implements learning object metrics in client (this is not being used because we get the URI in the full learning object builder in clark-service, but I implemented anyway to minimize future tech debt).

<img width="314" alt="Screenshot 2024-07-31 at 1 25 03 PM" src="https://github.com/user-attachments/assets/4ccc6adc-9f29-40cf-843b-eb12b2c11cd6">

Before (no numbers)

<img width="462" alt="Screenshot 2024-07-31 at 1 24 50 PM" src="https://github.com/user-attachments/assets/8f58f358-88a4-40bb-88f1-90895318f109">

After with numbers!
