### PR TITLE
fix: [sc-32498] First contributor removed in builder when enter is clicked

### DIFF
--- a/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
+++ b/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
@@ -1,7 +1,7 @@
 <div class="contributor-pill">
   <div class="contributor-pill__name">
     {{ user.name | titlecase }}
-    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (activate)="removeContributor.emit(user)">
+    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)">
       <i class="far fa-trash-alt"></i>
     </button>
   </div>

--- a/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
+++ b/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
@@ -1,7 +1,7 @@
 <div class="contributor-pill">
   <div class="contributor-pill__name">
     {{ user.name | titlecase }}
-    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)">
+    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)" (keydown.enter)="removeContributor.emit($event)">
       <i class="far fa-trash-alt"></i>
     </button>
   </div>

--- a/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
+++ b/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
@@ -1,7 +1,7 @@
 <div class="contributor-pill">
   <div class="contributor-pill__name">
     {{ user.name | titlecase }}
-    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)" (keydown.enter)="removeContributor.emit(user)">
+    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerup)="removeContributor.emit(user)" (keydown.enter)="removeContributor.emit(user)">
       <i class="far fa-trash-alt"></i>
     </button>
   </div>

--- a/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
+++ b/src/app/onion/learning-object-builder/components/contributor-pill/contributor-pill.component.html
@@ -1,7 +1,7 @@
 <div class="contributor-pill">
   <div class="contributor-pill__name">
     {{ user.name | titlecase }}
-    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)" (keydown.enter)="removeContributor.emit($event)">
+    <button attr.aria-label="Remove {{ user.name }} as a contributor" class="contributor-pill__dropdown-option" (pointerdown)="removeContributor.emit(user)" (keydown.enter)="removeContributor.emit(user)">
       <i class="far fa-trash-alt"></i>
     </button>
   </div>


### PR DESCRIPTION
The button was listening on the `activate` event for all key and pointer events instead of just a pointerdown/click event.

Story details: https://app.shortcut.com/clarkcan/story/32498/first-contributor-removed-in-builder-when-enter-is-clicked