### PR TITLE
fix: [sc-32512] clicking save to library gives no final feedback

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -49,10 +49,10 @@ export class LibraryService {
     }
 
     const query = new URLSearchParams({
-      page: opts.page ? opts.page.toString() : '1',
-      limit: opts.limit ? opts.limit.toString() : '10',
-      cuid: opts.learningObjectCuid ? opts.learningObjectCuid : '',
-      version: opts.version ? opts.version.toString() : '0'
+      page: opts?.page ? opts.page.toString() : '1',
+      limit: opts?.limit ? opts.limit.toString() : '10',
+      cuid: opts?.learningObjectCuid ? opts.learningObjectCuid : '',
+      version: opts?.version ? opts.version.toString() : '0'
     });
 
     return await this.http

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -149,6 +149,10 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
       if (!this.saved) {
         try {
           await this.libraryService.addToLibrary(this.learningObject.cuid, this.learningObject.version);
+
+          this.toaster.success('Successfully Added!', 'Learning Object added to your library');
+          this.saved = true;
+          this.animateSaves();
         } catch (err: any) {
           if (err.status !== 201) {
             this.toaster.error('Error!', 'There was an error adding to your library');
@@ -161,10 +165,6 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
         }
       }
     }
-
-    this.toaster.success('Successfully Added!', 'Learning Object added to your library');
-    this.saved = true;
-    this.animateSaves();
 
     this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid });
     this.addingToLibrary = false;

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -21,6 +21,7 @@ import { Router } from '@angular/router';
 import { LearningObjectService } from '../../../../../app/onion/core/learning-object.service';
 import { NavbarDropdownService } from '../../../../core/client-module/navBarDropdown.service';
 import { BUNDLING_ROUTES } from 'app/core/learning-object-module/bundling/bundling.routes';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'cube-details-action-panel',
@@ -97,7 +98,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
-    await this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid, version: this.learningObject.version});
+    await this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid, version: this.learningObject.version });
     this.saved = this.libraryService.has(this.learningObject);
     this.getCollection();
     this.libraryService.loaded
@@ -142,26 +143,30 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
         this.learningObject.id
       );
     }
-    try {
-      if (!this.userIsAuthor && this.isReleased) {
-        this.saved = this.libraryService.has(this.learningObject);
+    if (!this.userIsAuthor && this.isReleased) {
+      this.saved = this.libraryService.has(this.learningObject);
 
-        if (!this.saved) {
-          try {
-            await this.libraryService.addToLibrary(this.learningObject.cuid, this.learningObject.version);
-          } catch (e) {
-            if (e.status === 201) {
-              this.toaster.success('Successfully Added!', 'Learning Object added to your library');
-              this.saved = true;
-              this.animateSaves();
-            }
+      if (!this.saved) {
+        try {
+          await this.libraryService.addToLibrary(this.learningObject.cuid, this.learningObject.version);
+        } catch (err: any) {
+          if (err.status !== 201) {
+            this.toaster.error('Error!', 'There was an error adding to your library');
+            this.addingToLibrary = false;
+            this.changeDetectorRef.detectChanges();
+            return;
+          } else {
+            // Do nothing if status is 201.
           }
         }
       }
-    } catch (error) {
-      this.toaster.error('Error!', 'There was an error adding to your library');
     }
-    this.libraryService.getLibrary();
+
+    this.toaster.success('Successfully Added!', 'Learning Object added to your library');
+    this.saved = true;
+    this.animateSaves();
+
+    this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid });
     this.addingToLibrary = false;
     this.changeDetectorRef.detectChanges();
   }


### PR DESCRIPTION
This PR fixes issues where no feedback is given to the user when saving a learning object to their library

The fixes in particular involved the removal of a nested try-catch block, which prevented the toaster from opening, and improved error handling to only handle unsuccessful requests.

https://github.com/user-attachments/assets/ed49c222-faaf-40f4-bc13-9e26058778a4

