### PR TITLE
Feature/sc 32777/revisions module route updates for clark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  cyber4all: cyber4all/orb@2.1.7
+  cyber4all: cyber4all/orb@2.1.8
   node: circleci/node@6.1.0
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,11 @@
 version: 2.1
 
 orbs:
+<<<<<<< HEAD
   cyber4all: cyber4all/orb@2.1.8
+=======
+  cyber4all: cyber4all/orb@2.1.7
+>>>>>>> dfe10b96dbbebf335b20d6975852330d2435f067
   node: circleci/node@6.1.0
 
 workflows:

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -16,7 +16,6 @@ import { environment } from '@env/environment';
 import { HttpHeaders, HttpClient } from '@angular/common/http';
 import { take, catchError } from 'rxjs/operators';
 import { of } from 'rxjs/internal/observable/of';
-import { UnreleaseService } from 'app/admin/core/unrelease.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { Router } from '@angular/router';
 import { HierarchyService } from '../../../core/learning-object-module/hierarchy/hierarchy.service';
@@ -25,6 +24,7 @@ import {
   LearningObjectService as RefactoredLearningObjectService
 } from 'app/core/learning-object-module/learning-object/learning-object.service';
 import { LEARNING_OBJECT_ROUTES } from 'app/core/learning-object-module/learning-object/learning-object.routes';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 @Component({
   selector: 'clark-learning-object-list-item',
@@ -72,14 +72,14 @@ export class LearningObjectListItemComponent implements OnChanges {
   private headers = new HttpHeaders();
   constructor(
     private auth: AuthService,
-    private unreleaseService: UnreleaseService,
     private statuses: StatusDescriptions,
     private cd: ChangeDetectorRef,
     private http: HttpClient,
     private toaster: ToastrOvenService,
     private hierarchyService: HierarchyService,
     private loService: LearningObjectService,
-    private refactoredLearningObjectService: RefactoredLearningObjectService
+    private refactoredLearningObjectService: RefactoredLearningObjectService,
+    private revisionsService: RevisionsService,
   ) { }
 
   async ngOnChanges(changes: SimpleChanges) {
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   deleteRevision() {
-    this.unreleaseService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
+    this.revisionsService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
       .then(() => {
         this.toaster.success('Success', 'Learning object unreleased revision deleted successfully');
       }).catch(() => {

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -79,7 +79,7 @@ export class LearningObjectListItemComponent implements OnChanges {
     private hierarchyService: HierarchyService,
     private loService: LearningObjectService,
     private refactoredLearningObjectService: RefactoredLearningObjectService,
-    private revisionsService: RevisionsService,
+    private revisionsService: RevisionsService
   ) { }
 
   async ngOnChanges(changes: SimpleChanges) {
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   deleteRevision() {
-    this.revisionsService.deleteRevision(this.learningObject.cuid, this.learningObject.version + 1)
+    this.revisionsService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
       .then(() => {
         this.toaster.success('Success', 'Learning object unreleased revision deleted successfully');
       }).catch(() => {

--- a/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
+++ b/src/app/admin/components/learning-object-list-item/learning-object-list-item.component.ts
@@ -249,7 +249,7 @@ export class LearningObjectListItemComponent implements OnChanges {
   }
 
   deleteRevision() {
-    this.revisionsService.deleteRevision(this.learningObject.author.username, this.learningObject.cuid, this.learningObject.version + 1)
+    this.revisionsService.deleteRevision(this.learningObject.cuid, this.learningObject.version + 1)
       .then(() => {
         this.toaster.success('Success', 'Learning object unreleased revision deleted successfully');
       }).catch(() => {

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -10,25 +10,6 @@ import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/rev
 })
 export class UnreleaseService {
   constructor(private http: HttpClient) {}
-
-  /**
-   * Deletes a revision of a learning object. This is designed to allow an editor to create a new
-   * revision when it is necessary for the editorial process to continue.
-   *
-   * @param username username of the author
-   * @param cuid cuid of the learning object
-   * @returns
-   */
-  deleteRevision(username: string, cuid: string, version: number) {
-    return this.http
-      .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
-        withCredentials: true,
-        responseType: 'text',
-      })
-      .pipe(catchError(this.handleError))
-      .toPromise();
-  }
-
   /**
    * Generic error-handling function for errors through from the HttpClient module
    *

--- a/src/app/admin/core/unrelease.service.ts
+++ b/src/app/admin/core/unrelease.service.ts
@@ -1,30 +1,9 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { LearningObject } from '@entity';
-import { throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
-import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/revisions.routes';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UnreleaseService {
   constructor(private http: HttpClient) {}
-  /**
-   * Generic error-handling function for errors through from the HttpClient module
-   *
-   * @private
-   * @param {HttpErrorResponse} error
-   * @returns
-   * @memberof PrivilegeService
-   */
-  private handleError(error: HttpErrorResponse) {
-    if (error.error instanceof ErrorEvent) {
-      // Client-side or network returned error
-      return throwError(error.error.message);
-    } else {
-      // API returned error
-      return throwError(error);
-    }
-  }
 }

--- a/src/app/clark.component.ts
+++ b/src/app/clark.component.ts
@@ -95,10 +95,10 @@ export class ClarkComponent implements OnInit {
   ) {
     this.isSupportedBrowser = !(/msie\s|trident\/|edge\//i.test(window.navigator.userAgent));
     !this.isSupportedBrowser ? this.router.navigate(['/unsupported']) :
-      this.authService.isLoggedIn.subscribe(val => {
-        if (val) {
-          this.libraryService.updateUser();
-          this.libraryService.getLibrary();
+      this.authService.isLoggedIn.subscribe((value: boolean) => {
+        // Loads the user's library if they are logged in
+        if (value) {
+          this.libraryService.getLibrary({});
         }
       });
 

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, ViewContainerRef } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
-import { MatRadioChange } from '@angular/material/radio';
 import { AuthValidationService } from 'app/core/auth-module/auth-validation.service';
-import { CollectionService } from 'app/core/collection-module/collections.service';
+import { ReportService } from 'app/core/report-module/report.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 
 @Component({
@@ -23,7 +22,7 @@ export class NcyteDashboardComponent implements OnInit {
     private toaster: ToastrOvenService,
     private view: ViewContainerRef,
     private authValidationService: AuthValidationService,
-    private collectionService: CollectionService
+    private reportService: ReportService,
   ) { }
 
   ngOnInit(): void {
@@ -42,11 +41,11 @@ export class NcyteDashboardComponent implements OnInit {
     }
 
     if (this.when === 'All-time') {
-      this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value);
+      this.reportService.generateCollectionReport(['ncyte'], this.email.value, this.name.value);
     } else {
       const start = `${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`;
       const end = `${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`;
-      this.collectionService.generateCollectionReport(['ncyte'], this.email.value, this.name.value, { start: start, end: end });
+      this.reportService.generateCollectionReport(['ncyte'], this.email.value, this.name.value, { start: start, end: end });
     }
 
     this.toaster.alert('We\'re working on it!', 'Please check your email in a few minutes for your report.');

--- a/src/app/core/collection-module/collections.service.ts
+++ b/src/app/core/collection-module/collections.service.ts
@@ -3,6 +3,8 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BehaviorSubject, throwError } from 'rxjs';
 import { catchError, skipWhile } from 'rxjs/operators';
 import { COLLECTION_ROUTES } from './collections.routes';
+import { REPORT_ROUTES } from '../report-module/report.routes';
+import { USER_ROUTES } from '../user-module/user.routes';
 
 export interface Collection {
   name: string;

--- a/src/app/core/collection-module/collections.service.ts
+++ b/src/app/core/collection-module/collections.service.ts
@@ -1,13 +1,8 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
-import {
-  LEGACY_COLLECTIONS_ROUTES
-} from '../../core/learning-object-module/learning-object/learning-object.routes';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BehaviorSubject, throwError } from 'rxjs';
 import { catchError, skipWhile } from 'rxjs/operators';
 import { COLLECTION_ROUTES } from './collections.routes';
-import { REPORT_ROUTES } from '../report-module/report.routes';
-import { USER_ROUTES } from '../user-module/user.routes';
 
 export interface Collection {
   name: string;
@@ -21,7 +16,6 @@ export interface Collection {
 export class CollectionService {
   private collections: Collection[];
   private loading$ = new BehaviorSubject<boolean>(true);
-  private headers: HttpHeaders = new HttpHeaders();
   darkMode502 = new BehaviorSubject<boolean>(true);
   constructor(private http: HttpClient) {
     this.getAllCollections();
@@ -121,32 +115,6 @@ export class CollectionService {
   changeStatus502(status: boolean) {
     if (this.darkMode502.getValue() !== status) {
       this.darkMode502.next(status);
-    }
-  }
-
-  async generateCollectionReport(
-    collections: string[],
-    email: string,
-    name: string,
-    date?: {
-      start: string,
-      end: string
-    }) {
-    if (collections.length > 0) {
-      const route = REPORT_ROUTES.GENERATE_REPORT(collections, date);
-      this.http
-        .post(
-          route,
-          {
-            email,
-            name
-          },
-          { headers: this.headers, withCredentials: true }
-        )
-        .pipe(
-          catchError(this.handleError)
-        )
-        .toPromise();
     }
   }
 

--- a/src/app/core/feature-module/featured.routes.ts
+++ b/src/app/core/feature-module/featured.routes.ts
@@ -15,12 +15,16 @@ export const FEATURED_ROUTES = {
    * @param collectionAbvName the abbreviated name of the collection
    * @param limit (optional) the number of featured learning objects to retrieve
    */
-  GET_COLLECTION_FEATURED_OBJECTS(collectionAbvName: string, limit?: number) {
-    let url = `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}`;
-    if (limit) {
-      url += `&limit=${encodeURIComponent(limit)}`;
+  GET_COLLECTION_FEATURED_OBJECTS(
+    collectionAbvName: string,
+    limit?: number,
+  ) {
+    if (typeof limit !== 'undefined') {
+      return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(
+        collectionAbvName,
+      )}&limit=${encodeURIComponent(limit)}`;
     }
-    return url;
+    return `${environment.apiURL}/featured/learning-objects?collection=${encodeURIComponent(collectionAbvName)}`;
   },
   /**
    * Request to update the list of featured learning objects

--- a/src/app/core/feature-module/featured.service.ts
+++ b/src/app/core/feature-module/featured.service.ts
@@ -22,7 +22,7 @@ export class FeaturedObjectsService {
   private _mutationError$ = new BehaviorSubject<boolean>(false);
   // Errors that occur if the featuredObjects array does not contain exactly 5 objects
   private _submitError$ = new BehaviorSubject<boolean>(false);
-  private featuredStore: { featured } = { featured: [] };
+  private featuredStore: { featured: any } = { featured: [] };
 
   private headers = new HttpHeaders();
   featuredObjectIds: string[];

--- a/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
+++ b/src/app/core/learning-object-module/learning-object/learning-object.routes.ts
@@ -97,7 +97,7 @@ export const LEARNING_OBJECT_ROUTES = {
     GET_MY_DRAFT_LEARNING_OBJECTS(username, filters, query) {
         return `${environment.apiURL}/users/${encodeURIComponent(
             username,
-        )}/learning-objects?draftsOnly=true&${querystring.stringify(filters, query)}`;
+        )}/learning-objects?draftsOnly=true&limit=200&${querystring.stringify(filters, query)}`;
     },
 
     /**

--- a/src/app/core/learning-object-module/revisions/revisions.service.ts
+++ b/src/app/core/learning-object-module/revisions/revisions.service.ts
@@ -1,9 +1,54 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { REVISION_ROUTES } from './revisions.routes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RevisionsService {
 
-  constructor() { }
+  constructor(private http: HttpClient) { }
+
+  /**
+   * Creates a Revision of an existing learning object
+   *
+   * @param cuid the CUID of the learning object to create a revision of
+   */
+  async createRevision(cuid: string): Promise<any> {
+    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
+    const response = await this.http
+      .post(route, {}, { withCredentials: true })
+      .pipe(catchError(this.handleError))
+      .toPromise();
+    return response;
+  }
+
+  /**
+   * Deletes a revision of a learning object. This is designed to allow an editor to create a new
+   * revision when it is necessary for the editorial process to continue.
+   *
+   * @param cuid cuid of the learning object
+   * @returns
+   */
+  deleteRevision(cuid: string, version: number) {
+    return this.http
+      .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
+        withCredentials: true,
+        responseType: 'text',
+      })
+      .pipe(catchError(this.handleError))
+      .toPromise();
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      // Client-side or network returned error
+      return throwError(error.error.message);
+    } else {
+      // API returned error
+      return throwError(error);
+    }
+  }
 }

--- a/src/app/core/learning-object-module/revisions/revisions.service.ts
+++ b/src/app/core/learning-object-module/revisions/revisions.service.ts
@@ -2,15 +2,15 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { REVISION_ROUTES } from './revisions.routes';
+import { REVISION_ROUTES } from '../revisions/revisions.routes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RevisionsService {
 
-  constructor(private http: HttpClient) { }
-
+  constructor(private http: HttpClient) {}
+  
   /**
    * Creates a Revision of an existing learning object
    *
@@ -29,10 +29,11 @@ export class RevisionsService {
    * Deletes a revision of a learning object. This is designed to allow an editor to create a new
    * revision when it is necessary for the editorial process to continue.
    *
+   * @param username username of the author
    * @param cuid cuid of the learning object
    * @returns
    */
-  deleteRevision(cuid: string, version: number) {
+  deleteRevision(username: string, cuid: string, version: number) {
     return this.http
       .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
         withCredentials: true,

--- a/src/app/core/learning-object-module/revisions/revisions.service.ts
+++ b/src/app/core/learning-object-module/revisions/revisions.service.ts
@@ -10,7 +10,7 @@ import { REVISION_ROUTES } from '../revisions/revisions.routes';
 export class RevisionsService {
 
   constructor(private http: HttpClient) {}
-  
+
   /**
    * Creates a Revision of an existing learning object
    *
@@ -33,7 +33,7 @@ export class RevisionsService {
    * @param cuid cuid of the learning object
    * @returns
    */
-  deleteRevision(username: string, cuid: string, version: number) {
+  deleteRevision(cuid: string, version: number) {
     return this.http
       .delete(REVISION_ROUTES.DELETE_REVISION(cuid, version), {
         withCredentials: true,

--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -8,6 +8,8 @@ import { AuthService } from '../auth-module/auth.service';
 import { BUNDLING_ROUTES } from '../learning-object-module/bundling/bundling.routes';
 import { LIBRARY_ROUTES } from './library.routes';
 
+export interface LibraryItem { _id: string, savedBy: string, savedOn: string, learningObject: LearningObject }
+
 const DEFAULT_BUNDLE_NAME = 'CLARK_LEARNING_OBJECT.zip';
 @Injectable({
   providedIn: 'root'
@@ -15,8 +17,7 @@ const DEFAULT_BUNDLE_NAME = 'CLARK_LEARNING_OBJECT.zip';
 export class LibraryService {
   private user;
   private headers = new HttpHeaders();
-  private cartItems: Array<any> = [];
-  public libraryItems: Array<LearningObject> = [];
+  public libraryItems: Array<LibraryItem> = [];
 
   // Observable boolean to toggle download spinner in components
   private _loading$ = new BehaviorSubject<boolean>(false);
@@ -26,33 +27,47 @@ export class LibraryService {
     return this._loading$.asObservable();
   }
 
-  constructor(private http: HttpClient, private auth: AuthService, public toaster: ToastrOvenService) {
+  constructor(
+    private http: HttpClient,
+    private auth: AuthService,
+    public toaster: ToastrOvenService
+  ) {
     this.updateUser();
   }
 
+  /**
+   * Method to update the user object and headers with the latest user information
+   */
   updateUser() {
     // get new user from auth service
     this.user = this.auth.user || undefined;
 
     // reset headers with new users auth token
     this.headers = new HttpHeaders();
-    // this.headers.append('Content-Type', 'application/json');
   }
 
-  async getLibrary(opts?: {
-    learningObjectCuid?: string, version?: number,
-    page?: number, limit?: number
-  }): Promise<{ cartItems: LearningObject[], lastPage: number }> {
+  /**
+   *
+   * @param opts
+   * @returns
+   */
+  async getLibrary(opts: {
+    learningObjectCuid?: string,
+    version?: number,
+    page?: number,
+    limit?: number
+  }): Promise<{ libraryItems: LibraryItem[], lastPage: number }> {
+    // Resets the auth token in the headers
     this.updateUser();
     if (!this.user) {
       return Promise.reject('User is undefined');
     }
 
     const query = new URLSearchParams({
-      page: opts?.page ? opts.page.toString() : '1',
-      limit: opts?.limit ? opts.limit.toString() : '10',
-      cuid: opts?.learningObjectCuid ? opts.learningObjectCuid : '',
-      version: opts?.version ? opts.version.toString() : '0'
+      page: opts.page ? opts.page.toString() : '1',
+      limit: opts.limit ? opts.limit.toString() : '10',
+      cuid: opts.learningObjectCuid ? opts.learningObjectCuid : '',
+      version: opts.version ? opts.version.toString() : '0'
     });
 
     return await this.http
@@ -66,15 +81,19 @@ export class LibraryService {
       .toPromise()
       .then((val: any) => {
         // preserves carts from cartsdb
-        this.cartItems = val.userLibraryItems;
         this.libraryItems = val.userLibraryItems
-          .map(object => {
-            if (object.learningObject) {
-              object.learningObject.id = object.learningObject._id;
-            }
-            return new LearningObject(object.learningObject);
+          .map((libraryItem) => {
+            const learningObject = new LearningObject(libraryItem.learningObject);
+            learningObject.id = libraryItem.learningObject?._id;
+
+            return {
+              _id: libraryItem._id,
+              savedBy: libraryItem.savedBy,
+              savedOn: libraryItem.savedOn,
+              learningObject
+            };
           });
-        return { cartItems: this.libraryItems, lastPage: val.lastPage };
+        return { libraryItems: this.libraryItems, lastPage: val.lastPage };
       });
   }
 
@@ -111,25 +130,20 @@ export class LibraryService {
       .toPromise();
   }
 
-  removeFromLibrary(learningObjectId: string): Promise<void> {
+  removeFromLibrary(libraryItemId: string): Promise<void> {
     if (!this.user) {
       return Promise.reject('User is undefined');
     }
-    const cartId = this.cartItems
-    .filter(cart => cart.learningObject && cart.learningObject._id === learningObjectId)
-    .map(cart => cart._id)[0];
+
     this.http
       .delete(
         LIBRARY_ROUTES.REMOVE_LEARNING_OBJECT_FROM_LIBRARY(
           this.user.username,
-          cartId
+          libraryItemId
         ),
         { headers: this.headers, withCredentials: true }
       )
-      .pipe(
-
-        catchError((error) => this.handleError(error))
-      )
+      .pipe(catchError((error) => this.handleError(error)))
       .toPromise();
   }
 
@@ -219,12 +233,15 @@ export class LibraryService {
       });
   }
 
-  has(object: LearningObject): boolean {
-    const inLibrary = this.libraryItems.filter(
-      o =>
-        o.cuid === object.cuid
-    ).length > 0;
-    return inLibrary;
+  /**
+   * Returns whether the learning object exists in the user's library
+   * This is done by checking the library items for the learningObjectId
+   *
+   * @param learningObjectId the learning object to check for in the library
+   * @returns whether the learning object exists in the library
+   */
+  has(learningObjectId: string): boolean {
+    return this.libraryItems.filter((libraryItem: LibraryItem) => libraryItem.learningObject.id === learningObjectId).length > 0;
   }
 
   /**
@@ -238,6 +255,7 @@ export class LibraryService {
     if (!contentDisposition) {
       return DEFAULT_BUNDLE_NAME;
     }
+
     // Split the content disposition header by semicolon
     const split = contentDisposition.split(';');
     for (const part of split) {
@@ -247,6 +265,7 @@ export class LibraryService {
         return value.replace(/"/g, '').trim();
       }
     }
+
     // Return default bundle name if no filename key found
     return DEFAULT_BUNDLE_NAME;
   }

--- a/src/app/core/report-module/report.routes.ts
+++ b/src/app/core/report-module/report.routes.ts
@@ -12,9 +12,7 @@ export const REPORT_ROUTES = {
     ) {
         let route = `${environment.apiURL}/reports?output=csv&collection=${collections.join(',')}`;
 
-        if (date) {
-            route += `&start=${date.start}&end=${date.end}`;
-        }
+        route += (date ? `&${new URLSearchParams(date).toString()}` : '');
 
         return route;
     }

--- a/src/app/core/report-module/report.service.ts
+++ b/src/app/core/report-module/report.service.ts
@@ -1,9 +1,50 @@
 import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { REPORT_ROUTES } from './report.routes';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ReportService {
 
-  constructor() { }
+  constructor(
+    private http: HttpClient,
+    private headers: HttpHeaders = new HttpHeaders()
+  ) {}
+
+  async generateCollectionReport(
+    collections: string[],
+    email: string,
+    name: string,
+    date?: {
+      start: string,
+      end: string
+    }) {
+    if (collections.length > 0) {
+      this.http
+        .post(REPORT_ROUTES.GENERATE_REPORT(collections, date),
+          {
+            email,
+            name
+          },
+          { headers: this.headers, withCredentials: true }
+        )
+        .pipe(
+          catchError(this.handleError)
+        )
+        .toPromise();
+    }
+  }
+
+  private handleError(error: HttpErrorResponse) {
+    if (error.error instanceof ErrorEvent) {
+      // Client-side or network returned error
+      return throwError(error.error.message);
+    } else {
+      // API returned error
+      return throwError(error);
+    }
+  }
 }

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -21,7 +21,6 @@ import { Router } from '@angular/router';
 import { LearningObjectService } from '../../../../../app/onion/core/learning-object.service';
 import { NavbarDropdownService } from '../../../../core/client-module/navBarDropdown.service';
 import { BUNDLING_ROUTES } from 'app/core/learning-object-module/bundling/bundling.routes';
-import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'cube-details-action-panel',
@@ -99,7 +98,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     this.url = this.buildLocation();
     // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
     await this.libraryService.getLibrary({ learningObjectCuid: this.learningObject.cuid, version: this.learningObject.version });
-    this.saved = this.libraryService.has(this.learningObject);
+    this.saved = this.libraryService.has(this.learningObject.id);
     this.getCollection();
     this.libraryService.loaded
       .subscribe(val => {
@@ -144,7 +143,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
       );
     }
     if (!this.userIsAuthor && this.isReleased) {
-      this.saved = this.libraryService.has(this.learningObject);
+      this.saved = this.libraryService.has(this.learningObject.id);
 
       if (!this.saved) {
         try {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -4,6 +4,7 @@ import { LearningObject } from '@entity';
 import { LearningObjectService } from 'app/cube/learning-object.service';
 import { LearningObjectService as LOUri } from 'app/core/learning-object-module/learning-object/learning-object.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 /**
  * EditorialActionPadComponent coordinates all editor functionality inside of the
@@ -30,6 +31,7 @@ export class EditorialActionPadComponent implements OnInit {
     private learningObjectService: LearningObjectService,
     private learningObjectServiceUri: LOUri,
     private toaster: ToastrOvenService,
+    private revisionsService: RevisionsService,
   ) { }
 
   async ngOnInit() {
@@ -82,7 +84,7 @@ export class EditorialActionPadComponent implements OnInit {
   async createRevision() {
     this.closeRevisionModal();
     this.toaster.success('One Moment Please', 'Your revision is being created.');
-    await this.learningObjectService
+    await this.revisionsService
       .createRevision(this.learningObject.cuid).then(async (revisionUri: any) => {
         this.revisedLearningObject = (await this.learningObjectServiceUri.fetchUri(revisionUri.revisionUri).toPromise())[0];
         this.router.navigate([`/onion/learning-object-builder/${this.revisedLearningObject.cuid}`]);

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Router } from '@angular/router';
 import { LearningObject } from '@entity';
-import { LearningObjectService } from 'app/cube/learning-object.service';
 import { LearningObjectService as LOUri } from 'app/core/learning-object-module/learning-object/learning-object.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
@@ -28,10 +27,9 @@ export class EditorialActionPadComponent implements OnInit {
 
   constructor(
     private router: Router,
-    private learningObjectService: LearningObjectService,
     private learningObjectServiceUri: LOUri,
     private toaster: ToastrOvenService,
-    private revisionsService: RevisionsService,
+    private revisionsService: RevisionsService
   ) { }
 
   async ngOnInit() {

--- a/src/app/cube/details/components/materials/materials.component.html
+++ b/src/app/cube/details/components/materials/materials.component.html
@@ -10,13 +10,13 @@
   <!-- </clark-carousel> -->
 
   <div>
-    <div *ngIf="((!materials.files || materials.files.length === 0) && materials.notes.length === 0 && materials.urls.length === 0)"
+    <div *ngIf="((!materials.files || materials.files?.length === 0) && materials.notes?.length === 0 && materials.urls?.length === 0)"
       class="materials__review-materials__empty-banner">
       <i class="fas fa-exclamation icon" style="font-size: 1.2rem;"></i>
       <p>This Learning Object has no materials attached.</p>
     </div>
 
-    <div class='materials__file-browser-container' *ngIf="materials.files && materials.files.length > 0">
+    <div class='materials__file-browser-container' *ngIf="materials.files && materials.files?.length > 0">
       <clark-file-browser *ngIf='materials?.files.length || materials.folderDescriptions?.length' [files$]="files$"
         [folderMeta$]="folderMeta$"></clark-file-browser>
       <p tab-index='0' class='materials__file-browser-container__empty-message'
@@ -24,12 +24,12 @@
         files or folders</p>
     </div>
 
-    <div class='materials__file-browser-container' *ngIf="materials.urls.length > 0">
+    <div class='materials__file-browser-container' *ngIf="materials.urls?.length > 0">
       <clark-urls [urls]='materials.urls'></clark-urls>
     </div>
 
 
-    <div class='materials__file-browser-container' *ngIf="materials.notes.length > 0">
+    <div class='materials__file-browser-container' *ngIf="materials.notes?.length > 0">
       <clark-notes [notes]='materials.notes'></clark-notes>
     </div>
   </div>

--- a/src/app/cube/learning-object.service.ts
+++ b/src/app/cube/learning-object.service.ts
@@ -10,8 +10,6 @@ import {
 import { Query } from '../interfaces/query';
 
 import { SEARCH_ROUTES } from 'app/core/learning-object-module/search/search.routes';
-import * as querystring from 'querystring';
-import { REVISION_ROUTES } from '../core/learning-object-module/revisions/revisions.routes';
 import { USER_ROUTES } from '../core/user-module/user.routes';
 
 // TODO: move to core module
@@ -132,20 +130,6 @@ export class LearningObjectService {
       .then((val: any) => {
         return val.map((l) => new LearningObject(l));
       });
-  }
-
-  /**
-   * Creates a Revision of an existing learning object
-   *
-   * @param cuid the CUID of the learning object to create a revision of
-   */
-  async createRevision(cuid: string): Promise<any> {
-    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
-    const response = await this.http
-      .post(route, {}, { withCredentials: true })
-      .pipe(catchError(this.handleError))
-      .toPromise();
-    return response;
   }
 
   private handleError(error: HttpErrorResponse) {

--- a/src/app/cube/learning-object.service.ts
+++ b/src/app/cube/learning-object.service.ts
@@ -10,6 +10,8 @@ import {
 import { Query } from '../interfaces/query';
 
 import { SEARCH_ROUTES } from 'app/core/learning-object-module/search/search.routes';
+import * as querystring from 'querystring';
+import { REVISION_ROUTES } from '../core/learning-object-module/revisions/revisions.routes';
 import { USER_ROUTES } from '../core/user-module/user.routes';
 
 // TODO: move to core module

--- a/src/app/cube/library/library.component.html
+++ b/src/app/cube/library/library.component.html
@@ -46,13 +46,13 @@
                 Saved Items
             </h2>
             <div *ngIf='libraryItems?.length; else emptyLibraryTemplate' class='library-items__list-items'>
-                <div *ngFor='let item of libraryItems; let i = index'>
+                <div *ngFor='let libraryItem of libraryItems; let i = index'>
                     <clark-library-item
-                        [learningObject]='item'
-                        [learningObjectAverageRating]='item.avgRating'
-                        (downloadButtonClicked)='downloadObject($event, item, i)'
-                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemToDelete = item;'
-                        (titleClicked)='goToItem(item)'
+                        [learningObject]='libraryItem.learningObject'
+                        [learningObjectAverageRating]='libraryItem.avgRating'
+                        (downloadButtonClicked)='downloadObject($event, libraryItem.learningObject, i)'
+                        (deleteButtonClicked)='toggleDeleteLibraryItemModal(true); libraryItemIdToDelete = libraryItem._id;'
+                        (titleClicked)='goToItem(libraryItem.learningObject)'
                         [currIndex]='currentIndex'
                         [myIndex]=i
                     ></clark-library-item>

--- a/src/app/cube/library/library.component.ts
+++ b/src/app/cube/library/library.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, HostListener, ChangeDetectorRef, ViewChild, ElementRef } from '@angular/core';
-import { LibraryService } from 'app/core/library-module/library.service';
+import { LibraryItem, LibraryService } from 'app/core/library-module/library.service';
 import { LearningObject } from 'entity/learning-object/learning-object';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { Subject } from 'rxjs';
@@ -47,7 +47,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   @ViewChild('savedList') topOfList: ElementRef;
   loading: boolean;
   serviceError: boolean;
-  libraryItems: LearningObject[] = [];
+  libraryItems: LibraryItem[] = [];
   downloading = [];
   currentIndex = null;
   destroyed$ = new Subject<void>();
@@ -62,7 +62,7 @@ export class LibraryComponent implements OnInit, OnDestroy {
   showDeleteLibraryItemModal = false;
   changelogs = [];
   changelogLearningObject;
-  libraryItemToDelete;
+  libraryItemIdToDelete: string;
   lastPageNumber;
   currentPageNumber = 1;
   currentNotificationsPageNumber = 1;
@@ -124,17 +124,20 @@ export class LibraryComponent implements OnInit, OnDestroy {
   async loadLibrary() {
     try {
       this.loading = true;
-      const libraryItemInformation = await this.libraryService.getLibrary({page: this.currentPageNumber, limit: 10});
-      this.libraryItems = libraryItemInformation.cartItems;
-      this.lastPageNumber = libraryItemInformation.lastPage;
-      this.libraryItems.map(async (libraryItem: LearningObject) => {
-        const ratings = await this.getRatings(libraryItem);
+      const getLibraryResponse = await this.libraryService.getLibrary({page: this.currentPageNumber, limit: 10});
+
+      this.libraryItems = getLibraryResponse.libraryItems;
+      this.lastPageNumber = getLibraryResponse.lastPage;
+
+      this.libraryItems.map(async (libraryItem: LibraryItem) => {
+        const ratings = await this.getRatings(libraryItem.learningObject);
         if (ratings) {
           libraryItem['avgRating'] = ratings.avgValue;
         }
       });
       this.loading = false;
     } catch (e) {
+      console.log(e);
       this.toaster.error('Error!', 'Unable to load your library. Please try again later.');
       this.serviceError = true;
       this.loading = false;
@@ -224,8 +227,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async removeItem() {
     try {
-      await this.libraryService.removeFromLibrary(this.libraryItemToDelete.id);
-      this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).cartItems;
+      await this.libraryService.removeFromLibrary(this.libraryItemIdToDelete);
+      this.libraryItems = (await this.libraryService.getLibrary({page: 1, limit: 10})).libraryItems;
       this.changeLibraryItemPage(this.currentPageNumber);
       this.showDeleteLibraryItemModal = false;
     } catch (e) {
@@ -310,10 +313,8 @@ export class LibraryComponent implements OnInit, OnDestroy {
 
   async changeLibraryItemPage(pageNumber: number) {
     this.topOfList.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    const libraryItemInformation = await this.libraryService.getLibrary({page: pageNumber, limit: 10});
-    this.libraryItems = libraryItemInformation.cartItems;
-    this.lastPageNumber = libraryItemInformation.lastPage;
     this.currentPageNumber = pageNumber;
+    await this.loadLibrary();
   }
 
   ngOnDestroy() {

--- a/src/app/onion/core/learning-object.service.ts
+++ b/src/app/onion/core/learning-object.service.ts
@@ -12,7 +12,6 @@ import { FileUploadMeta } from '../learning-object-builder/components/content-up
 import { SUBMISSION_ROUTES } from '../../core/learning-object-module/submissions/submissions.routes';
 import { BUNDLING_ROUTES } from '../../core/learning-object-module/bundling/bundling.routes';
 import { OUTCOME_ROUTES } from '../../core/learning-object-module/outcomes/outcome.routes';
-import { REVISION_ROUTES } from '../../core/learning-object-module/revisions/revisions.routes';
 import { FILE_ROUTES } from '../../core/learning-object-module/file/file.routes';
 import {
   LEGACY_USER_ROUTES,
@@ -122,27 +121,6 @@ export class LearningObjectService {
     // TODO: Verify this response gives the learning object name
   }
 
-  /**
-   * Creates a Revision of an existing learning object
-   *
-   * @param learningObjectId
-   * @param authorUsername
-   */
-  createRevision(cuid: string) {
-    const route = REVISION_ROUTES.CREATE_REVISION(cuid);
-    return this.http
-      .post(
-        route, {},
-        { withCredentials: true }
-      )
-      .pipe(
-
-        catchError(this.handleError)
-      )
-      .toPromise().then(response => {
-        return response;
-      });
-  }
   /**
    * Fetches Learning Object by ID (full)
    *

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -12,6 +12,7 @@ import { ChangelogService } from 'app/core/learning-object-module/changelog/chan
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { takeUntil, take } from 'rxjs/operators';
 import { SubmissionsService } from 'app/core/learning-object-module/submissions/submissions.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
 
 @Component({
   selector: 'clark-dashboard',
@@ -84,7 +85,8 @@ export class DashboardComponent implements OnInit, OnDestroy {
     private changelogService: ChangelogService,
     public notificationService: ToastrOvenService,
     private cd: ChangeDetectorRef,
-    private submissionService: SubmissionsService
+    private submissionService: SubmissionsService,
+    private revisionsService: RevisionsService,
   ) {
     this.navbar.hide();
   }
@@ -353,7 +355,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   }
 
   createRevision(object: LearningObject) {
-    this.sidePanelPromiseResolver = this.learningObjectService.createRevision(object.cuid).then(() => {
+    this.sidePanelPromiseResolver = this.revisionsService.createRevision(object.cuid).then(() => {
       this.getReleasedLearningObjects({ status: LearningObject.Status.RELEASED });
     });
   }

--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -7,7 +7,6 @@ import { LearningObjectService } from '../core/learning-object.service';
 import { AuthService } from 'app/core/auth-module/auth.service';
 import { Subject, BehaviorSubject } from 'rxjs';
 import { trigger, transition, style, animate } from '@angular/animations';
-import { CollectionService } from 'app/core/collection-module/collections.service';
 import { ChangelogService } from 'app/core/learning-object-module/changelog/changelog.service';
 import { ToastrOvenService } from 'app/shared/modules/toaster/notification.service';
 import { takeUntil, take } from 'rxjs/operators';

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -23,7 +23,6 @@ import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 import { SubmissionsService } from 'app/core/learning-object-module/submissions/submissions.service';
 import { OutcomeService } from 'app/core/learning-object-module/outcomes/outcome.service';
 import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
-import { Revision } from 'aws-sdk/clients/codepipeline';
 
 /**
  * Defines a list of actions the builder can take
@@ -157,7 +156,7 @@ export class BuilderStore {
     private uriRetriever: UriRetrieverService,
     private submissionService: SubmissionsService,
     private outcomeService: OutcomeService,
-    private revisionsService: RevisionsService,
+    private revisionsSerivce: RevisionsService,
   ) {
     // subscribe to our objectCache$ observable and initiate calls to save object after a debounce
     this.objectCache$
@@ -256,7 +255,7 @@ export class BuilderStore {
     async () => {
       // eslint-disable-next-line eqeqeq
       if (revisionId == 0) {
-        revisionId = await this.revisionsService.createRevision(cuid);
+        revisionId = await this.revisionsSerivce.createRevision(cuid);
       }
 
       return this.learningObjectService.getLearningObjectRevision(username, cuid, revisionId);

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -22,6 +22,8 @@ import { v4 as uuidv4 } from 'uuid';
 import { DirectoryNode } from 'app/shared/modules/filesystem/DirectoryNode';
 import { SubmissionsService } from 'app/core/learning-object-module/submissions/submissions.service';
 import { OutcomeService } from 'app/core/learning-object-module/outcomes/outcome.service';
+import { RevisionsService } from 'app/core/learning-object-module/revisions/revisions.service';
+import { Revision } from 'aws-sdk/clients/codepipeline';
 
 /**
  * Defines a list of actions the builder can take
@@ -155,6 +157,7 @@ export class BuilderStore {
     private uriRetriever: UriRetrieverService,
     private submissionService: SubmissionsService,
     private outcomeService: OutcomeService,
+    private revisionsService: RevisionsService,
   ) {
     // subscribe to our objectCache$ observable and initiate calls to save object after a debounce
     this.objectCache$
@@ -253,7 +256,7 @@ export class BuilderStore {
     async () => {
       // eslint-disable-next-line eqeqeq
       if (revisionId == 0) {
-        revisionId = await this.learningObjectService.createRevision(cuid);
+        revisionId = await this.revisionsService.createRevision(cuid);
       }
 
       return this.learningObjectService.getLearningObjectRevision(username, cuid, revisionId);

--- a/src/app/onion/learning-object-builder/learning-object-builder.component.ts
+++ b/src/app/onion/learning-object-builder/learning-object-builder.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { NavbarService } from '../../core/client-module/navbar.service';
 import { BuilderStore, BUILDER_ERRORS } from './builder-store.service';
 import { ActivatedRoute, Router } from '@angular/router';
-
 import { Subject } from 'rxjs';
 import {
   trigger,


### PR DESCRIPTION
- Removed and updated the routes to point to revisions.service.ts. Opted to choose the async createRevision function over the series of then statements. Got rid of unused parameter for deleteRevision in the service. Updated all function calls.
- Removed username parameter in learning-object-list-item.component.ts since it is unused