### PR TITLE
fix: [sc-32554] do not nest the object when sending outcome

### DIFF
--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -266,7 +266,7 @@ export class LearningObjectService {
     return this.http
       .patch(
         OUTCOME_ROUTES.UPDATE_OUTCOME(outcomeId),
-        { outcome },
+        { ...outcome },
         { headers: this.headers, withCredentials: true },
       )
       .pipe(


### PR DESCRIPTION
When updating a learning outcome, the client would send a nested object instead of a single object with all the fields. This PR changes the logic to send all the fields which is what the service will expect.

Story details: https://app.shortcut.com/clarkcan/story/32554


https://github.com/user-attachments/assets/ddd6a295-d5ed-4463-91eb-eeabe7d9a039