### PR TITLE
fixes the learning outcome id issue

### DIFF
--- a/src/app/core/learning-object-module/outcomes/outcome.service.ts
+++ b/src/app/core/learning-object-module/outcomes/outcome.service.ts
@@ -20,7 +20,7 @@ export class OutcomeService {
   /**
    * Create an outcome for a source learning object
    *
-   * @param {LearningObject} source the learningObject
+   * @param {LearningObject} source the learningObject id
    * @param {LearningOutcome} outcome
    * @param username The username of the learning object author
    * @memberof LearningObjectService
@@ -33,7 +33,6 @@ export class OutcomeService {
         {
           headers: this.headers,
           withCredentials: true,
-          responseType: 'text'
         }
       )
       .pipe(
@@ -50,7 +49,7 @@ export class OutcomeService {
    * @memberof LearningObjectService
    */
   saveOutcome(
-    outcome: { id: string;[key: string]: any }
+    outcome: { id: string; [key: string]: any }
   ): Promise<any> {
     const outcomeId = outcome.id;
     delete outcome.id;

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -1103,16 +1103,20 @@ export class BuilderStore {
 
     this.outcomeService
       .addLearningOutcome(this.learningObject.id, newOutcome)
-      .then((serviceId: string) => {
+      .then((response: { id: string }) => {
         this.serviceInteraction$.next(false);
+
         // delete the id from the newOutcomes map so that the next time it's modified, we know to save it instead of creating it
         this.newOutcomes.delete(newOutcome.id);
+        
         // retrieve the outcome from the map keyed by it's temp ID, and then delete that entry;
         const outcome: Partial<LearningOutcome> & {
           serviceId?: string;
         } = this.outcomes.get(newOutcome.id);
+
         // store the temporary id in the outcome so that the page component know's which outcome to keep focused
-        outcome.serviceId = serviceId;
+        outcome.serviceId = response.id;
+        
         // re-enter outcome into map
         this.outcomes.set(newOutcome.id, outcome);
         this.outcomeEvent.next(this.outcomes);

--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -1108,7 +1108,7 @@ export class BuilderStore {
 
         // delete the id from the newOutcomes map so that the next time it's modified, we know to save it instead of creating it
         this.newOutcomes.delete(newOutcome.id);
-        
+
         // retrieve the outcome from the map keyed by it's temp ID, and then delete that entry;
         const outcome: Partial<LearningOutcome> & {
           serviceId?: string;
@@ -1116,7 +1116,7 @@ export class BuilderStore {
 
         // store the temporary id in the outcome so that the page component know's which outcome to keep focused
         outcome.serviceId = response.id;
-        
+
         // re-enter outcome into map
         this.outcomes.set(newOutcome.id, outcome);
         this.outcomeEvent.next(this.outcomes);


### PR DESCRIPTION
The backend returns { id: string } not string now, also we were using 'text' instead of our default 'json' return type for http responses which was causing issues.