### PR TITLE
Topics selected from the navbar not loading after clear-filters is clicked 

### DIFF
--- a/src/app/core/client-module/navBarDropdown.service.ts
+++ b/src/app/core/client-module/navBarDropdown.service.ts
@@ -50,8 +50,9 @@ export class NavbarDropdownService {
 
     public setTopic(topic: Topic): void {
         this.closeAll();
-        this.router.navigate(['/browse'], { queryParams: { currPage: 1, limit: 10, status: 'released', topics: topic } });
-    }
+        this.router.navigate(['/browse'], { queryParams: { currPage: 1, limit: 10, status: 'released', topics: topic } })
+            .then(() => window.location.reload());
+    }    
 
     //close mobile slideouts
     public closeMobileMenus(): void {

--- a/src/app/core/client-module/navBarDropdown.service.ts
+++ b/src/app/core/client-module/navBarDropdown.service.ts
@@ -52,7 +52,7 @@ export class NavbarDropdownService {
         this.closeAll();
         this.router.navigate(['/browse'], { queryParams: { currPage: 1, limit: 10, status: 'released', topics: topic } })
             .then(() => window.location.reload());
-    }    
+    }
 
     //close mobile slideouts
     public closeMobileMenus(): void {


### PR DESCRIPTION
Added JS functionality to reload the page whenever a topic is selected from the dropdown, ensuring the page updates with the newly applied topic.

**_Problem_**
If a user interacted with the browse component by applying filters, clearing filters, or searching text—the nav bar's topic dropdown would became unresponsive after. As a result, selecting a topic from the nav bar dropdown would not apply the filter unless the user manually reloaded the page. 

Before:

https://github.com/user-attachments/assets/8c157b75-4488-4392-bf9e-21e75bbae5d8

After:

https://github.com/user-attachments/assets/835ccaaa-8d8a-45dd-976d-e5cf61c3c309

