### PR TITLE
fix: [sc-32563] deleting a learning outcome doesn't seem to work

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -527,17 +527,14 @@ export class BuilderStore {
     this.validator.validateLearningObject(this.learningObject, this.outcomes);
 
     // we make a service call here instead of referring to the saveObject method since the API has a different route for outcome deletion
-    if (!checkIfUUID(outcome.serviceId) && outcome.serviceId) {
+    if (!checkIfUUID(outcome.id) && outcome.id) {
       this.serviceInteraction$.next(true);
       this.learningObjectService
-        .deleteOutcome(
-          (outcome as Partial<LearningOutcome> & { serviceId?: string })
-            .serviceId || id,
-        )
-        .then(() => {
-          this.serviceInteraction$.next(false);
-        })
-        .catch(e => this.handleServiceError(e, BUILDER_ERRORS.DELETE_OUTCOME));
+      .deleteOutcome(outcome.id)
+      .then(() => {
+        this.serviceInteraction$.next(false);
+      })
+      .catch(e => this.handleServiceError(e, BUILDER_ERRORS.DELETE_OUTCOME));
     }
   }
 

--- a/src/entity/learning-outcome/learning-outcome.ts
+++ b/src/entity/learning-outcome/learning-outcome.ts
@@ -159,8 +159,8 @@ export class LearningOutcome {
    * @memberof LearningOutcome
    */
   private copyOutcome(outcome: any): void {
-    if (outcome.id) {
-      this.id = outcome.id;
+    if (outcome._id) {
+      this.id = outcome._id;
     }
     this.bloom = outcome.bloom || this.bloom;
     this.verb = outcome.verb || this.verb;

--- a/src/entity/learning-outcome/learning-outcome.ts
+++ b/src/entity/learning-outcome/learning-outcome.ts
@@ -21,20 +21,6 @@ export class LearningOutcome {
     }
   }
 
-  /**
-   * @property {string} serviceId
-   *      the actual outcome ID stored in the database
-   *      this field is only populated if an outcome is completely created and stored in the database
-   *      used to delete an outcome from the database
-   */
-  private _serviceId!: string;
-  get serviceId(): string {
-    return this._serviceId;
-  }
-  set serviceId(serviceId: string) {
-    this._serviceId = serviceId;
-  }
-
   private _bloom!: string;
   /**
    * @property {string} bloom
@@ -144,7 +130,6 @@ export class LearningOutcome {
     this._verb = (taxonomy.taxons[this.bloom] as { verbs: string[] }).verbs[0];
     this._text = '';
     this._mappings = [];
-    this.serviceId = '';
 
     if (outcome) {
       this.copyOutcome(outcome);


### PR DESCRIPTION
This change removes `serviceId` and sets the `id` field of the outcome to `_id`. This fixes some issues with deleting and patching learning objects, and guidelines.