### PR TITLE
fix: [sc-32622] Updating the description of a folder fails

### DIFF
--- a/src/app/core/learning-object-module/file/file.routes.ts
+++ b/src/app/core/learning-object-module/file/file.routes.ts
@@ -12,9 +12,7 @@ export const FILE_ROUTES = {
    * @param fileId - The id of the file to update
    */
   UPDATE_FILE(username: string, learningObjectId: string, fileId: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(
-      username,
-    )}/learning-objects/${encodeURIComponent(
+    return `${environment.apiURL}/learning-objects/${encodeURIComponent(
       learningObjectId,
     )}/materials/files/${encodeURIComponent(fileId)}`;
   },
@@ -31,9 +29,7 @@ export const FILE_ROUTES = {
     learningObjectId: string;
     fileId: string;
   }) {
-    return `${environment.apiURL}/users/${encodeURIComponent(
-      params.username,
-    )}/learning-objects/${encodeURIComponent(
+    return `${environment.apiURL}/learning-objects/${encodeURIComponent(
       params.learningObjectId,
     )}/materials/files/${encodeURIComponent(params.fileId)}`;
   },

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -455,7 +455,6 @@ export class LearningObjectService {
           { headers: this.headers, withCredentials: true, responseType: 'text' }
         )
         .pipe(
-
           catchError(this.handleError)
         )
         .toPromise();
@@ -653,7 +652,7 @@ export class LearningObjectService {
       .patch(
         route,
         { description },
-        { withCredentials: true, responseType: 'text' }
+        { headers: this.headers, withCredentials: true, responseType: 'text' }
       )
       .pipe(
 

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -413,7 +413,6 @@ export class BuilderStore {
       case BUILDER_ACTIONS.UPDATE_FOLDER_DESCRIPTION:
         return await this.updateFolderDescription({
           path: data.path,
-          index: data.index,
           description: data.description
         });
       case BUILDER_ACTIONS.DELETE_FILES:
@@ -807,20 +806,25 @@ export class BuilderStore {
    * @memberof BuilderStore
    */
   private updateFolderDescription(params: {
-    path?: string;
-    index?: number;
+    path: string;
     description: string;
   }): void {
-    if (params.index !== undefined) {
-      this.learningObject.materials.folderDescriptions[
-        params.index
-      ].description = params.description;
+    // If the folder path already exists, update the description
+    // Otherwise, add a new folder description
+    const index = this.learningObject.materials.folderDescriptions.findIndex(
+      folder => folder.path === params.path
+    );
+    if (index !== -1) {
+      this.learningObject.materials.folderDescriptions[index].description =
+        params.description;
     } else {
       this.learningObject.materials.folderDescriptions.push({
         path: params.path,
         description: params.description
       });
     }
+
+    // Update the learning object
     this.learningObjectEvent.next(this.learningObject);
     this.saveObject({
       materials: { folderDescriptions: this.learningObject.materials

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -800,50 +800,25 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
    */
   async handleEdit(file: LearningObject.Material.File | any): Promise<void> {
     try {
+      // If the file is not a folder, update the file description
       if (!file.isFolder) {
         this.fileDescriptionUpdated.emit({
           id: file.id,
           description: file.description,
         });
-      } else {
-        const index = await this.findFolder(file.path);
-        if (index > -1) {
-          this.folderDescriptionUpdated.emit({
-            index,
-            description: file.description,
-          });
-        } else {
-          this.folderDescriptionUpdated.emit({
-            path: file.path,
-            description: file.description,
-          });
-        }
+
+        // Early return to prevent updating folder description
+        return;
       }
+
+      // Update the folder description
+      this.folderDescriptionUpdated.emit({
+        path: file.path,
+        description: file.description,
+      });
     } catch (e) {
       console.error(e);
     }
-  }
-
-  /**
-   * Finds index of folder
-   *
-   * @private
-   * @param {string} path
-   * @returns {number}
-   * @memberof UploadComponent
-   */
-  private async findFolder(path: string): Promise<number> {
-    let index = -1;
-    const object = await this.learningObject$.pipe(take(1)).toPromise();
-    const folders = object.materials.folderDescriptions;
-    for (let i = 0; i < folders.length; i++) {
-      const folderPath = folders[i].path;
-      if (folderPath === path) {
-        index = i;
-        break;
-      }
-    }
-    return index;
   }
 
   ngOnDestroy() {

--- a/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
+++ b/src/app/onion/learning-object-builder/pages/materials-page/materials-page.component.ts
@@ -135,8 +135,7 @@ export class MaterialsPageComponent implements OnInit, OnDestroy {
   }
 
   async handleFolderDescriptionUpdate(folderMeta: {
-    path?: string;
-    index?: number;
+    path: string;
     description: string;
   }) {
     try {


### PR DESCRIPTION
Story details: https://app.shortcut.com/clarkcan/story/32622

Changes how the payload for updating folder descriptions is sent and removes deprecated code.