### PR TITLE
Fix client sending learning object id instead of cuid

### DIFF
--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -219,7 +219,7 @@ export class LearningObjectListItemComponent implements OnChanges {
 
   goToUrl(url) {
     if (url === 'builder') {
-      window.open(`/onion/learning-object-builder/${this.learningObject.cuid}`, '_blank');
+      window.open(`/onion/learning-object-builder/${this.learningObject.cuid}`);
     } else if (url === 'contact') {
       window.open(`/users/${this.learningObject.author.username}`);
     } else if (url === 'details') {

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -91,7 +91,6 @@ export class ChangeStatusModalComponent implements OnInit {
   private moveToMapAndTag() {
     // Set a small timeout before navigating so that the change in status applies
     setTimeout(() => {
-      console.log('cuid:',this.learningObject.cuid);
       this.router.navigate(['onion', 'relevancy-builder', this.learningObject.cuid, 'outcomes']);
     }, 1000);
   }

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -91,7 +91,8 @@ export class ChangeStatusModalComponent implements OnInit {
   private moveToMapAndTag() {
     // Set a small timeout before navigating so that the change in status applies
     setTimeout(() => {
-      this.router.navigate(['onion', 'relevancy-builder', this.learningObject.id, 'outcomes']);
+      console.log('cuid:',this.learningObject.cuid);
+      this.router.navigate(['onion', 'relevancy-builder', this.learningObject.cuid, 'outcomes']);
     }, 1000);
   }
 


### PR DESCRIPTION
When editing a learning object's status to released, it goes to map and tag but the function that routes towards map and tag passes learning object ID instead of CUID, so client is confusion