### PR TITLE
Fixing a bug in determining whether we need a changelog

### DIFF
--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -266,12 +266,10 @@ export class SubmitComponent implements OnInit {
    */
   getCollectionSelected(collection: string) {
     this.submissionService.getFirstSubmission(this.learningObject.id, collection)
-      .then(val => {
+      .then(response => {
         this.collection = collection;
         // If the learning object has been submitted before then it needs a changelog
-        if (!val.isFirstSubmission) {
-          this.needsChangelog = true;
-        }
+        this.needsChangelog = !response.isFirstSubmission;
       });
   }
 

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -268,9 +268,9 @@ export class SubmitComponent implements OnInit {
     this.submissionService.getFirstSubmission(this.learningObject.id, collection)
       .then(val => {
         this.collection = collection;
+        // If the learning object has been submitted before then it needs a changelog
         if (!val.isFirstSubmission) {
-          // if this is a first submission there is no need for a change log
-          this.needsChangelog = false;
+          this.needsChangelog = true;
         }
       });
   }


### PR DESCRIPTION
We never were able to set needs changelog to true since it defaults to false. 