### PR TITLE
Feature/sc 32781/submissions module route updates for clark

### DIFF
--- a/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
+++ b/src/app/admin/components/hierarchy-builder/hierarchy-builder.component.ts
@@ -124,7 +124,7 @@ export class HierarchyBuilderComponent implements OnInit {
    * @returns
    */
   async setParents(node, childs) {
-    await this.hierarchyService.addChildren(this.parent.author.username, node, childs);
+    await this.hierarchyService.addChildren(node, childs);
     return node;
   }
 }

--- a/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
+++ b/src/app/core/learning-object-module/hierarchy/hierarchy.service.ts
@@ -1,9 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { LearningObject } from '@entity';
-import { ADMIN_ROUTES, LEARNING_OBJECT_ROUTES, LEGACY_USER_ROUTES, USER_ROUTES } from '../learning-object/learning-object.routes';
+import { ADMIN_ROUTES, LEARNING_OBJECT_ROUTES } from '../learning-object/learning-object.routes';
 import { HIERARCHY_ROUTES } from './hierarchy.routes';
-import { LEARNING_OBJECT_ERRORS } from 'entity/learning-object/error-messages';
 
 @Injectable({
   providedIn: 'root'
@@ -13,10 +12,10 @@ export class HierarchyService {
   constructor(private http: HttpClient) { }
 
 
-  async addHierarchyObject(username: string, object: any): Promise<any> {
+  async addHierarchyObject(username: string, learningObject: LearningObject): Promise<any> {
     return await this.http.post(
       ADMIN_ROUTES.ADD_HIERARCHY_OBJECT(),
-      { object, username }, { withCredentials: true, responseType: 'text' }
+      { object: learningObject, username }, { withCredentials: true, responseType: 'text' }
     ).toPromise();
   }
 
@@ -25,12 +24,12 @@ export class HierarchyService {
    * only be called for root objects, but can be used for subtrees
    * according to Hierarchy Service docs.
    *
-   * @param id id of the root learning object of a hierarchy
+   * @param learningObjectId id of the root learning object of a hierarchy
    * @returns A promise
    */
-  async releaseHierarchy(id: string): Promise<any> {
+  async releaseHierarchy(learningObjectId: string): Promise<any> {
     return await this.http.patch(
-      HIERARCHY_ROUTES.CHANGE_HIERARCHY_STATUS(id),
+      HIERARCHY_ROUTES.CHANGE_HIERARCHY_STATUS(learningObjectId),
       {
         status: LearningObject.Status.RELEASED
       },
@@ -43,13 +42,13 @@ export class HierarchyService {
    * only be called for root objects, but can be used for subtrees
    * according to Hierarchy Service docs.
    *
-   * @param id id of the root learning object of a hierarchy
+   * @param learningObjectId id of the root learning object of a hierarchy
    * @param collection the collection the objects will belong to
    * @returns A promise
    */
-  async submitHierarchy(id: string, collection: string): Promise<any> {
+  async submitHierarchy(learningObjectId: string, collection: string): Promise<any> {
     return await this.http.patch(
-      HIERARCHY_ROUTES.CHANGE_HIERARCHY_STATUS(id),
+      HIERARCHY_ROUTES.CHANGE_HIERARCHY_STATUS(learningObjectId),
       {
         status: LearningObject.Status.WAITING,
         collection: collection
@@ -60,14 +59,13 @@ export class HierarchyService {
   /**
    * Adds children to a learning object
    *
-   * @param username the username of the author
-   * @param object the object having children
+   * @param parent the object having children
    * @param children the children to be had
    * @returns
    */
-  async addChildren(username: string, object: any, children): Promise<any> {
+  async addChildren(parent: LearningObject, children: LearningObject): Promise<any> {
     return await this.http.post(
-      LEARNING_OBJECT_ROUTES.UPDATE_CHILDREN(object.id),
+      LEARNING_OBJECT_ROUTES.UPDATE_CHILDREN(parent.id),
       {
         children
       },
@@ -82,18 +80,18 @@ export class HierarchyService {
    * Checks if the name of the learning object is already taken for the author
    *
    * @param username the username of the author
-   * @param objectName the objectName to check for
+   * @param learningObjectName the objectName to check for
    * @returns
    */
-  async checkName(username: string, objectName: string): Promise<boolean> {
+  async checkName(username: string, learningObjectName: string): Promise<boolean> {
     return this.http
-      .get(LEARNING_OBJECT_ROUTES.GET_MY_LEARNING_OBJECTS(username, {text: objectName}), { withCredentials: true })
+      .get(LEARNING_OBJECT_ROUTES.GET_MY_LEARNING_OBJECTS(username, {text: learningObjectName}), { withCredentials: true })
       .toPromise()
       .then((response: any) => {
         const possibleMatches = response.map(object => {
           return object.name;
         });
-        return possibleMatches.includes(objectName) ? true : false;
+        return possibleMatches.includes(learningObjectName) ? true : false;
       });
   }
 }

--- a/src/app/core/learning-object-module/submissions/submissions.routes.ts
+++ b/src/app/core/learning-object-module/submissions/submissions.routes.ts
@@ -3,16 +3,6 @@ import { environment } from '../../../../environments/environment';
 
 export const SUBMISSION_ROUTES = {
     /**
-     * Request to get submissions for a learning object
-     * @param userId - The id of the author of the learning object
-     * @param learningObjectId - The id of the learning object to get submissions for
-     */
-    GET_SUBMISSIONS(userId: string, learningObjectId: string) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            userId
-        )}/learning-objects/${encodeURIComponent(learningObjectId)}/submissions`;
-    },
-    /**
      * Request to check if a learning object has been submitted to a specific collection
      * @param learningObjectId - The id of the learning object to check
      * @param collection - The collection associated with the submission

--- a/src/app/core/learning-object-module/submissions/submissions.routes.ts
+++ b/src/app/core/learning-object-module/submissions/submissions.routes.ts
@@ -1,4 +1,3 @@
-import { LearningObjectService } from 'app/onion/core/learning-object.service';
 import { environment } from '../../../../environments/environment';
 
 export const SUBMISSION_ROUTES = {

--- a/src/app/core/learning-object-module/submissions/submissions.service.ts
+++ b/src/app/core/learning-object-module/submissions/submissions.service.ts
@@ -20,7 +20,7 @@ export class SubmissionsService {
    * @param {string[]} [selectedAuthorizations] authorizations that the author gave for changes
    * @return {Promise<any>}
    */
-  submit(params: {
+  submitLearningObject(params: {
     learningObjectId: string,
     collectionName: string,
     submissionReason?: string,
@@ -45,7 +45,7 @@ export class SubmissionsService {
       .toPromise();
   }
 
-  unsubmit(
+  unsubmitLearningObject(
     learningObjectId: string,
   ): Promise<any> {
     return this.http

--- a/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
@@ -3,33 +3,6 @@ import * as querystring from 'querystring';
 
 export const STANDARD_GUIDELINES_ROUTES = {
     /**
-     * Request to retrieve a framework
-     * @method GET
-     * @param id the id of the framework
-     * @returns the framework
-     */
-    GET_FRAMEWORK(id: string) {
-        return `${environment.apiURL}/frameworks/${id}`;
-    },
-    /**
-     * Request to retrieve the guidelines for a framework
-     * @method GET
-     * @param id the id of the framework
-     * @returns the guidelines for the framework
-     */
-    GET_FRAMEWORK_GUIDELINES(id: string) {
-        return `${environment.apiURL}/frameworks/${id}/guidelines`;
-    },
-    /**
-     * Request to retrieve a guideline
-     * @method GET
-     * @param id the id of the guideline
-     * @returns the guideline
-     */
-    GET_GUIDELINE(id: string) {
-        return `${environment.apiURL}/guidelines/${id}`;
-    },
-    /**
      * Request to retrieve a list of frameworks
      * @method GET
      * @returns list of frameworks

--- a/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
@@ -2,52 +2,60 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import * as querystring from 'querystring';
 import { throwError } from 'rxjs';
-import { retry, catchError, map } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { STANDARD_GUIDELINES_ROUTES } from './standard-guidelines.routes';
 import { FrameworkDocument } from '../../../entity/standard-guidelines/Framework';
 import { SearchItemDocument } from '../../../entity/standard-guidelines/search-index';
 
+interface GuidelinesFilter {
+  text?: string;
+  filterText?: string;
+  year?: string;
+  levels?: string;
+  page?: number;
+  limit?: number;
+  type?: string;
+  frameworks?: string | string[];
+}
+
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class GuidelineService {
+  constructor(public http: HttpClient) {}
 
-  constructor(public http: HttpClient) { }
-
-  getGuidelines(
-    filter?
+  async getGuidelines(
+    filter?: GuidelinesFilter,
   ): Promise<{ total: number; results: SearchItemDocument[] }> {
     let query = '';
     if (filter) {
       query = querystring.stringify(this.formatFilter(filter));
     }
     // CLARK-SERVICE-FIX: SUPPORT SEARCH QUERY
-    return this.http
-      .get<{ total: number, results: SearchItemDocument[] }>(STANDARD_GUIDELINES_ROUTES.SEARCH_GUIDELINES())
-      .pipe(
-
-        catchError(this.handleError)
-      )
-      .toPromise()
-      .then((res: { total: number, results: any[] }) => {
-        return res;
-      });
+    const res = await this.http
+      .get<{ total: number; results: SearchItemDocument[]; }>(
+        STANDARD_GUIDELINES_ROUTES.SEARCH_GUIDELINES())
+      .pipe(catchError(this.handleError))
+      .toPromise();
+    return res;
   }
 
   // CLARK-SERVICE-FIX: SUPPORT SEARCH QUERY
-  async getFrameworks(query?: any): Promise<FrameworkDocument[]> {
+  async getFrameworks(filter?: GuidelinesFilter): Promise<FrameworkDocument[]> {
     return this.http
-      .get<{ total: number, results: FrameworkDocument[] }>(STANDARD_GUIDELINES_ROUTES.SEARCH_FRAMEWORKS(query))
+      .get<{ total: number; results: FrameworkDocument[] }>(
+        STANDARD_GUIDELINES_ROUTES.SEARCH_FRAMEWORKS(filter),
+      )
       .pipe(
-
         catchError(this.handleError),
         map((res) => {
           return res.results;
-        })
-      ).toPromise();
+        }),
+      )
+      .toPromise();
   }
 
-  private formatFilter(filter) {
+  private formatFilter(filter: GuidelinesFilter) {
     if (!filter) {
       return {};
     }
@@ -56,8 +64,8 @@ export class GuidelineService {
       text: filter.text || filter.filterText,
       year: filter.year !== '' ? filter.year : undefined,
       levels: filter?.levels?.length > 0 ? filter.levels : undefined,
-      page: filter.page !== '' ? filter.page : undefined,
-      limit: filter.limit !== '' ? filter.limit : undefined,
+      page: filter.page ? filter.page : undefined,
+      limit: filter.limit ? filter.limit : undefined,
       type: filter.type !== '' ? filter.type : undefined,
       frameworks: filter.frameworks !== '' ? filter.frameworks : undefined,
     };

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -9,7 +9,6 @@ import { CookieService } from 'ngx-cookie-service';
 import { catchError, takeUntil } from 'rxjs/operators';
 import { throwError, Subject, BehaviorSubject } from 'rxjs';
 import { FileUploadMeta } from '../learning-object-builder/components/content-upload/app/services/typings';
-import { SUBMISSION_ROUTES } from '../../core/learning-object-module/submissions/submissions.routes';
 import { BUNDLING_ROUTES } from '../../core/learning-object-module/bundling/bundling.routes';
 import { OUTCOME_ROUTES } from '../../core/learning-object-module/outcomes/outcome.routes';
 import { FILE_ROUTES } from '../../core/learning-object-module/file/file.routes';
@@ -330,29 +329,6 @@ export class LearningObjectService {
       .delete(
         LEGACY_USER_ROUTES.DELETE_MAPPING(username, learningObjectId, outcome, mappingId),
         { headers: this.headers, withCredentials: true }
-      )
-      .pipe(
-
-        catchError(this.handleError)
-      )
-      .toPromise();
-  }
-
-  /**
-   * Publish a learning object
-   *
-   * @param {LearningObject} learningObject the learning object to be published
-   * @param {string} collection the abreviated name of the collection to which to submit this learning object
-   */
-  submit(learningObject: LearningObject, collection: string): Promise<{}> {
-    const route = SUBMISSION_ROUTES.SUBMIT_LEARNING_OBJECT({
-      learningObjectId: learningObject.id,
-    });
-    return this.http
-      .post(
-        route,
-        { collection },
-        { headers: this.headers, withCredentials: true, responseType: 'text' }
       )
       .pipe(
 

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -225,7 +225,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
       this.currentlySubmittingObject = event;
       this.submitToCollection = true;
     } else {
-      this.submissionService.submit({
+      this.submissionService.submitLearningObject({
         learningObjectId: event.id,
         collectionName: event.collection,
       })
@@ -248,7 +248,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
    * @param l {LearningObject} learning object to be unpublished
    */
   cancelSubmission(l: LearningObject): Promise<void> {
-    return this.submissionService.unsubmit(
+    return this.submissionService.unsubmitLearningObject(
       l.id,
       ).then(async () => {
       l.status = LearningObject.Status.UNRELEASED;

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -884,7 +884,7 @@ export class BuilderStore {
 
   public cancelSubmission(): void {
     this.submissionService
-      .unsubmit(
+      .unsubmitLearningObject(
         this.learningObject.id,
       )
       .then(() => {

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -216,7 +216,7 @@ export class SubmitComponent implements OnInit {
           });
       } else {
         this.submissionService
-          .submit({
+          .submitLearningObject({
             learningObjectId: this.learningObject.id,
             collectionName: this.collection,
             submissionReason: this.submissionReason,


### PR DESCRIPTION
Removed SUBMIT_LEARNING_OBJECT route from learning-object.service.ts--a function already exists in submissions.service.ts. GET_SUBMISSIONS route has no reference