### PR TITLE
fix: [sc-34004] Changelog modal appears on first submission of a learning object

### DIFF
--- a/src/app/core/learning-object-module/submissions/submissions.service.ts
+++ b/src/app/core/learning-object-module/submissions/submissions.service.ts
@@ -81,7 +81,7 @@ export class SubmissionsService {
    */
   getFirstSubmission(learningObjectId: string, collection: string) {
     return this.http
-      .get<{ isFirstSubmission: boolean }>(
+      .get<{ firstSubmission: boolean }>(
         SUBMISSION_ROUTES.CHECK_FIRST_SUBMISSION({
           learningObjectId,
           query: {

--- a/src/app/onion/shared/submit/submit.component.ts
+++ b/src/app/onion/shared/submit/submit.component.ts
@@ -269,7 +269,7 @@ export class SubmitComponent implements OnInit {
       .then(response => {
         this.collection = collection;
         // If the learning object has been submitted before then it needs a changelog
-        this.needsChangelog = !response.isFirstSubmission;
+        this.needsChangelog = !response.firstSubmission;
       });
   }
 


### PR DESCRIPTION
Our first submission check was expecting `isFirstSubmission`, not `firstSubmission`. This is fixed now.

Story details: https://app.shortcut.com/clarkcan/story/34004/changelog-modal-appears-on-first-submission-of-a-learning-object