### PR TITLE
fix: [sc-32631] 400 Bad Request when releasing a proofing learning object

### DIFF
--- a/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
+++ b/src/app/onion/learning-object-builder/components/editor-action-panel/change-status-modal/change-status-modal.component.ts
@@ -179,7 +179,7 @@ export class ChangeStatusModalComponent implements OnInit {
       // If the object released, move to map and tag, else update the valid status moves
       this.learningObject.status = this.selectedStatus as LearningObject.Status;
       if (this.selectedStatus === LearningObject.Status.RELEASED) {
-        this.moveToMapAndTag();
+        this.moveToAdminDashboard();
       } else if (this.learningObject.status === LearningObject.Status.REJECTED) {
         this.moveToAdminDashboard();
       } else {


### PR DESCRIPTION
This fix addresses an issue where the user cannot map or tag a LO after it's been released.

When releasing a learning object we will navigate to the admin dashboard instead of the map and tag page. Learning objects should be mapped and tagged prior to release, not after.

https://github.com/user-attachments/assets/0b662e59-27ba-44f8-a388-939fd586d859


Story details: https://app.shortcut.com/clarkcan/story/32631