### PR TITLE
Fix broken preview URL being generated

### DIFF
--- a/src/app/core/learning-object-module/file/file.service.ts
+++ b/src/app/core/learning-object-module/file/file.service.ts
@@ -47,7 +47,7 @@ export class FileService {
         responseType: 'blob'
       })
       .pipe(catchError(this.handleError))
-      .toPromise()  
+      .toPromise()
       .then((blob) => window.URL.createObjectURL(blob));
   }
 

--- a/src/app/core/learning-object-module/file/file.service.ts
+++ b/src/app/core/learning-object-module/file/file.service.ts
@@ -42,12 +42,12 @@ export class FileService {
    * @returns the blob url of the file
    */
   async previewLearningObjectFile(url: string): Promise<string> {
-    return fetch(url, {
-        headers: {
-          Authorization: this.headers.get('Authorization')
-        }
+    return this.http.get(url, {
+        withCredentials: true,
+        responseType: 'blob'
       })
-      .then((response) => response.blob())
+      .pipe(catchError(this.handleError))
+      .toPromise()  
       .then((blob) => window.URL.createObjectURL(blob));
   }
 

--- a/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
+++ b/src/app/shared/modules/filesystem/file-list-view/file-list-view.component.ts
@@ -113,10 +113,11 @@ export class FileListViewComponent implements OnInit, OnDestroy {
    * @param {LearningObject.Material.File} file
    * @memberof FileListViewComponent
    */
-  openFile(file: LearningObject.Material.File): void {
+  async openFile(file: LearningObject.Material.File): Promise<void> {
     const url = this.auth.isLoggedIn.value ? file.previewUrl : '';
     if (url) {
-      window.open(url, '_blank');
+      const previewUrl = await this.fileService.previewLearningObjectFile(url);
+      window.open(previewUrl, '_blank');
       this.preview = true;
     } else {
       this.file = file;


### PR DESCRIPTION
Hopefully this fixes the CORS issue...

Kinda hard to replicate CORS locally. This fix at-least will authenticate the request to preview and return the blob then the client will render the blob in a new tab.