### PR TITLE
bug: [sc-33807] No children returned in learning object builder

### DIFF
--- a/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
+++ b/src/app/onion/learning-object-builder/components/scaffold/add-child/add-child.component.ts
@@ -53,7 +53,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
   async getLearningObjects(filters?: any, query?: string): Promise<LearningObject[]> {
     this.loading = true;
     const draftObjects = await this.searchLearningObjectService
-      .getUsersLearningObjects(this.child.author.username, { ...filters, text: query })
+      .getUsersLearningObjects(this.child.author.username, { ...filters, text: query ?? '' })
       .then((response: { learningObjects: LearningObject[], total: number }) => {
         const indx = this.lengths.indexOf(this.child.length);
         const childrenLengths = this.lengths.slice(0, indx);
@@ -63,7 +63,7 @@ export class AddChildComponent implements OnInit, OnDestroy {
       });
 
     const releasedObjects = await this.searchLearningObjectService
-      .getLearningObjects({ ...filters, text: query, childId: this.child.id })
+      .getLearningObjects({ ...filters, text: query ?? '', childId: this.child.id })
       .then((response: { learningObjects: LearningObject[], total: number }) => {
         let { learningObjects } = response;
         const indx = this.lengths.indexOf(this.child.length);


### PR DESCRIPTION
The text parameter was set as "undefined" which returns... nothing because there's no LOs with "undefined" in them. Now, if the text truly is undefined, we return an empty string.

This fixes the issue where no objects are returned when there is no input text.

https://app.shortcut.com/clarkcan/story/33807/no-children-returned-in-learning-object-builder