### PR TITLE
fix: [sc-35541] 'Users undefined' when viewing learning object

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -60,7 +60,7 @@ export class LibraryService {
     // Resets the auth token in the headers
     this.updateUser();
     if (!this.user) {
-      return Promise.reject('User is undefined');
+      return;
     }
 
     const query = new URLSearchParams({
@@ -101,7 +101,7 @@ export class LibraryService {
     cuid: string, version: number
   ): Promise<any> {
     if (!this.user) {
-      return Promise.reject('User is undefined');
+      return;
     }
     return await this.http
       .post(
@@ -132,7 +132,7 @@ export class LibraryService {
 
   removeFromLibrary(libraryItemId: string): Promise<void> {
     if (!this.user) {
-      return Promise.reject('User is undefined');
+      return;
     }
     this.http
       .delete(


### PR DESCRIPTION
Action buttons were returning an error when the user isn't authenticated. This change makes an early return instead when the user isn't authenticated.

Story details: https://app.shortcut.com/clarkcan/story/35541