### PR TITLE
Repurpose blogs component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "5.7.2",
+      "version": "5.7.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/blogs/blogs.component.html
+++ b/src/app/components/blogs/blogs.component.html
@@ -1,16 +1,18 @@
 <div class="blogs-component" *ngIf="blogObservable | async as blog;">
-    <div @blogView class="first-view" *ngIf="view===0">
+    <div class="first-view" *ngIf="view===0">
         <div class="left">
-            <i class="fal fa-newspaper fa-2x"></i>
+            <i class="fal fa-wrench fa-2x"></i>
+            <!-- <i class="fal fa-newspaper fa-2x"></i> -->
             <p>
-                <strong>{{blog[0].name}} </strong> {{" " + blog[0].description}}
-                <a [href]="blog[0].url" target="_blank">See blog for more details.</a>
+                <!-- <strong>{{blog[0].name}} </strong> {{" " + blog[0].description}}
+                <a [href]="blog[0].url" target="_blank">See blog for more details.</a> -->
+                CLARK will be unavailable <strong>December 16, 2024 from 8:00AM EST - 10:00AM EST</strong> for scheduled maintenance. We thank you for your patience as we work to improve your experience.
             </p>
         </div>
-        <div class="side-by-side">
+        <!-- <div class="side-by-side">
             <button class="dismiss" [tip]="dismissText" (click)="dismiss()" >Dismiss</button>
             <button class="dismissOnce" [tip]="dismissOnceText" (click)="dismissOnce()">Dismiss Once</button>
-        </div>
+        </div> -->
     </div>
 
 </div>

--- a/src/app/cube/home/home.component.html
+++ b/src/app/cube/home/home.component.html
@@ -1,10 +1,8 @@
-<!--Temporarilly disabling blogs banner-->
-<!-- <clark-blogs
+<clark-blogs
     @blog
-    *ngIf="displayBlogsBanner()"
     (showBlogsBanner)="showBlogsBanner($event)"
     (neverShowBanner)="neverShowBanner($event)"
-  ></clark-blogs> -->
+  ></clark-blogs>
 <clark-splash></clark-splash>
 <clark-help></clark-help>
 <clark-mission></clark-mission>


### PR DESCRIPTION
# READ THIS FIRST
This PR repurposes the blogs component to be used for downtime since the banner is currently being used by content for office hours. 

We will create two components in the future, but for now this will do to get us ready for the clark-service deployment. 
<img width="1575" alt="Screenshot 2024-12-04 at 9 04 26 AM" src="https://github.com/user-attachments/assets/8da1d1f6-a00c-4569-92d6-a5d076fd4367">
