### PR TITLE
fix: [sc-32930] Add support for username on admin dashboard

### DIFF
--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -22,10 +22,11 @@ import { UserService } from 'app/core/user-module/user.service';
   selector: 'clark-learning-objects',
   templateUrl: './learning-objects.component.html',
   styleUrls: ['./learning-objects.component.scss'],
-  providers: [PublicLearningObjectService]
+  providers: [PublicLearningObjectService],
 })
 export class LearningObjectsComponent
-  implements OnInit, OnDestroy, AfterViewInit {
+  implements OnInit, OnDestroy, AfterViewInit
+{
   @ViewChild('list') listElement: ElementRef<HTMLElement>;
   @ViewChild('headers') headersElement: ElementRef<HTMLElement>;
 
@@ -93,7 +94,9 @@ export class LearningObjectsComponent
 
     if (this.isCurator && !this.isAdminOrEditor) {
       // Get first curator access group only
-      const curatorAccessGroup = this.auth.accessGroups.find(accessGroup => accessGroup.includes('curator'));
+      const curatorAccessGroup = this.auth.accessGroups.find((accessGroup) =>
+        accessGroup.includes('curator'),
+      );
 
       // Split to get collection name
       const collection = curatorAccessGroup.split('@');
@@ -101,52 +104,54 @@ export class LearningObjectsComponent
       // If the curator access group has a collection then we want to
       // set the query to that collection
       if (collection.length === 2) {
-
         // Verify that the current user is actually a curator for the collection
         // before setting the query to the collection. This is to prevent users
         // from updating the access groups on the browser and getting access to
         // collections they are not supposed to have access to.
-        this.userService.searchUsers({ accessGroups: [curatorAccessGroup] })
+        this.userService
+          .searchUsers({ accessGroups: [curatorAccessGroup] })
           .then((curators) => {
-            curators.forEach(curator => {
+            curators.forEach((curator) => {
               if (curator.username === this.auth.user.username) {
                 this.query = {
-                  collection: collection[1]
+                  collection: collection[1],
                 };
               }
             });
           });
       } else {
-        console.warn(`Curator access group is not formatted correctly: ${curatorAccessGroup}`);
+        console.warn(
+          `Curator access group is not formatted correctly: ${curatorAccessGroup}`,
+        );
       }
     }
 
     // query by anything if it's passed in
     // reset page to 1 since we can't scroll backwards
-    this.route.queryParams.subscribe(params => {
+    this.route.queryParams.subscribe((params) => {
       this.query = {
         ...params,
-        currPage: (params.currPage && !isNaN(params.currPage)) ? parseInt(params.currPage, 10) : 1,
-       };
+        currPage:
+          params.currPage && !isNaN(params.currPage)
+            ? parseInt(params.currPage, 10)
+            : 1,
+      };
     });
 
     // listen for input events from the search component and perform the search action
     this.userSearchInput$
-      .pipe(
-        takeUntil(this.componentDestroyed$),
-        debounceTime(650)
-      )
-      .subscribe(async searchTerm => {
+      .pipe(takeUntil(this.componentDestroyed$), debounceTime(650))
+      .subscribe(async (searchTerm) => {
         this.query = { currPage: 1, text: searchTerm };
         if (!searchTerm || searchTerm.length <= 0) {
           this.query = {
             sortType: SortType.Descending,
-            orderBy: OrderBy.Date
+            orderBy: OrderBy.Date,
           };
         } else {
           this.query = {
             sortType: undefined,
-            orderBy: undefined
+            orderBy: undefined,
           };
         }
         this.learningObjects = [];
@@ -170,9 +175,12 @@ export class LearningObjectsComponent
   }
 
   changePage(pageNum) {
-    this.listElement.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'start'});
+    this.listElement.nativeElement.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
     this.query = {
-      currPage: pageNum
+      currPage: pageNum,
     };
     this.getLearningObjects();
   }
@@ -194,14 +202,11 @@ export class LearningObjectsComponent
       this.allResultsReceived = false;
     }
 
-    this.router.navigate(
-      [],
-      {
-        queryParams: { ...this.query },
-        relativeTo: this.route,
-        replaceUrl: true
-      }
-    );
+    this.router.navigate([], {
+      queryParams: { ...this.query },
+      relativeTo: this.route,
+      replaceUrl: true,
+    });
   }
 
   /**
@@ -217,7 +222,7 @@ export class LearningObjectsComponent
 
       await this.publicLearningObjectService
         .getLearningObjects(this.query)
-        .then(val => {
+        .then((val) => {
           this.learningObjects = val.learningObjects;
 
           if (this.learningObjects.length === val.total) {
@@ -225,10 +230,10 @@ export class LearningObjectsComponent
           }
           this.lastPage = Math.ceil(val.total / 20);
         })
-        .catch(error => {
+        .catch((error) => {
           this.toaster.error(
             'Error!',
-            'There was an error fetching Learning Objects. Please try again later.'
+            'There was an error fetching Learning Objects. Please try again later.',
           );
         })
         .finally(() => {
@@ -256,17 +261,17 @@ export class LearningObjectsComponent
    * @param direction the direction of the sort (ASC or DESC)
    */
   sortByDate() {
-    if(!this.query.sortType) {
+    if (!this.query.sortType) {
       this.query = {
         sortType: SortType.Descending,
-        orderBy: OrderBy.Date
+        orderBy: OrderBy.Date,
       };
     } else if (this.query.sortType.toString() === '-1') {
       this.query.sortType = SortType.Ascending;
     } else if (this.query.sortType.toString() === '1') {
       this.query = {
         sortType: undefined,
-        orderBy: undefined
+        orderBy: undefined,
       };
     }
 
@@ -294,7 +299,11 @@ export class LearningObjectsComponent
    */
 
   getRelevancyFilteredLearningObjects(dates: any) {
-    this.query = { startNextCheck: dates.start, endNextCheck: dates.end, currPage: 1};
+    this.query = {
+      startNextCheck: dates.start,
+      endNextCheck: dates.end,
+      currPage: 1,
+    };
     this.learningObjects = [];
 
     this.getLearningObjects();
@@ -335,7 +344,10 @@ export class LearningObjectsComponent
     if (this.allSelected) {
       this.selected = new Map(
         // @ts-ignore
-        this.learningObjects.map((learningObject) => [learningObject.id, learningObject])
+        this.learningObjects.map((learningObject) => [
+          learningObject.id,
+          learningObject,
+        ]),
       );
       this.selectedLearningObjects = this.learningObjects;
       this.cd.detectChanges();
@@ -345,21 +357,21 @@ export class LearningObjectsComponent
     }
   }
 
-   /**
-    * Decides based on the value whether to select or deselect the learning object
-    *
-    * @param l learning object to be selected
-    * @param value boolean, true if object is selected, false otherwise
-    */
-  toggleSelect(l: LearningObject, value: boolean ) {
+  /**
+   * Decides based on the value whether to select or deselect the learning object
+   *
+   * @param l learning object to be selected
+   * @param value boolean, true if object is selected, false otherwise
+   */
+  toggleSelect(l: LearningObject, value: boolean) {
     value ? this.selectLearningObject(l) : this.deselectLearningObject(l);
   }
 
-    /**
-     * Fired on select of a Learning Object, takes the object and either adds to the list of selected Learning Objects
-     *
-     * @param l Learning Object to be selected
-     */
+  /**
+   * Fired on select of a Learning Object, takes the object and either adds to the list of selected Learning Objects
+   *
+   * @param l Learning Object to be selected
+   */
   selectLearningObject(l: LearningObject) {
     this.selected.set(l.id, l);
     this.selectedLearningObjects.push(l);

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -26,7 +26,8 @@ import { SearchService } from 'app/core/learning-object-module/search/search.ser
   styleUrls: ['./learning-objects.component.scss'],
   providers: [PublicLearningObjectService],
 })
-export class LearningObjectsComponent implements OnInit, OnDestroy, AfterViewInit {
+export class LearningObjectsComponent
+  implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('list') listElement: ElementRef<HTMLElement>;
   @ViewChild('headers') headersElement: ElementRef<HTMLElement>;
 
@@ -217,17 +218,6 @@ export class LearningObjectsComponent implements OnInit, OnDestroy, AfterViewIni
    * @memberof LearningObjectsComponent
    */
   async getLearningObjects() {
-    const allStatuses = [
-      'UNRELEASED',
-      'WAITING',
-      'REVIEW',
-      'ACCEPTED_MAJOR',
-      'ACCEPTED_MINOR',
-      'PROOFING',
-      'REJECTED',
-      'RELEASED',
-    ];
-
     if (!this.allResultsReceived) {
       // we know there are more objects to pull
       this.loading = true;
@@ -236,8 +226,10 @@ export class LearningObjectsComponent implements OnInit, OnDestroy, AfterViewIni
         await this.searchService
           .getUsersLearningObjects(this.query.username, {
             ...this.query,
-            // too lazy to lowercase allStatuses values
-            status: allStatuses.map((v) => v.toLowerCase()),
+            // "all" is not a valid status
+            status: Object.values(LearningObject.Status).filter(
+              (v) => v !== 'all',
+            ),
           })
           .then((val) => {
             this.learningObjects = [...val.objects];

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -238,8 +238,6 @@ export class LearningObjectsComponent implements OnInit, OnDestroy, AfterViewIni
             ...this.query,
             // too lazy to lowercase allStatuses values
             status: allStatuses.map((v) => v.toLowerCase()),
-            // TODO: prefer currPage on clark-service
-            page: this.query.currPage,
           })
           .then((val) => {
             this.learningObjects = [...val.objects];

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -26,9 +26,7 @@ import { SearchService } from 'app/core/learning-object-module/search/search.ser
   styleUrls: ['./learning-objects.component.scss'],
   providers: [PublicLearningObjectService],
 })
-export class LearningObjectsComponent
-  implements OnInit, OnDestroy, AfterViewInit
-{
+export class LearningObjectsComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('list') listElement: ElementRef<HTMLElement>;
   @ViewChild('headers') headersElement: ElementRef<HTMLElement>;
 

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -27,8 +27,7 @@ import { SearchService } from 'app/core/learning-object-module/search/search.ser
   providers: [PublicLearningObjectService],
 })
 export class LearningObjectsComponent
-  implements OnInit, OnDestroy, AfterViewInit
-{
+  implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('list') listElement: ElementRef<HTMLElement>;
   @ViewChild('headers') headersElement: ElementRef<HTMLElement>;
 

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -27,7 +27,8 @@ import { SearchService } from 'app/core/learning-object-module/search/search.ser
   providers: [PublicLearningObjectService],
 })
 export class LearningObjectsComponent
-  implements OnInit, OnDestroy, AfterViewInit {
+  implements OnInit, OnDestroy, AfterViewInit
+{
   @ViewChild('list') listElement: ElementRef<HTMLElement>;
   @ViewChild('headers') headersElement: ElementRef<HTMLElement>;
 
@@ -226,11 +227,10 @@ export class LearningObjectsComponent
         await this.searchService
           .getUsersLearningObjects(this.query.username, {
             ...this.query,
-            // "all" is not a valid status
-            status: Object.values(LearningObject.Status).filter(
-              (v) => v !== 'all',
-            ),
-          })
+            status: Object.values(LearningObject.Status)
+              // "all" is not a valid status
+              .filter((v) => v !== 'all'),
+            })
           .then((val) => {
             this.learningObjects = val.objects;
 

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -232,7 +232,7 @@ export class LearningObjectsComponent
             ),
           })
           .then((val) => {
-            this.learningObjects = [...val.objects];
+            this.learningObjects = val.objects;
 
             if (this.learningObjects.length === val.total) {
               this.allResultsReceived = true;

--- a/src/app/core/learning-object-module/search/search.routes.ts
+++ b/src/app/core/learning-object-module/search/search.routes.ts
@@ -1,4 +1,5 @@
 import { environment } from '../../../../environments/environment';
+import * as querystring from 'querystring';
 
 export const SEARCH_ROUTES = {
   GET_PUBLIC_LEARNING_OBJECTS: `${environment.apiURL}/learning-objects`,
@@ -10,9 +11,10 @@ export const SEARCH_ROUTES = {
    * Request to retrieve a user's learning objects
    * @method GET
    * @param user the username or userId of the user
+   * @param query the query filters to apply to the search
    * @returns the learning objects
    */
-  GET_USER_LEARNING_OBJECTS(user: string) {
-    return `${environment.apiURL}/users/${encodeURIComponent(user)}/learning-objects`;
+  GET_USER_LEARNING_OBJECTS(user: string, query: any) {
+    return `${environment.apiURL}/users/${encodeURIComponent(user)}/learning-objects?${querystring.stringify(query)}`;
   },
 };

--- a/src/app/core/learning-object-module/search/search.service.ts
+++ b/src/app/core/learning-object-module/search/search.service.ts
@@ -11,15 +11,19 @@ import { catchError } from 'rxjs/operators';
 export class SearchService {
   constructor(private http: HttpClient) {}
 
-  getUsersLearningObjects(username: string): Promise<LearningObject[]> {
+  getUsersLearningObjects(
+    username: string,
+    query?: any,
+    draftsOnly?: boolean,
+  ): Promise<{ objects: LearningObject[]; total: number }> {
     return this.http
-      .get(SEARCH_ROUTES.GET_USER_LEARNING_OBJECTS(username), {
+      .get(SEARCH_ROUTES.GET_USER_LEARNING_OBJECTS(username, query), {
         withCredentials: true,
       })
       .pipe(catchError(this.handleError))
       .toPromise()
       .then((val: any) => {
-        return val.objects.map((r) => new LearningObject(r));
+        return val;
       });
   }
 

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -29,6 +29,7 @@ export interface Query {
   startNextCheck?: string;
   endNextCheck?: string;
   topics?: string[];
+  username?: string;
 }
 
 export interface MappingQuery extends Query {

--- a/src/app/shared/components/user-card/user-card.component.ts
+++ b/src/app/shared/components/user-card/user-card.component.ts
@@ -36,7 +36,7 @@ export class UserCardComponent implements OnInit, OnChanges {
   }
 
   async fetchLearningObjects() {
-    this.objects = await this.searchService.getUsersLearningObjects(this.user.username);
+    this.objects = (await this.searchService.getUsersLearningObjects(this.user.username)).objects;
   }
 
   showGravatarModal(e: Event) {


### PR DESCRIPTION
This PR adds support for querying a user's learning objects with a username query. The admin "users" page utilizes this functionality.

Story details: https://app.shortcut.com/clarkcan/story/32930