### PR TITLE
User profile not filtering out unreleased learning objects

### DIFF
--- a/src/app/cube/user-profile/user-profile.component.ts
+++ b/src/app/cube/user-profile/user-profile.component.ts
@@ -51,8 +51,10 @@ export class UserProfileComponent implements OnInit {
     await this.collectionService
       .getUserSubmittedCollections(this.user.username).then(async (collectionMeta) => {
         const tempObjects = [];
+        // Filter for released objects
+        const filteredMeta = collectionMeta.filter(objectMeta => objectMeta.status === 'released');
         // Await each learning object for a users profile
-        const promises = collectionMeta.map(async (objectMeta) => {
+        const promises = filteredMeta.map(async (objectMeta) => {
           // Return a promise for the current learning object
           return await this.learningObjectService.fetchLearningObject(objectMeta.cuid, objectMeta.version);
         });


### PR DESCRIPTION
Added a filter so only the authors released objects would be retrieved

Picture from shortcut story (a lot of 403 errors):

![image](https://github.com/user-attachments/assets/342755ee-ac37-49a3-afed-7760b1f38089)

Now:

<img width="1505" alt="Screenshot 2025-01-04 at 1 26 33 AM" src="https://github.com/user-attachments/assets/912b2956-4c95-46a3-8f23-baa855cadf6c" />

