### PR TITLE
fix: [sc-32712] Unable to add child as an author admin

### DIFF
--- a/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
@@ -52,7 +52,8 @@ export class AddChildComponent implements OnInit, OnDestroy {
    */
   async getLearningObjects(filters?: any, query?: string): Promise<LearningObject[]> {
     this.loading = true;
-    const draftObjects = await this.learningObjectService.getDraftLearningObjects(this.child.author.username, { ...filters, text: query })
+    const draftObjects = await this.learningObjectService.getDraftLearningObjects(this.child.author.username || this.auth.username,
+      { ...filters, text: query })
       .then((children: LearningObject[]) => {
         const indx = this.lengths.indexOf(this.child.length);
         const childrenLengths = this.lengths.slice(0, indx);
@@ -61,7 +62,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
       });
 
     const releasedObjects = await this.learningObjectService
-      .getLearningObjects(this.child.author.username, {...filters, text: query, childId: this.child.id } )
+      .getLearningObjects(this.child.author.username || this.auth.username, {...filters, text: query, childId: this.child.id } )
       .then((children: LearningObject[]) => {
         const indx = this.lengths.indexOf(this.child.length);
         const childrenLengths = this.lengths.slice(0, indx);


### PR DESCRIPTION
### I wasn't able to reproduce this bug, this change might or might not fix anything.

When trying to add a new child to a *new* learning object, the search will break because it couldn't find the username of the author.