### PR TITLE
Feature/sc 32768/library module route updates for clark refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cyber4all: cyber4all/orb@2.1.7
+  cyber4all: cyber4all/orb@2.1.8
   node: circleci/node@6.1.0
 
 workflows:

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -98,7 +98,7 @@ export class ClarkComponent implements OnInit {
       this.authService.isLoggedIn.subscribe((value: boolean) => {
         // Loads the user's library if they are logged in
         if (value) {
-          this.libraryService.getLibrary();
+          this.libraryService.getLibrary({});
         }
       });
 

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -95,9 +95,9 @@ export class ClarkComponent implements OnInit {
   ) {
     this.isSupportedBrowser = !(/msie\s|trident\/|edge\//i.test(window.navigator.userAgent));
     !this.isSupportedBrowser ? this.router.navigate(['/unsupported']) :
-      this.authService.isLoggedIn.subscribe(val => {
-        if (val) {
-          this.libraryService.updateUser();
+      this.authService.isLoggedIn.subscribe((value: boolean) => {
+        // Loads the user's library if they are logged in
+        if (value) {
           this.libraryService.getLibrary();
         }
       });

--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -8,7 +8,7 @@ import { AuthService } from '../auth-module/auth.service';
 import { BUNDLING_ROUTES } from '../learning-object-module/bundling/bundling.routes';
 import { LIBRARY_ROUTES } from './library.routes';
 
-export type LibraryItem = { _id: string, savedBy: string, savedOn: string, learningObject: LearningObject };
+export interface LibraryItem { _id: string, savedBy: string, savedOn: string, learningObject: LearningObject }
 
 const DEFAULT_BUNDLE_NAME = 'CLARK_LEARNING_OBJECT.zip';
 @Injectable({
@@ -47,9 +47,9 @@ export class LibraryService {
   }
 
   /**
-   * 
-   * @param opts 
-   * @returns 
+   *
+   * @param opts
+   * @returns
    */
   async getLibrary(opts?: {
     learningObjectCuid?: string, version?: number,
@@ -82,12 +82,12 @@ export class LibraryService {
         this.libraryItems = val.userLibraryItems
           .map((libraryItem) => {
             libraryItem.learningObject.id = libraryItem.learningObject?._id;
-            
-            return { 
-              _id: libraryItem._id, 
-              savedBy: libraryItem.savedBy, 
-              savedOn: libraryItem.savedOn, 
-              learningObject: new LearningObject(libraryItem.learningObject) 
+
+            return {
+              _id: libraryItem._id,
+              savedBy: libraryItem.savedBy,
+              savedOn: libraryItem.savedOn,
+              learningObject: new LearningObject(libraryItem.learningObject)
             };
           });
         return { libraryItems: this.libraryItems, lastPage: val.lastPage };
@@ -132,7 +132,7 @@ export class LibraryService {
       return Promise.reject('User is undefined');
     }
 
-    console.log("DELETE", this.libraryItems);
+    console.log('DELETE', this.libraryItems);
 
     const libraryItemIds = this.libraryItems
       .filter((libraryItem: LibraryItem) => libraryItem.learningObject?.id === learningObjectId)
@@ -243,7 +243,7 @@ export class LibraryService {
   /**
    * Returns whether the learning object exists in the user's library
    * This is done by checking the library items for the learningObjectId
-   * 
+   *
    * @param learningObjectId the learning object to check for in the library
    * @returns whether the learning object exists in the library
    */
@@ -272,7 +272,7 @@ export class LibraryService {
         return value.replace(/"/g, '').trim();
       }
     }
-    
+
     // Return default bundle name if no filename key found
     return DEFAULT_BUNDLE_NAME;
   }

--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -8,6 +8,8 @@ import { AuthService } from '../auth-module/auth.service';
 import { BUNDLING_ROUTES } from '../learning-object-module/bundling/bundling.routes';
 import { LIBRARY_ROUTES } from './library.routes';
 
+export type LibraryItem = { _id: string, savedBy: string, savedOn: string, learningObject: LearningObject };
+
 const DEFAULT_BUNDLE_NAME = 'CLARK_LEARNING_OBJECT.zip';
 @Injectable({
   providedIn: 'root'
@@ -15,8 +17,7 @@ const DEFAULT_BUNDLE_NAME = 'CLARK_LEARNING_OBJECT.zip';
 export class LibraryService {
   private user;
   private headers = new HttpHeaders();
-  private cartItems: Array<any> = [];
-  public libraryItems: Array<LearningObject> = [];
+  public libraryItems: Array<LibraryItem> = [];
 
   // Observable boolean to toggle download spinner in components
   private _loading$ = new BehaviorSubject<boolean>(false);
@@ -26,23 +27,35 @@ export class LibraryService {
     return this._loading$.asObservable();
   }
 
-  constructor(private http: HttpClient, private auth: AuthService, public toaster: ToastrOvenService) {
+  constructor(
+    private http: HttpClient,
+    private auth: AuthService,
+    public toaster: ToastrOvenService
+  ) {
     this.updateUser();
   }
 
+  /**
+   * Method to update the user object and headers with the latest user information
+   */
   updateUser() {
     // get new user from auth service
     this.user = this.auth.user || undefined;
 
     // reset headers with new users auth token
     this.headers = new HttpHeaders();
-    // this.headers.append('Content-Type', 'application/json');
   }
 
+  /**
+   * 
+   * @param opts 
+   * @returns 
+   */
   async getLibrary(opts?: {
     learningObjectCuid?: string, version?: number,
     page?: number, limit?: number
-  }): Promise<{ cartItems: LearningObject[], lastPage: number }> {
+  }): Promise<{ libraryItems: LibraryItem[], lastPage: number }> {
+    // Resets the auth token in the headers
     this.updateUser();
     if (!this.user) {
       return Promise.reject('User is undefined');
@@ -66,15 +79,18 @@ export class LibraryService {
       .toPromise()
       .then((val: any) => {
         // preserves carts from cartsdb
-        this.cartItems = val.userLibraryItems;
         this.libraryItems = val.userLibraryItems
-          .map(object => {
-            if (object.learningObject) {
-              object.learningObject.id = object.learningObject._id;
-            }
-            return new LearningObject(object.learningObject);
+          .map((libraryItem) => {
+            libraryItem.learningObject.id = libraryItem.learningObject?._id;
+            
+            return { 
+              _id: libraryItem._id, 
+              savedBy: libraryItem.savedBy, 
+              savedOn: libraryItem.savedOn, 
+              learningObject: new LearningObject(libraryItem.learningObject) 
+            };
           });
-        return { cartItems: this.libraryItems, lastPage: val.lastPage };
+        return { libraryItems: this.libraryItems, lastPage: val.lastPage };
       });
   }
 
@@ -115,21 +131,26 @@ export class LibraryService {
     if (!this.user) {
       return Promise.reject('User is undefined');
     }
-    const cartId = this.cartItems
-    .filter(cart => cart.learningObject && cart.learningObject._id === learningObjectId)
-    .map(cart => cart._id)[0];
+
+    console.log("DELETE", this.libraryItems);
+
+    const libraryItemIds = this.libraryItems
+      .filter((libraryItem: LibraryItem) => libraryItem.learningObject?.id === learningObjectId)
+      .map((libraryItem: LibraryItem) => libraryItem._id);
+
+    if  (libraryItemIds.length === 0) {
+      return Promise.reject('Learning object not found in library');
+    }
+
     this.http
       .delete(
         LIBRARY_ROUTES.REMOVE_LEARNING_OBJECT_FROM_LIBRARY(
           this.user.username,
-          cartId
+          libraryItemIds[0]
         ),
         { headers: this.headers, withCredentials: true }
       )
-      .pipe(
-
-        catchError((error) => this.handleError(error))
-      )
+      .pipe(catchError((error) => this.handleError(error)))
       .toPromise();
   }
 
@@ -219,12 +240,15 @@ export class LibraryService {
       });
   }
 
-  has(object: LearningObject): boolean {
-    const inLibrary = this.libraryItems.filter(
-      o =>
-        o.cuid === object.cuid
-    ).length > 0;
-    return inLibrary;
+  /**
+   * Returns whether the learning object exists in the user's library
+   * This is done by checking the library items for the learningObjectId
+   * 
+   * @param learningObjectId the learning object to check for in the library
+   * @returns whether the learning object exists in the library
+   */
+  has(learningObjectId: string): boolean {
+    return this.libraryItems.filter((libraryItem: LibraryItem) => libraryItem.learningObject.id === learningObjectId).length > 0;
   }
 
   /**
@@ -238,6 +262,7 @@ export class LibraryService {
     if (!contentDisposition) {
       return DEFAULT_BUNDLE_NAME;
     }
+
     // Split the content disposition header by semicolon
     const split = contentDisposition.split(';');
     for (const part of split) {
@@ -247,6 +272,7 @@ export class LibraryService {
         return value.replace(/"/g, '').trim();
       }
     }
+    
     // Return default bundle name if no filename key found
     return DEFAULT_BUNDLE_NAME;
   }

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -21,7 +21,6 @@ import { Router } from '@angular/router';
 import { LearningObjectService } from '../../../../../app/onion/core/learning-object.service';
 import { NavbarDropdownService } from '../../../../core/client-module/navBarDropdown.service';
 import { BUNDLING_ROUTES } from 'app/core/learning-object-module/bundling/bundling.routes';
-import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'cube-details-action-panel',
@@ -99,7 +98,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
     await this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid, version: this.learningObject.version });
-    this.saved = this.libraryService.has(this.learningObject);
+    this.saved = this.libraryService.has(this.learningObject.id);
     this.getCollection();
     this.libraryService.loaded
       .subscribe(val => {
@@ -144,7 +143,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
       );
     }
     if (!this.userIsAuthor && this.isReleased) {
-      this.saved = this.libraryService.has(this.learningObject);
+      this.saved = this.libraryService.has(this.learningObject.id);
 
       if (!this.saved) {
         try {

--- a/src/app/cube/library/library.component.html
+++ b/src/app/cube/library/library.component.html
@@ -51,7 +51,7 @@
                         [learningObject]='libraryItem.learningObject'
                         [learningObjectAverageRating]='libraryItem.avgRating'
                         (downloadButtonClicked)='downloadObject($event, libraryItem.learningObject, i)'
-                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemToDelete = libraryItem.learningObject;'
+                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemIdToDelete = libraryItem._id;'
                         (titleClicked)='goToItem(libraryItem.learningObject)'
                         [currIndex]='currentIndex'
                         [myIndex]=i

--- a/src/app/cube/library/library.component.html
+++ b/src/app/cube/library/library.component.html
@@ -46,13 +46,13 @@
                 Saved Items
             </h2>
             <div *ngIf='libraryItems?.length; else emptyLibraryTemplate' class='library-items__list-items'>
-                <div *ngFor='let item of libraryItems; let i = index'>
+                <div *ngFor='let libraryItem of libraryItems; let i = index'>
                     <clark-library-item
-                        [learningObject]='item'
-                        [learningObjectAverageRating]='item.avgRating'
-                        (downloadButtonClicked)='downloadObject($event, item, i)'
-                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemToDelete = item;'
-                        (titleClicked)='goToItem(item)'
+                        [learningObject]='libraryItem.learningObject'
+                        [learningObjectAverageRating]='libraryItem.avgRating'
+                        (downloadButtonClicked)='downloadObject($event, libraryItem.learningObject, i)'
+                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemToDelete = libraryItem.learningObject;'
+                        (titleClicked)='goToItem(libraryItem.learningObject)'
                         [currIndex]='currentIndex'
                         [myIndex]=i
                     ></clark-library-item>

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, HostListener, ChangeDetectorRef, ViewChild, ElementRef } from '@angular/core';
-import { LibraryService } from 'app/core/library-module/library.service';
+import { LibraryItem, LibraryService } from 'app/core/library-module/library.service';
 import { LearningObject } from 'entity/learning-object/learning-object';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { Subject } from 'rxjs';
@@ -47,7 +47,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   @ViewChild('savedList') topOfList: ElementRef;
   loading: boolean;
   serviceError: boolean;
-  libraryItems: LearningObject[] = [];
+  libraryItems: LibraryItem[] = [];
   downloading = [];
   currentIndex = null;
   destroyed$ = new Subject<void>();
@@ -124,11 +124,13 @@ export class LibraryComponent implements OnInit, OnDestroy {
   async loadLibrary() {
     try {
       this.loading = true;
-      const libraryItemInformation = await this.libraryService.getLibrary({page: this.currentPageNumber, limit: 10});
-      this.libraryItems = libraryItemInformation.cartItems;
-      this.lastPageNumber = libraryItemInformation.lastPage;
-      this.libraryItems.map(async (libraryItem: LearningObject) => {
-        const ratings = await this.getRatings(libraryItem);
+      const getLibraryResponse = await this.libraryService.getLibrary({page: this.currentPageNumber, limit: 10});
+
+      this.libraryItems = getLibraryResponse.libraryItems;
+      this.lastPageNumber = getLibraryResponse.lastPage;
+
+      this.libraryItems.map(async (libraryItem: LibraryItem) => {
+        const ratings = await this.getRatings(libraryItem.learningObject);
         if (ratings) {
           libraryItem['avgRating'] = ratings.avgValue;
         }
@@ -225,7 +227,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   async removeItem() {
     try {
       await this.libraryService.removeFromLibrary(this.libraryItemToDelete.id);
-      this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).cartItems;
+      this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).libraryItems;
       this.changeLibraryItemPage(this.currentPageNumber);
       this.showDeleteLibraryItemModal = false;
     } catch (e) {
@@ -310,9 +312,9 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async changeLibraryItemPage(pageNumber: number) {
     this.topOfList.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const libraryItemInformation = await this.libraryService.getLibrary({page: pageNumber, limit: 10});
-    this.libraryItems = libraryItemInformation.cartItems;
-    this.lastPageNumber = libraryItemInformation.lastPage;
+    const libraryItemResponse = await this.libraryService.getLibrary({page: pageNumber, limit: 10});
+    this.libraryItems = libraryItemResponse.libraryItems;
+    this.lastPageNumber = libraryItemResponse.lastPage;
     this.currentPageNumber = pageNumber;
   }
 

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -62,7 +62,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   showDeleteLibraryItemModal = false;
   changelogs = [];
   changelogLearningObject;
-  libraryItemToDelete;
+  libraryItemIdToDelete: string;
   lastPageNumber;
   currentPageNumber = 1;
   currentNotificationsPageNumber = 1;
@@ -137,6 +137,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
       });
       this.loading = false;
     } catch (e) {
+      console.log(e);
       this.toaster.error('Error!', 'Unable to load your library. Please try again later.');
       this.serviceError = true;
       this.loading = false;
@@ -226,7 +227,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async removeItem() {
     try {
-      await this.libraryService.removeFromLibrary(this.libraryItemToDelete.id);
+      await this.libraryService.removeFromLibrary(this.libraryItemIdToDelete);
       this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).libraryItems;
       this.changeLibraryItemPage(this.currentPageNumber);
       this.showDeleteLibraryItemModal = false;
@@ -312,10 +313,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async changeLibraryItemPage(pageNumber: number) {
     this.topOfList.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const libraryItemResponse = await this.libraryService.getLibrary({page: pageNumber, limit: 10});
-    this.libraryItems = libraryItemResponse.libraryItems;
-    this.lastPageNumber = libraryItemResponse.lastPage;
     this.currentPageNumber = pageNumber;
+    await this.loadLibrary();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
This story fixes the library service routes and broken logic that didn't allow for pagination and simplified some roundabout legacy logic of getting library _id by using the learningObject that exists on the document etc. etc..