### PR TITLE
Feature/sc 32777/revisions module route updates for clark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "sass": "^1.46.0",
         "ts-jest": "^27.1.3",
         "tslib": "^1.10.0",
-        "typescript": "4.6.2"
+        "typescript": "^4.6.4"
       },
       "engines": {
         "node": ">=v16.13.2 <17",
@@ -255,6 +255,23 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/@ngtools/webpack": {
+      "version": "13.3.11",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-13.3.11.tgz",
+      "integrity": "sha512-gB33hTbc/RJmHyIgSUYj8ErPazhYYm7yfapOnvwHdYhCjrj1TKkR1ierOlhJtpfBYUQg6FChdl2YpyIQNPjWMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler-cli": "^13.0.0",
+        "typescript": ">=4.4.3 <4.7",
+        "webpack": "^5.30.0"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/@types/estree": {
@@ -3925,22 +3942,6 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
-      }
-    },
-    "node_modules/@ngtools/webpack": {
-      "version": "13.3.11",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-13.3.11.tgz",
-      "integrity": "sha512-gB33hTbc/RJmHyIgSUYj8ErPazhYYm7yfapOnvwHdYhCjrj1TKkR1ierOlhJtpfBYUQg6FChdl2YpyIQNPjWMA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "@angular/compiler-cli": "^13.0.0",
-        "typescript": ">=4.4.3 <4.7",
-        "webpack": "^5.30.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -19005,9 +19006,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "sass": "^1.46.0",
     "ts-jest": "^27.1.3",
     "tslib": "^1.10.0",
-    "typescript": "4.6.2"
+    "typescript": "^4.6.4"
   },
   "prettier": {
     "singleQuote": true

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -16,7 +16,6 @@ import { environment } from '@env/environment';
 import { HttpHeaders, HttpClient } from '@angular/common/http';
 import { take, catchError } from 'rxjs/operators';
 import { of } from 'rxjs/internal/observable/of';
-import { UnreleaseService } from 'app/admin/core/unrelease.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { Router } from '@angular/router';
 import { HierarchyService } from '../../../core/learning-object-module/hierarchy/hierarchy.service';
@@ -25,6 +24,7 @@ import {
   LearningObjectService as RefactoredLearningObjectService
 } from 'app/core/learning-object-module/learning-object/learning-object.service';
 import { LEARNING_OBJECT_ROUTES } from 'app/core/learning-object-module/learning-object/learning-object.routes';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -72,14 +72,14 @@ export class LearningObjectListItemComponent implements OnChanges {
   private headers = new HttpHeaders();
   constructor(
     private auth: AuthService,
-    private unreleaseService: UnreleaseService,
     private statuses: StatusDescriptions,
     private cd: ChangeDetectorRef,
     private http: HttpClient,
     private toaster: ToastrOvenService,
     private hierarchyService: HierarchyService,
     private loService: LearningObjectService,
-    private refactoredLearningObjectService: RefactoredLearningObjectService
+    private refactoredLearningObjectService: RefactoredLearningObjectService,
+    private revisionsService: RevisionsService,
   ) { }
 
   async ngOnChanges(changes: SimpleChanges) {
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   deleteRevision() {
-    this.unreleaseService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
+    this.revisionsService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
       .then(() => {
         this.toaster.success('Success', 'Learning object unreleased revision deleted successfully');
       }).catch(() => {

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   deleteRevision() {
-    this.revisionsService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
+    this.revisionsService.deleteRevision(this.learningObject.cuid, this.learningObject.version + 1)
       .then(() => {
         this.toaster.success('Success', 'Learning object unreleased revision deleted successfully');
       }).catch(() => {

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -10,25 +10,6 @@ import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/rev
 })
 export class UnreleaseService {
   constructor(private http: HttpClient) {}
-
-  /**
-   * Deletes a revision of a learning object. This is designed to allow an editor to create a new
-   * revision when it is necessary for the editorial process to continue.
-   *
-   * @param username username of the author
-   * @param cuid cuid of the learning object
-   * @returns
-   */
-  deleteRevision(username: string, cuid: string, version: number) {
-    return this.http
-      .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
-        withCredentials: true,
-        responseType: 'text',
-      })
-      .pipe(catchError(this.handleError))
-      .toPromise();
-  }
-
   /**
    * Generic error-handling function for errors through from the HttpClient module
    *

--- a/src/app/core/learning-object-module/revisions/revisions.service.ts
+++ b/src/app/core/learning-object-module/revisions/revisions.service.ts
@@ -1,9 +1,54 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { REVISION_ROUTES } from './revisions.routes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RevisionsService {
 
-  constructor() { }
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Creates a Revision of an existing learning object
+   *
+   * @param cuid the CUID of the learning object to create a revision of
+   */
+  async createRevision(cuid: string): Promise<any> {
+    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
+    const response = await this.http
+      .post(route, {}, { withCredentials: true })
+      .pipe(catchError(this.handleError))
+      .toPromise();
+    return response;
+  }
+
+  /**
+   * Deletes a revision of a learning object. This is designed to allow an editor to create a new
+   * revision when it is necessary for the editorial process to continue.
+   *
+   * @param cuid cuid of the learning object
+   * @returns
+   */
+  deleteRevision(cuid: string, version: number) {
+    return this.http
+      .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
+        withCredentials: true,
+        responseType: 'text',
+      })
+      .pipe(catchError(this.handleError))
+      .toPromise();
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      // Client-side or network returned error
+      return throwError(error.error.message);
+    } else {
+      // API returned error
+      return throwError(error);
+    }
+  }
 }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -4,6 +4,7 @@ import { LearningObject } from '@entity';
 import { LearningObjectService } from 'app/cube/learning-object.service';
 import { LearningObjectService as LOUri } from 'app/core/learning-object-module/learning-object/learning-object.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 /**
  * EditorialActionPadComponent coordinates all editor functionality inside of the
@@ -30,6 +31,7 @@ export class EditorialActionPadComponent implements OnInit {
     private learningObjectService: LearningObjectService,
     private learningObjectServiceUri: LOUri,
     private toaster: ToastrOvenService,
+    private revisionsService: RevisionsService,
   ) { }
 
   async ngOnInit() {
@@ -82,7 +84,7 @@ export class EditorialActionPadComponent implements OnInit {
   async createRevision() {
     this.closeRevisionModal();
     this.toaster.success('One Moment Please', 'Your revision is being created.');
-    await this.learningObjectService
+    await this.revisionsService
       .createRevision(this.learningObject.cuid).then(async (revisionUri: any) => {
         this.revisedLearningObject = (await this.learningObjectServiceUri.fetchUri(revisionUri.revisionUri).toPromise())[0];
         this.router.navigate([`/onion/learning-object-builder/${this.revisedLearningObject.cuid}`]);

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -84,8 +84,8 @@ export class EditorialActionPadComponent implements OnInit {
   async createRevision() {
     this.closeRevisionModal();
     this.toaster.success('One Moment Please', 'Your revision is being created.');
-    // TODO: Update the createRevision's response to be a revised learning object rather than 
-    // using a GET request to make a request that would effectively do the same thing. 
+    // TODO: Update the createRevision's response to be a revised learning object rather than
+    // using a GET request to make a request that would effectively do the same thing.
     // This will cut down on requests and simplify abstraction.
     await this.revisionsService
       .createRevision(this.learningObject.cuid).then(async (revisionUri: any) => {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -84,7 +84,9 @@ export class EditorialActionPadComponent implements OnInit {
   async createRevision() {
     this.closeRevisionModal();
     this.toaster.success('One Moment Please', 'Your revision is being created.');
-    //TODO: Update createRevision to return the revised learning object than the URI that we use to make a GET request directly after.
+    // TODO: Update the createRevision's response to be a revised learning object rather than 
+    // using a GET request to make a request that would effectively do the same thing. 
+    // This will cut down on requests and simplify abstraction.
     await this.revisionsService
       .createRevision(this.learningObject.cuid).then(async (revisionUri: any) => {
         this.revisedLearningObject = (await this.learningObjectServiceUri.fetchUri(revisionUri.revisionUri).toPromise())[0];

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -84,6 +84,7 @@ export class EditorialActionPadComponent implements OnInit {
   async createRevision() {
     this.closeRevisionModal();
     this.toaster.success('One Moment Please', 'Your revision is being created.');
+    //TODO: Update createRevision to return the revised learning object than the URI that we use to make a GET request directly after.
     await this.revisionsService
       .createRevision(this.learningObject.cuid).then(async (revisionUri: any) => {
         this.revisedLearningObject = (await this.learningObjectServiceUri.fetchUri(revisionUri.revisionUri).toPromise())[0];

--- a/src/app/cube/learning-object.service.ts
+++ b/src/app/cube/learning-object.service.ts
@@ -10,8 +10,6 @@ import {
 import { Query } from '../interfaces/query';
 
 import { SEARCH_ROUTES } from 'app/core/learning-object-module/search/search.routes';
-import * as querystring from 'querystring';
-import { REVISION_ROUTES } from '../core/learning-object-module/revisions/revisions.routes';
 import { USER_ROUTES } from '../core/user-module/user.routes';
 
 // TODO: move to core module
@@ -132,20 +130,6 @@ export class LearningObjectService {
       .then((val: any) => {
         return val.map((l) => new LearningObject(l));
       });
-  }
-
-  /**
-   * Creates a Revision of an existing learning object
-   *
-   * @param cuid the CUID of the learning object to create a revision of
-   */
-  async createRevision(cuid: string): Promise<any> {
-    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
-    const response = await this.http
-      .post(route, {}, { withCredentials: true })
-      .pipe(catchError(this.handleError))
-      .toPromise();
-    return response;
   }
 
   private handleError(error: HttpErrorResponse) {

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -12,7 +12,6 @@ import { FileUploadMeta } from '../learning-object-builder/components/content-up
 import { SUBMISSION_ROUTES } from '../../core/learning-object-module/submissions/submissions.routes';
 import { BUNDLING_ROUTES } from '../../core/learning-object-module/bundling/bundling.routes';
 import { OUTCOME_ROUTES } from '../../core/learning-object-module/outcomes/outcome.routes';
-import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/revisions.routes';
 import { FILE_ROUTES } from '../../core/learning-object-module/file/file.routes';
 import {
   LEGACY_USER_ROUTES,
@@ -122,27 +121,6 @@ export class LearningObjectService {
     // TODO: Verify this response gives the learning object name
   }
 
-  /**
-   * Creates a Revision of an existing learning object
-   *
-   * @param learningObjectId
-   * @param authorUsername
-   */
-  createRevision(cuid: string) {
-    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
-    return this.http
-      .post(
-        route, {},
-        { withCredentials: true }
-      )
-      .pipe(
-
-        catchError(this.handleError)
-      )
-      .toPromise().then(response => {
-        return response;
-      });
-  }
   /**
    * Fetches Learning Object by ID (full)
    *

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -12,6 +12,7 @@ import { ChangelogService } from 'app/core/learning-object-module/changelog/chan
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { takeUntil, take } from 'rxjs/operators';
 import { SubmissionsService } from 'app/core/learning-object-module/submissions/submissions.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 @Component({
   selector: 'clark-dashboard',
@@ -84,7 +85,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private changelogService: ChangelogService,
     public notificationService: ToastrOvenService,
     private cd: ChangeDetectorRef,
-    private submissionService: SubmissionsService
+    private submissionService: SubmissionsService,
+    private revisionsService: RevisionsService,
   ) {
     this.navbar.hide();
   }
@@ -353,7 +355,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   createRevision(object: LearningObject) {
-    this.sidePanelPromiseResolver = this.learningObjectService.createRevision(object.cuid).then(() => {
+    this.sidePanelPromiseResolver = this.revisionsService.createRevision(object.cuid).then(() => {
       this.getReleasedLearningObjects({ status: LearningObject.Status.RELEASED });
     });
   }

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -22,6 +22,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 import { SubmissionsService } from 'app/core/learning-object-module/submissions/submissions.service';
 import { OutcomeService } from 'app/core/learning-object-module/outcomes/outcome.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
+import { Revision } from 'aws-sdk/clients/codepipeline';
 
 /**
  * Defines a list of actions the builder can take
@@ -155,6 +157,7 @@ export class BuilderStore {
     private uriRetriever: UriRetrieverService,
     private submissionService: SubmissionsService,
     private outcomeService: OutcomeService,
+    private revisionsService: RevisionsService,
   ) {
     // subscribe to our objectCache$ observable and initiate calls to save object after a debounce
     this.objectCache$
@@ -253,7 +256,7 @@ export class BuilderStore {
     async () => {
       // eslint-disable-next-line eqeqeq
       if (revisionId == 0) {
-        revisionId = await this.learningObjectService.createRevision(cuid);
+        revisionId = await this.revisionsService.createRevision(cuid);
       }
 
       return this.learningObjectService.getLearningObjectRevision(username, cuid, revisionId);


### PR DESCRIPTION
Removed and updated the routes to point to revisions.service.ts. Opted to choose the createRevision function that makes use of the Promise class over then statements.