### PR TITLE
fix: [sc-32644] Curator - Filtering in curator dashboard always returns all released learning objects

### DIFF
--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -8,7 +8,7 @@
         >
         <span *ngIf="!startNextCheck">Filter By Relevancy Check Dates</span>
         </button>
-        <button 
+        <button
           #toggleTopicMenuElement
           class="button neutral filters-button"
           (activate)="toggleTopicMenu(true)"
@@ -95,10 +95,10 @@
         >
           <div #contextMenu id="contextMenu" class="filter-status__container">
             <ul>
-              <li 
+              <li
                 *ngFor="let status of statuses"
                 [ngClass]="status"
-                (activate)="toggleStatusFilter(status)">
+                (activate)="toggleStatusFilter([status])">
                   <div *ngIf="filters.has(status)" class="indicator"></div>
                   <i [ngClass]="getStatusIcon(status)"></i> {{ status.replace('_', ' ') | titlecase }}
               </li>

--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -30,7 +30,7 @@
               <li
                 *ngFor="let topic of topics"
                 [className]="topic.name"
-                (activate)="toggleTopicFilter(topic)"
+                (activate)="toggleTopicFilter([topic])"
               >
                 <div
                   *ngIf="filterTopics.has(topic.name)"

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -78,28 +78,42 @@ export class FilterSearchComponent implements OnInit {
     //check for params in the query and add them to the filter dropdown bars
     const qParams = this.route.parent.snapshot.queryParams;
 
+    /**
+     * TODO: refactor this to send a complete search query
+     * at the first request instead of sending a request
+     * every time we emit an event on the toggle filter functions.
+     *
+     * this COULD be a cause of the client sending bad data back
+     * to the user, so just be aware.
+     */
+
     //if there are topics in the query, toggle them in the filter dropdown
     if (qParams.topics && qParams.topics.length > 0) {
       const topics = [];
         for (const topic of qParams.topics) {
           topics.push({ name: '', _id: topic });
         }
+
         this.toggleTopicFilter(topics[0]);
     }
 
-    //if there are statuses in the query add them too the filter dropdowns
+    // if there are statuses in the query add them to the filter dropdowns
     if (qParams.status && qParams.status.length > 0) {
-        const statuses = [];
+      const statuses = [];
+
+      if (Array.isArray(qParams.status) === false) {
+        statuses.push(qParams.status);
+        this.toggleStatusFilter(statuses);
+
+      } else {
         for (const status of qParams.status) {
           statuses.push(status);
         }
-
-        console.log(statuses);
-
         this.toggleStatusFilter(statuses);
+      }
     }
-    //if there is a collection selected in the query, toggle it
-    //there will only ever be a single collection selected at a time
+
+    // Set the collection if it exists, otherwise default back to the params.
     if (qParams.collection) {
       this.toggleCollectionFilter(qParams.collection);
     } else {

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -90,11 +90,15 @@ export class FilterSearchComponent implements OnInit {
     //if there are topics in the query, toggle them in the filter dropdown
     if (qParams.topics && qParams.topics.length > 0) {
       const topics = [];
+      if (Array.isArray(qParams.topics)) {
         for (const topic of qParams.topics) {
           topics.push({ name: '', _id: topic });
         }
 
-        this.toggleTopicFilter(topics[0]);
+        this.toggleTopicFilter(topics);
+      } else {
+        this.toggleTopicFilter([{ name: '', _id: qParams.topics }]);
+      }
     }
 
     // if there are statuses in the query add them to the filter dropdowns
@@ -299,16 +303,19 @@ export class FilterSearchComponent implements OnInit {
     }
   }
 
-  toggleTopicFilter(filter: { name?: string, _id: string }) {
-    if (filter.name.toLowerCase() === 'all') {
-      this.clearTopicFilters();
-      this.toggleTopicMenu(undefined);
-      return;
-    }
-    if (this.filterTopics.has(filter._id)) {
-      this.filterTopics.delete(filter._id);
-    } else {
-      this.filterTopics.add(filter._id);
+  toggleTopicFilter(filters?: { name?: string, _id: string }[]) {
+    for (const filter of filters) {
+      if (filter.name.toLowerCase() === 'all') {
+        this.clearTopicFilters();
+        this.toggleTopicMenu(undefined);
+        return;
+      }
+
+      if (this.filterTopics.has(filter._id)) {
+        this.filterTopics.delete(filter._id);
+      } else {
+        this.filterTopics.add(filter._id);
+      }
     }
     this.topicFilter.emit(Array.from(this.filterTopics));
   }

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -5,23 +5,26 @@ import {
   OnInit,
   Input,
   Output,
-  ViewChild
+  ViewChild,
 } from '@angular/core';
 
 
-import { CollectionService, Collection } from 'app/core/collection-module/collections.service';
+import {
+  CollectionService,
+  Collection,
+} from 'app/core/collection-module/collections.service';
 import { AuthService } from 'app/core/auth-module/auth.service';
 import { Subject } from 'rxjs';
 import { LearningObject } from '@entity';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { Topic } from '@entity';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
 import { TopicsService } from 'app/core/learning-object-module/topics/topics.service';
 
 @Component({
   selector: 'clark-admin-filter-search',
   templateUrl: './filter-search.component.html',
-  styleUrls: ['./filter-search.component.scss']
+  styleUrls: ['./filter-search.component.scss'],
 })
 export class FilterSearchComponent implements OnInit {
   collections: Collection[] = [];
@@ -41,7 +44,7 @@ export class FilterSearchComponent implements OnInit {
   @Output() statusFilter = new EventEmitter<any[]>();
   @Output() collectionFilter = new EventEmitter<string>();
   @Output() topicFilter = new EventEmitter<string[]>();
-  @Output() relevancyCheck = new EventEmitter<{ start: string, end: string }>();
+  @Output() relevancyCheck = new EventEmitter<{ start: string; end: string }>();
   @Output() clearAll = new EventEmitter<void>();
   @ViewChild('searchInput') searchInput: ElementRef;
 
@@ -53,14 +56,13 @@ export class FilterSearchComponent implements OnInit {
   relevancyEnd: Date;
   relevancyMenuDown: boolean;
 
-
   constructor(
     private collectionService: CollectionService,
     private topicsService: TopicsService,
     private authService: AuthService,
     private toaster: ToastrOvenService,
-    private route: ActivatedRoute
-  ) { }
+    private route: ActivatedRoute,
+  ) {}
 
   async ngOnInit() {
     await this.getCollections();
@@ -71,7 +73,7 @@ export class FilterSearchComponent implements OnInit {
     this.statuses.splice(0, 0);
 
     this.statuses = this.statuses.filter(
-      s => !['rejected', 'unreleased'].includes(s.toLowerCase())
+      (s) => !['rejected', 'unreleased'].includes(s.toLowerCase()),
     );
     this.relevancyStart = new Date();
 
@@ -131,7 +133,7 @@ export class FilterSearchComponent implements OnInit {
   private async getCollections(): Promise<void> {
     await this.collectionService
       .getCollections()
-      .then(collections => {
+      .then((collections) => {
         this.collections = Array.from(collections);
         this.collections.push({ abvName: 'all', name: 'All', hasLogo: false });
 
@@ -145,18 +147,19 @@ export class FilterSearchComponent implements OnInit {
           return 0;
         });
       })
-      .catch(error => {
+      .catch((error) => {
         this.toaster.error('Error!', error);
       });
   }
 
   private getTopics(): void {
-    this.topicsService
-      .getTopics()
-      .then(topics => {
-        this.topics = topics;
-        this.topics = [].concat([{ _id: 'all', name: 'All' }], Array.from(topics));
-      });
+    this.topicsService.getTopics().then((topics) => {
+      this.topics = topics;
+      this.topics = [].concat(
+        [{ _id: 'all', name: 'All' }],
+        Array.from(topics),
+      );
+    });
   }
 
   /**
@@ -177,7 +180,7 @@ export class FilterSearchComponent implements OnInit {
    */
   setSelectedCollection(abvName: string) {
     this._selectedCollection = this.collections.filter(
-      x => x.abvName === abvName
+      (x) => x.abvName === abvName,
     )[0];
   }
 
@@ -276,7 +279,6 @@ export class FilterSearchComponent implements OnInit {
       } else {
         this.filters.delete(filter);
       }
-
     }
 
     this.statusFilter.emit(Array.from(this.filters));
@@ -303,7 +305,7 @@ export class FilterSearchComponent implements OnInit {
     }
   }
 
-  toggleTopicFilter(filters?: { name?: string, _id: string }[]) {
+  toggleTopicFilter(filters?: { name?: string; _id: string }[]) {
     for (const filter of filters) {
       if (filter.name.toLowerCase() === 'all') {
         this.clearTopicFilters();
@@ -401,9 +403,11 @@ export class FilterSearchComponent implements OnInit {
    */
   isToday(date: Date): boolean {
     const today = new Date();
-    return date.getDate() === today.getDate() &&
+    return (
+      date.getDate() === today.getDate() &&
       date.getMonth() === today.getMonth() &&
-      date.getFullYear() === today.getFullYear();
+      date.getFullYear() === today.getFullYear()
+    );
   }
 
   /**

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -77,34 +77,33 @@ export class FilterSearchComponent implements OnInit {
 
     //check for params in the query and add them to the filter dropdown bars
     const qParams = this.route.parent.snapshot.queryParams;
+
     //if there are topics in the query, toggle them in the filter dropdown
-    if (qParams.topics) {
-      //more than one topic
-      if (Array.isArray(qParams.topics)) {
+    if (qParams.topics && qParams.topics.length > 0) {
+      const topics = [];
         for (const topic of qParams.topics) {
-          this.toggleTopicFilter({ name: '', _id: topic });
+          topics.push({ name: '', _id: topic });
         }
-        // one topic
-      } else {
-        this.toggleTopicFilter({ name: '', _id: qParams.topics });
-      }
+        this.toggleTopicFilter(topics[0]);
     }
+
     //if there are statuses in the query add them too the filter dropdowns
-    if (qParams.status) {
-      //multiple statuses in query
-      if (Array.isArray(qParams.status)) {
+    if (qParams.status && qParams.status.length > 0) {
+        const statuses = [];
         for (const status of qParams.status) {
-          this.toggleStatusFilter(status);
+          statuses.push(status);
         }
-        //one status in query
-      } else {
-        this.toggleStatusFilter(qParams.status);
-      }
+
+        console.log(statuses);
+
+        this.toggleStatusFilter(statuses);
     }
     //if there is a collection selected in the query, toggle it
     //there will only ever be a single collection selected at a time
     if (qParams.collection) {
       this.toggleCollectionFilter(qParams.collection);
+    } else {
+      this.toggleCollectionFilter(this.route.parent.snapshot.params.collection);
     }
   }
 
@@ -246,18 +245,22 @@ export class FilterSearchComponent implements OnInit {
    *
    * @param filter {string} the filter to be toggled
    */
-  toggleStatusFilter(filter: string) {
-    if (filter.toLowerCase() === 'all') {
-      this.clearStatusFilters();
-      this.toggleFilterMenu(undefined);
-      return;
+  toggleStatusFilter(filters: string[]) {
+    for (const filter of filters) {
+      if (filter.toLowerCase() === 'all') {
+        this.clearStatusFilters();
+        this.toggleFilterMenu(undefined);
+        return;
+      }
+
+      if (!this.filters.has(filter)) {
+        this.filters.add(filter);
+      } else {
+        this.filters.delete(filter);
+      }
+
     }
 
-    if (this.filters.has(filter)) {
-      this.filters.delete(filter);
-    } else {
-      this.filters.add(filter);
-    }
     this.statusFilter.emit(Array.from(this.filters));
   }
 

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -8,7 +8,6 @@ import {
   ViewChild,
 } from '@angular/core';
 
-
 import {
   CollectionService,
   Collection,
@@ -78,7 +77,7 @@ export class FilterSearchComponent implements OnInit {
     this.relevancyStart = new Date();
 
     //check for params in the query and add them to the filter dropdown bars
-    const qParams = this.route.parent.snapshot.queryParams;
+    const qParams = this.route.parent.snapshot.queryParamMap;
 
     /**
      * TODO: refactor this to send a complete search query
@@ -89,39 +88,27 @@ export class FilterSearchComponent implements OnInit {
      * to the user, so just be aware.
      */
 
-    //if there are topics in the query, toggle them in the filter dropdown
-    if (qParams.topics && qParams.topics.length > 0) {
-      const topics = [];
-      if (Array.isArray(qParams.topics)) {
-        for (const topic of qParams.topics) {
-          topics.push({ name: '', _id: topic });
-        }
+    const queryTopics = qParams.getAll('topics');
+    const queryStatuses = qParams.getAll('statuses');
 
-        this.toggleTopicFilter(topics);
-      } else {
-        this.toggleTopicFilter([{ name: '', _id: qParams.topics }]);
+    //if there are topics in the query, toggle them in the filter dropdown
+    if (queryTopics) {
+      const topics = [];
+      for (const topic of queryTopics) {
+        topics.push({ name: '', _id: topic });
       }
+
+      this.toggleTopicFilter(topics);
     }
 
     // if there are statuses in the query add them to the filter dropdowns
-    if (qParams.status && qParams.status.length > 0) {
-      const statuses = [];
-
-      if (Array.isArray(qParams.status) === false) {
-        statuses.push(qParams.status);
-        this.toggleStatusFilter(statuses);
-
-      } else {
-        for (const status of qParams.status) {
-          statuses.push(status);
-        }
-        this.toggleStatusFilter(statuses);
-      }
+    if (queryStatuses) {
+      this.toggleStatusFilter(queryStatuses);
     }
 
     // Set the collection if it exists, otherwise default back to the params.
-    if (qParams.collection) {
-      this.toggleCollectionFilter(qParams.collection);
+    if (qParams.get('collection')) {
+      this.toggleCollectionFilter(qParams.get('collection'));
     } else {
       this.toggleCollectionFilter(this.route.parent.snapshot.params.collection);
     }

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -80,7 +80,7 @@ export class FilterSearchComponent implements OnInit {
     const qParams = this.route.parent.snapshot.queryParamMap;
 
     /**
-     * TODO: refactor this to send a complete search query
+     * TODO: refactor this to send a complete search query, see sc-32835
      * at the first request instead of sending a request
      * every time we emit an event on the toggle filter functions.
      *

--- a/src/app/cube/details/components/materials/materials.component.html
+++ b/src/app/cube/details/components/materials/materials.component.html
@@ -10,13 +10,13 @@
   <!-- </clark-carousel> -->
 
   <div>
-    <div *ngIf="materials.files.length === 0 && materials.notes.length === 0 && materials.urls.length === 0"
+    <div *ngIf="((!materials.files || materials.files.length === 0) && materials.notes.length === 0 && materials.urls.length === 0)"
       class="materials__review-materials__empty-banner">
       <i class="fas fa-exclamation icon" style="font-size: 1.2rem;"></i>
       <p>This Learning Object has no materials attached.</p>
     </div>
 
-    <div class='materials__file-browser-container' *ngIf="materials.files.length > 0">
+    <div class='materials__file-browser-container' *ngIf="materials.files && materials.files.length > 0">
       <clark-file-browser *ngIf='materials?.files.length || materials.folderDescriptions?.length' [files$]="files$"
         [folderMeta$]="folderMeta$"></clark-file-browser>
       <p tab-index='0' class='materials__file-browser-container__empty-message'


### PR DESCRIPTION
The admin dashboard would apply filters to its query three times and the incorrect data would get returned. This PR fixes that issue, and the filter data should only be applied once to the query on initial page load.

See accompanying service PR: https://github.com/Cyber4All/clark-service/pull/201
Story details: https://app.shortcut.com/clarkcan/story/32644

https://github.com/user-attachments/assets/1f2a3bae-75e8-4e99-8c3a-4fe3a561e897
