### PR TITLE
Relevancy module route updates

### DIFF
--- a/src/app/core/learning-object-module/relevancy/relevancy.routes.ts
+++ b/src/app/core/learning-object-module/relevancy/relevancy.routes.ts
@@ -31,33 +31,11 @@ export const RELEVANCY_ROUTES = {
         return `${environment.apiURL}/learning-objects/evaluators`;
     },
     /**
-     * Request to add date of when a learning object was last evaluated
-     * @param username - The username of the author of the learning object
-     * @param cuid - The cuid of the learning object to update
-     * @auth required
-     * @method PATCH
-     */
-    ADD_EVALUATION_DATE(username: string, cuid: string) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            username
-        )}/learning-objects/${encodeURIComponent(cuid)}/evaluation`;
-    },
-    /**
      * Request to update evaluators of a learning object
      * @auth required
      * @method PATCH
      */
     UPDATE_EVALUATORS() {
         return `${environment.apiURL}/learning-objects/evaluators`;
-    },
-    /**
-     * Request to get evaluations for a user
-     * @param username - The username of the evaluator
-     * @method GET
-     */
-    GET_EVALUATIONS(username: string) {
-        return `${environment.apiURL}/users/${encodeURIComponent(
-            username
-        )}/evaluations`;
     },
 };


### PR DESCRIPTION
Removed both `ADD_EVALUATION_DATE` and `GET_EVALUATIONS` because they're not implemented in clark-service