### PR TITLE
fix: [sc-32525] rejecting lo in proofing status results in unexpected error handling

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -150,14 +150,30 @@ export class ChangeStatusModalComponent implements OnInit {
    */
   async updateStatus() {
     this.serviceInteraction = true;
+    let unableToUpdate = false;
+
     await Promise.all([
       this.builderStore
         .execute(BUILDER_ACTIONS.CHANGE_STATUS, { status: this.selectedStatus, reason: this.reason })
         .catch(error => {
-          this.toaster.error('Error!', 'There was an error trying to update the status of this learning object. Please try again later!');
+          // Set a variable to track update state and throw up a error toaster.
+          unableToUpdate = true;
+          if (error.status === 400) {
+            this.toaster.error('Error!', error.error.message);
+          } else {
+            this.toaster.error('Error!', 'There was an error trying to update the status of this learning object. Please try again later!');
+          }
+          return;
         }),
       this.changelog ? this.createChangelog() : undefined
     ]).then(() => {
+      // If we can't update the status, just close the modal after showing an error.
+      if (unableToUpdate) {
+        this.closeModal();
+        this.serviceInteraction = false;
+        return;
+      }
+
       // If the object released, move to map and tag, else update the valid status moves
       this.learningObject.status = this.selectedStatus as LearningObject.Status;
       if (this.selectedStatus === LearningObject.Status.RELEASED) {

--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -165,7 +165,6 @@ export class ChangeStatusModalComponent implements OnInit {
           }
           return;
         }),
-      this.changelog ? this.createChangelog() : undefined
     ]).then(() => {
       // If we can't update the status, just close the modal after showing an error.
       if (unableToUpdate) {
@@ -173,6 +172,9 @@ export class ChangeStatusModalComponent implements OnInit {
         this.serviceInteraction = false;
         return;
       }
+
+      // Create a changelog.
+      this.changelog ? this.createChangelog() : undefined;
 
       // If the object released, move to map and tag, else update the valid status moves
       this.learningObject.status = this.selectedStatus as LearningObject.Status;


### PR DESCRIPTION
the error message would not show when trying to release a LO that doesn't meet the criteria for release. instead it would show a generic error message that wouldn't exactly tell the user what went wrong.