### PR TITLE
Bug/sc 34007/suggestions for standard guidelines do not change

### DIFF
--- a/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.routes.ts
@@ -15,7 +15,7 @@ export const STANDARD_GUIDELINES_ROUTES = {
      * @method GET
      * @returns list of guidelines
      */
-    SEARCH_GUIDELINES() {
-        return `${environment.apiURL}/guidelines`;
+    SEARCH_GUIDELINES(query: any) {
+        return `${environment.apiURL}/guidelines/?${query}`;
     }
 };

--- a/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
@@ -34,7 +34,7 @@ export class GuidelineService {
     // CLARK-SERVICE-FIX: SUPPORT SEARCH QUERY
     const res = await this.http
       .get<{ total: number; results: SearchItemDocument[]; }>(
-        STANDARD_GUIDELINES_ROUTES.SEARCH_GUIDELINES())
+        STANDARD_GUIDELINES_ROUTES.SEARCH_GUIDELINES(query))
       .pipe(catchError(this.handleError))
       .toPromise();
     return res;


### PR DESCRIPTION
Fixed the standard guidelines suggestions to change as input text from the user is given, in the learning object builder. This feature was broken in staging (see shortcut story for video) and only required a fix to the search guidelines route to accept a query text parameter. It now works normally again.

https://github.com/user-attachments/assets/a4cf1c91-f656-4c5a-ade8-0baebec2c5ce

