### PR TITLE
Client changes for other collection pages

### DIFF
--- a/src/app/collection/pages/collection-502/collection-502.component.ts
+++ b/src/app/collection/pages/collection-502/collection-502.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { LearningObject } from '../../../../entity/learning-object/learning-object';
 import { NavbarService } from '../../../core/client-module/navbar.service';
-import { LearningObjectService } from '../../../cube/learning-object.service';
 import { Query } from '../../../interfaces/query';
 import { CollectionService } from '../../../core/collection-module/collections.service';
 import { Title } from '@angular/platform-browser';
+import { FeaturedObjectsService } from 'app/core/feature-module/featured.service';
 
 @Component({
   selector: 'clark-502-collection-index',
@@ -24,7 +24,7 @@ export class Collection502Component implements OnInit {
 
   constructor(
     private navbarService: NavbarService,
-    private learningObjectService: LearningObjectService,
+    private featureService: FeaturedObjectsService,
     private collectionService: CollectionService,
     private titleService: Title
   ) { }
@@ -56,11 +56,7 @@ export class Collection502Component implements OnInit {
     // Trim leading and trailing whitespace
     query.text = query.text ? query.text.trim() : undefined;
     try {
-      const {
-        learningObjects,
-        total
-      } = await this.learningObjectService.getLearningObjects(query);
-      this.learningObjects = learningObjects;
+      this.learningObjects = await this.featureService.getCollectionFeatured(query.collection);
       this.loading = false;
     } catch (e) {
       console.log(`Error: ${e}`);

--- a/src/app/collection/pages/collection-502/collection-502.component.ts
+++ b/src/app/collection/pages/collection-502/collection-502.component.ts
@@ -1,10 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { LearningObject } from '../../../../entity/learning-object/learning-object';
 import { NavbarService } from '../../../core/client-module/navbar.service';
+import { LearningObjectService } from '../../../cube/learning-object.service';
 import { Query } from '../../../interfaces/query';
 import { CollectionService } from '../../../core/collection-module/collections.service';
 import { Title } from '@angular/platform-browser';
-import { FeaturedObjectsService } from 'app/core/feature-module/featured.service';
 
 @Component({
   selector: 'clark-502-collection-index',
@@ -24,7 +24,7 @@ export class Collection502Component implements OnInit {
 
   constructor(
     private navbarService: NavbarService,
-    private featureService: FeaturedObjectsService,
+    private learningObjectService: LearningObjectService,
     private collectionService: CollectionService,
     private titleService: Title
   ) { }
@@ -53,10 +53,12 @@ export class Collection502Component implements OnInit {
   async fetchLearningObjects(query: Query) {
     this.loading = true;
     this.learningObjects = [];
-    // Trim leading and trailing whitespace
-    query.text = query.text ? query.text.trim() : undefined;
     try {
-      this.learningObjects = await this.featureService.getCollectionFeatured(query.collection);
+      const {
+        learningObjects,
+        total
+      } = await this.learningObjectService.getLearningObjects(query);
+      this.learningObjects = learningObjects;
       this.loading = false;
     } catch (e) {
       console.log(`Error: ${e}`);

--- a/src/app/collection/shared/included/collection-feature/collection-feature.component.html
+++ b/src/app/collection/shared/included/collection-feature/collection-feature.component.html
@@ -32,7 +32,7 @@
                 <div class="objects">
                     <div *ngFor="let object of learningObjects">
                         <a [routerLink]="['/details', object.author.username, object.cuid]">
-                            <clark-collection-feature-cards *ngIf="collection === 'ncyte'" [learningObject]="object"
+                            <clark-collection-feature-cards *ngIf="collection === 'ncyte'" [collection]="collection" [learningObject]="object"
                                 [primaryColor]="primaryColor"></clark-collection-feature-cards>
                         </a>
                     </div>

--- a/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
+++ b/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
@@ -9,6 +9,7 @@ import { AttributeService } from '../../core/attribute.service';
 })
 export class FeatureCardsComponent implements OnInit {
 
+  @Input()collection: string;
   @Input()learningObject: any;
   @Input()primaryColor: string;
 
@@ -35,7 +36,7 @@ export class FeatureCardsComponent implements OnInit {
     this.setHierarchy();
     this.setDescription();
 
-    this.learningObject.collection = await (await this.collectionService.getCollection(this.learningObject.collectionName));
+    this.learningObject.collection = await (await this.collectionService.getCollection(this.collection)).name;
     this.loading = false;
   }
 

--- a/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
+++ b/src/app/collection/shared/included/collection-feature/components/feature-cards/feature-cards.component.ts
@@ -27,7 +27,6 @@ export class FeatureCardsComponent implements OnInit {
     this.loading = true;
     this.setColorScheme();
     const hierarchy = await this.attributeService.getHierarchy(
-      this.learningObject.author.username,
       this.learningObject.id
     );
     this.parents = hierarchy.parents;
@@ -36,7 +35,7 @@ export class FeatureCardsComponent implements OnInit {
     this.setHierarchy();
     this.setDescription();
 
-    this.learningObject.collection = await (await this.collectionService.getCollection(this.learningObject.collectionName)).name;
+    this.learningObject.collection = await (await this.collectionService.getCollection(this.learningObject.collectionName));
     this.loading = false;
   }
 

--- a/src/app/collection/shared/included/collection-feature/core/attribute.service.ts
+++ b/src/app/collection/shared/included/collection-feature/core/attribute.service.ts
@@ -12,7 +12,7 @@ export class AttributeService {
 
   constructor(private http: HttpClient) { }
 
-  async getHierarchy(username: string, objectId: string): Promise<{ parents: any, children: any }> {
+  async getHierarchy(objectId: string): Promise<{ parents: any, children: any }> {
     const parents = await this.http.get(
       LEARNING_OBJECT_ROUTES.GET_LEARNING_OBJECT_PARENTS(
         objectId
@@ -20,7 +20,7 @@ export class AttributeService {
       .toPromise();
     const children = await this.http.get(
       LEARNING_OBJECT_ROUTES.GET_CHILDREN(
-        username,
+        objectId
       ))
       .toPromise();
 

--- a/src/app/collection/shared/included/collection-learning-object-list/collection-learning-object-list.component.ts
+++ b/src/app/collection/shared/included/collection-learning-object-list/collection-learning-object-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { FeaturedObjectsService } from 'app/core/feature-module/featured.service';
+import { LearningObjectService } from 'app/cube/learning-object.service';
 import { OrderBy, Query, SortType } from 'app/interfaces/query';
 import { LearningObject } from 'entity/learning-object/learning-object';
 
@@ -12,8 +12,8 @@ import { LearningObject } from 'entity/learning-object/learning-object';
 })
 export class CollectionLearningObjectListComponent implements OnInit {
   @Input() collectionName: string;
-  constructor(private featureService: FeaturedObjectsService) { }
-
+  constructor(private learningObjectService: LearningObjectService) { }
+  
   learningObjects: LearningObject[];
   query: Query = {
     limit: 6,
@@ -26,7 +26,9 @@ export class CollectionLearningObjectListComponent implements OnInit {
 
   async ngOnInit() {
     this.query.collection = this.collectionName;
-    this.learningObjects = await this.featureService.getCollectionFeaturedWithLimit(this.collectionName, this.query.limit);
+    this.learningObjectService.getLearningObjects(this.query).then((res) => {
+      this.learningObjects = res.learningObjects;
+    });
   }
 
 }

--- a/src/app/collection/shared/included/collection-learning-object-list/collection-learning-object-list.component.ts
+++ b/src/app/collection/shared/included/collection-learning-object-list/collection-learning-object-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { LearningObjectService } from 'app/cube/learning-object.service';
+import { FeaturedObjectsService } from 'app/core/feature-module/featured.service';
 import { OrderBy, Query, SortType } from 'app/interfaces/query';
 import { LearningObject } from 'entity/learning-object/learning-object';
 
@@ -12,7 +12,7 @@ import { LearningObject } from 'entity/learning-object/learning-object';
 })
 export class CollectionLearningObjectListComponent implements OnInit {
   @Input() collectionName: string;
-  constructor(private learningObjectService: LearningObjectService) { }
+  constructor(private featureService: FeaturedObjectsService) { }
 
   learningObjects: LearningObject[];
   query: Query = {
@@ -24,11 +24,9 @@ export class CollectionLearningObjectListComponent implements OnInit {
   };
 
 
-  ngOnInit() {
+  async ngOnInit() {
     this.query.collection = this.collectionName;
-    this.learningObjectService.getLearningObjects(this.query).then((res) => {
-      this.learningObjects = res.learningObjects;
-    });
+    this.learningObjects = await this.featureService.getCollectionFeaturedWithLimit(this.collectionName, this.query.limit);
   }
 
 }

--- a/src/app/core/feature-module/featured.routes.ts
+++ b/src/app/core/feature-module/featured.routes.ts
@@ -24,9 +24,12 @@ export const FEATURED_ROUTES = {
    * @param limit the number of featured learning objects to retrieve
    */
   GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collectionAbvName: string, limit: number) {
-      return `${environment.apiURL}/featured/learning-objects?
-        collection=${encodeURIComponent(collectionAbvName)}&limit=${encodeURIComponent(limit)}`;
-    },
+    return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(
+      collectionAbvName,
+    )}&limit=${encodeURIComponent(
+      limit
+    )}`;
+  },
   /**
    * Request to update the list of featured learning objects
    * @method PATCH

--- a/src/app/core/feature-module/featured.routes.ts
+++ b/src/app/core/feature-module/featured.routes.ts
@@ -18,10 +18,11 @@ export const FEATURED_ROUTES = {
     return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}`;
   },
   /**
-  * Request to retrieve the featured learning objects for a specific collection with a limit
-  * @method GET
-  * @param collectionAbvName the abbreviated name of the collection
-  */
+   * Request to retrieve the featured learning objects for a specific collection with a limit
+   * @method GET
+   * @param collectionAbvName the abbreviated name of the collection
+   * @param limit the number of featured learning objects to retrieve
+   */
   GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collectionAbvName: string, limit: number) {
       return `${environment.apiURL}/featured/learning-objects?
         collection=${encodeURIComponent(collectionAbvName)}&limit=${encodeURIComponent(limit)}`;

--- a/src/app/core/feature-module/featured.routes.ts
+++ b/src/app/core/feature-module/featured.routes.ts
@@ -17,14 +17,14 @@ export const FEATURED_ROUTES = {
   GET_COLLECTION_FEATURED_OBJECTS(collectionAbvName: string) {
     return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}`;
   },
-    /**
-     * Request to retrieve the featured learning objects for a specific collection with a limit
-     * @method GET
-     * @param collectionAbvName the abbreviated name of the collection
-     */
-    GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collectionAbvName: string, limit: number) {
-      return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}
-      &limit=${encodeURIComponent(limit)}`;
+  /**
+  * Request to retrieve the featured learning objects for a specific collection with a limit
+  * @method GET
+  * @param collectionAbvName the abbreviated name of the collection
+  */
+  GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collectionAbvName: string, limit: number) {
+      return `${environment.apiURL}/featured/learning-objects?
+        collection=${encodeURIComponent(collectionAbvName)}&limit=${encodeURIComponent(limit)}`;
     },
   /**
    * Request to update the list of featured learning objects

--- a/src/app/core/feature-module/featured.routes.ts
+++ b/src/app/core/feature-module/featured.routes.ts
@@ -17,6 +17,15 @@ export const FEATURED_ROUTES = {
   GET_COLLECTION_FEATURED_OBJECTS(collectionAbvName: string) {
     return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}`;
   },
+    /**
+     * Request to retrieve the featured learning objects for a specific collection with a limit
+     * @method GET
+     * @param collectionAbvName the abbreviated name of the collection
+     */
+    GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collectionAbvName: string, limit: number) {
+      return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}
+      &limit=${encodeURIComponent(limit)}`;
+    },
   /**
    * Request to update the list of featured learning objects
    * @method PATCH

--- a/src/app/core/feature-module/featured.service.ts
+++ b/src/app/core/feature-module/featured.service.ts
@@ -193,6 +193,22 @@ export class FeaturedObjectsService {
       });
   }
 
+  /**
+   * Get the featured learning objects for a collection with a limit
+   *
+   * @param collection
+   * @returns [LearningObject]
+   */
+  getCollectionFeaturedWithLimit(collection: string, limit: number) {
+    return this.http
+      .get(FEATURED_ROUTES.GET_COLLECTION_FEATURED_OBJECTS_WITH_LIMIT(collection, limit))
+      .pipe(catchError(this.handleError))
+      .toPromise()
+      .then((response: any) => {
+        return response;
+      });
+  }
+
   private handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {
       // Client-side or network returned error

--- a/src/app/core/feature-module/featured.service.ts
+++ b/src/app/core/feature-module/featured.service.ts
@@ -197,6 +197,7 @@ export class FeaturedObjectsService {
    * Get the featured learning objects for a collection with a limit
    *
    * @param collection
+   * @param limit
    * @returns [LearningObject]
    */
   getCollectionFeaturedWithLimit(collection: string, limit: number) {

--- a/src/app/cube/shared/featured/featured.component.ts
+++ b/src/app/cube/shared/featured/featured.component.ts
@@ -1,6 +1,5 @@
 import { LearningObject } from '@entity';
 import { Component, OnInit, Input } from '@angular/core';
-import { LearningObjectService } from '../../learning-object.service';
 import { Query, OrderBy, SortType } from '../../../interfaces/query';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -24,7 +23,7 @@ export class FeaturedComponent implements OnInit {
   loading = false;
   collectionName: string;
 
-  constructor(private learningObjectService: LearningObjectService, private featureService: FeaturedObjectsService) {
+  constructor(private featureService: FeaturedObjectsService) {
     this.learningObjects = this.learningObjects.fill(new LearningObject());
   }
 
@@ -50,9 +49,9 @@ export class FeaturedComponent implements OnInit {
     this.loading = true;
 
     try {
-      this.learningObjects = (await this.learningObjectService.getLearningObjects(
-        this.query
-      )).learningObjects;
+      this.learningObjects = (await this.featureService.getCollectionFeatured(
+        this.collectionName
+      ));
       this.loading = false;
     } catch (e) {
       this.loading = false;

--- a/src/app/cube/shared/featured/featured.component.ts
+++ b/src/app/cube/shared/featured/featured.component.ts
@@ -1,5 +1,6 @@
 import { LearningObject } from '@entity';
 import { Component, OnInit, Input } from '@angular/core';
+import { LearningObjectService } from 'app/cube/learning-object.service';
 import { Query, OrderBy, SortType } from '../../../interfaces/query';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -23,8 +24,7 @@ export class FeaturedComponent implements OnInit {
   loading = false;
   collectionName: string;
 
-  constructor(private featureService: FeaturedObjectsService) {
-    this.learningObjects = this.learningObjects.fill(new LearningObject());
+  constructor(private learningObjectService: LearningObjectService, private featureService: FeaturedObjectsService) {    this.learningObjects = this.learningObjects.fill(new LearningObject());
   }
 
   ngOnInit() {
@@ -49,9 +49,9 @@ export class FeaturedComponent implements OnInit {
     this.loading = true;
 
     try {
-      this.learningObjects = (await this.featureService.getCollectionFeatured(
-        this.collectionName
-      ));
+      this.learningObjects = (await this.learningObjectService.getLearningObjects(
+        this.query
+      )).learningObjects;
       this.loading = false;
     } catch (e) {
       this.loading = false;


### PR DESCRIPTION
Sorry I focused only on the NCYTE page that I forgot to make necessary changes for the other collection pages,

**NICE:**
<img width="1424" alt="Screenshot 2024-07-31 at 9 31 57 PM" src="https://github.com/user-attachments/assets/9ed27f3c-2357-4d50-97fa-b35f623a88f6">

**502:**
<img width="833" alt="Screenshot 2024-07-31 at 9 54 57 PM" src="https://github.com/user-attachments/assets/77aef091-7ea3-402b-aa1c-692064b6f2f3">

**General collection pages:**
<img width="1401" alt="Screenshot 2024-07-31 at 9 47 10 PM" src="https://github.com/user-attachments/assets/47ee1b62-e9bf-46f6-aed9-64c788600fab">

NCYTE:
<img width="1356" alt="Screenshot 2024-07-31 at 10 18 32 PM" src="https://github.com/user-attachments/assets/2fa71956-9815-4131-9509-d5dda274f9ff">