### PR TITLE
add fix to preview url

### DIFF
--- a/src/app/core/learning-object-module/file/file.service.ts
+++ b/src/app/core/learning-object-module/file/file.service.ts
@@ -14,7 +14,7 @@ export class FileService {
   constructor(
     private http: HttpClient,
     private cookies: CookieService
-  ) { 
+  ) {
     const token = this.cookies.get('presence');
     if (token) {
       this.headers = new HttpHeaders().append('Authorization',`Bearer ${token}`);
@@ -39,7 +39,7 @@ export class FileService {
   /**
    * Makes a request to the previewUrl with authorization headers to get the file
    * and returns the blob url of the file that can be opened in a new tab
-   * 
+   *
    * @param url the previewUrl of the material on the learning object
    * @returns the blob url of the file
    */

--- a/src/app/core/learning-object-module/file/file.service.ts
+++ b/src/app/core/learning-object-module/file/file.service.ts
@@ -3,6 +3,7 @@ import { FILE_ROUTES } from './file.routes';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { catchError } from 'rxjs/operators';
 import { throwError } from 'rxjs';
+import { CookieService } from 'ngx-cookie-service';
 
 @Injectable({
   providedIn: 'root'
@@ -10,10 +11,15 @@ import { throwError } from 'rxjs';
 export class FileService {
   private headers = new HttpHeaders();
 
-
   constructor(
     private http: HttpClient,
-  ) { }
+    private cookies: CookieService
+  ) { 
+    const token = this.cookies.get('presence');
+    if (token) {
+      this.headers = new HttpHeaders().append('Authorization',`Bearer ${token}`);
+    }
+  }
 
   // TODO: Upload should be moved from the file mnager to this file
 
@@ -28,6 +34,23 @@ export class FileService {
       })
       .pipe(catchError(this.handleError))
       .toPromise();
+  }
+
+  /**
+   * Makes a request to the previewUrl with authorization headers to get the file
+   * and returns the blob url of the file that can be opened in a new tab
+   * 
+   * @param url the previewUrl of the material on the learning object
+   * @returns the blob url of the file
+   */
+  async previewLearningObjectFile(url: string): Promise<string> {
+    return fetch(url, {
+        headers: {
+          Authorization: this.headers.get('Authorization')
+        }
+      })
+      .then((response) => response.blob())
+      .then((blob) => window.URL.createObjectURL(blob));
   }
 
   private handleError(error: HttpErrorResponse) {

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -233,15 +233,4 @@ export const LEGACY_PUBLIC_LEARNING_OBJECT_ROUTES = {
 
         return uri;
     },
-    DOWNLOAD_FILE(params: {
-        username: string;
-        loId: string;
-        fileId: string;
-        open?: boolean;
-    }) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            params.username,
-        )}/learning-objects/${params.loId}/files/${params.fileId}/download${params.open ? '?open=true' : ''
-            }`;
-    },
 };

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -118,9 +118,11 @@ export class FileListViewComponent implements OnInit, OnDestroy {
     if (url) {
       this.fileService.previewLearningObjectFile(url)
         .then((previewUrl) => {
-          window.open(previewUrl, "_blank");
+          window.open(previewUrl, '_blank');
         })
-        .catch((err) => { console.error(err); });
+        .catch((err) => {
+ console.error(err);
+});
     } else {
       this.file = file;
       this.preview = false;

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -13,6 +13,7 @@ import { FormControl } from '@angular/forms';
 import { DescriptionUpdate } from '../file-browser/file-browser.component';
 import { LearningObject } from '@entity';
 import { AuthService } from 'app/core/auth-module/auth.service';
+import { FileService } from 'app/core/learning-object-module/file/file.service';
 
 @Component({
   selector: 'clark-file-list-view',
@@ -57,7 +58,10 @@ export class FileListViewComponent implements OnInit, OnDestroy {
     Deselected items will be accessible through a download link in the PDF.`;
   accessGroups: string[];
 
-  constructor(private auth: AuthService) {}
+  constructor(
+    private auth: AuthService,
+    private fileService: FileService
+  ) {}
 
   ngOnInit(): void {
     this.subToDirChange();
@@ -112,8 +116,11 @@ export class FileListViewComponent implements OnInit, OnDestroy {
   openFile(file: LearningObject.Material.File): void {
     const url = this.auth.isLoggedIn.value ? file.previewUrl : '';
     if (url) {
-      window.open(url, '_blank');
-      this.preview = true;
+      this.fileService.previewLearningObjectFile(url)
+        .then((previewUrl) => {
+          window.open(previewUrl, "_blank");
+        })
+        .catch((err) => { console.error(err); });
     } else {
       this.file = file;
       this.preview = false;


### PR DESCRIPTION
When previewing a URL no headers were being attached causing a 404. This PR moves the previewFile request to the file service and gets the bearer token from the cookie to add to the request prior to casting the response to a blob in a new url.

There are backend fixes as well in clark-service.