### PR TITLE
fix: [sc-32604] Filtering in author dashboard doesn't filter

### DIFF
--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -96,12 +96,13 @@ export const LEARNING_OBJECT_ROUTES = {
      * Path to get an author's learning objects
      * @param username username of the author
      * @param filters learning object status filters
+     * @param query searching by text
      * @returns LearningObjects for Author Dashboard
      */
-    GET_MY_DRAFT_LEARNING_OBJECTS(username, filters) {
+    GET_MY_DRAFT_LEARNING_OBJECTS(username, filters, query) {
         return `${environment.apiURL}/users/${encodeURIComponent(
             username,
-        )}/learning-objects?draftsOnly=true&${querystring.stringify(filters)}`;
+        )}/learning-objects?draftsOnly=true&${querystring.stringify(filters, query)}`;
     },
 
     /**

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -95,12 +95,13 @@ export const LEARNING_OBJECT_ROUTES = {
     /**
      * Path to get an author's learning objects
      * @param username username of the author
+     * @param filters learning object status filters
      * @returns LearningObjects for Author Dashboard
      */
-    GET_MY_DRAFT_LEARNING_OBJECTS(username) {
+    GET_MY_DRAFT_LEARNING_OBJECTS(username, filters) {
         return `${environment.apiURL}/users/${encodeURIComponent(
             username,
-        )}/learning-objects?draftsOnly=true`;
+        )}/learning-objects?draftsOnly=true&${querystring.stringify(filters)}`;
     },
 
     /**

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -207,7 +207,7 @@ export class LearningObjectService {
     filters?: any,
     query?: string
   ): Promise<LearningObject[]> {
-    const route = LEARNING_OBJECT_ROUTES.GET_MY_DRAFT_LEARNING_OBJECTS(authorUsername);
+    const route = LEARNING_OBJECT_ROUTES.GET_MY_DRAFT_LEARNING_OBJECTS(authorUsername, filters);
     return this.http
       .get(route, { headers: this.headers, withCredentials: true })
       .pipe(

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -207,7 +207,7 @@ export class LearningObjectService {
     filters?: any,
     query?: string
   ): Promise<LearningObject[]> {
-    const route = LEARNING_OBJECT_ROUTES.GET_MY_DRAFT_LEARNING_OBJECTS(authorUsername, filters);
+    const route = LEARNING_OBJECT_ROUTES.GET_MY_DRAFT_LEARNING_OBJECTS(authorUsername, filters, query);
     return this.http
       .get(route, { headers: this.headers, withCredentials: true })
       .pipe(

--- a/src/app/onion/dashboard/components/list/list.component.html
+++ b/src/app/onion/dashboard/components/list/list.component.html
@@ -1,7 +1,7 @@
 <div class="dashboard-list">
   <div class="dashboard-list__top">
     <p class="dashboard-list__title" tabindex="0">
-      {{ title || 'Learning Objects' }} 
+      {{ title || 'Learning Objects' }}
       <span *ngIf="learningObjects; else noLearningObjects">({{ learningObjects.length }})</span>
     </p>
     <div *ngIf="showOptions; else buttonPlaceholderTemplate" class="dashboard-list__options">
@@ -27,6 +27,14 @@
               <li class="review" (activate)="toggleFilter('review')">
                 <div *ngIf="filters.get('review')" class="indicator"></div>
                 <i class="far fa-sync"></i>Under Review
+              </li>
+              <li class="accepted_major" (activate)="toggleFilter('accepted_major')">
+                <div *ngIf="filters.get('accepted_major')" class="indicator"></div>
+                <i class="far fa-check"></i>Major Changes Requested
+              </li>
+              <li class="accepted_minor" (activate)="toggleFilter('accepted_minor')">
+                <div *ngIf="filters.get('accepted_minor')" class="indicator"></div>
+                <i class="far fa-check-double"></i>Minor Changes Requested
               </li>
               <li class="proofing" (activate)="toggleFilter('proofing')">
                 <div *ngIf="filters.get('proofing')" class="indicator"></div>


### PR DESCRIPTION
This fixes an issue where filters aren't passed to the backend and filtering does nothing on the client.

See https://github.com/Cyber4All/clark-service/pull/194 for service changes


https://github.com/user-attachments/assets/99a31a71-814a-4be2-9946-2fa9bbed54c1

