### PR TITLE
Bug/sc 32508/clear filters button in learning object builder

### DIFF
--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -303,12 +303,10 @@ export class LearningObjectsComponent
    * @memberof LearningObjectsComponent
    */
   clearStatusAndCollectionFilters() {
-    this.query = {
-      collection: ((this.isCurator && !this.isAdminOrEditor) ? this.query.collection : undefined),
-      topics: undefined,
-      status: undefined,
-      currPage: 1
-    };
+    delete this.query.collection;
+    delete this.query.topics;
+    delete this.query.status;
+    this.query.currPage = 1;
     this.learningObjects = [];
 
     this.getLearningObjects();


### PR DESCRIPTION
Back end is receiving 'undefined' for the following properties when a filter is applied:
- status
- collection
- topics

These properties overstay their welcome after pressing 'Clear filters' and brings in their trashy values, namely `'undefined'` and gives the API a hard time

**Before**
<img width="208" alt="image" src="https://github.com/user-attachments/assets/b6f1e5af-ab49-4c29-816c-61b23754a5a0">

**After**
<img width="159" alt="image" src="https://github.com/user-attachments/assets/feb80393-5120-4a46-8162-9c1ac049bdfb">

