### PR TITLE
Bug/sc 35607/fix 404 on details page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "6.0.23",
+  "version": "6.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "6.0.23",
+      "version": "6.0.24",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "6.0.23",
+  "version": "6.0.24",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/cube/details/details.module.ts
+++ b/src/app/cube/details/details.module.ts
@@ -35,6 +35,11 @@ import { OnionCoreModule } from '../../onion/core/core.module';
     CommonModule,
     RouterModule.forChild([
       {
+        path: ':username/:cuid',
+        component: DetailsComponent,
+        canActivate:[ RouteBackwardsCompatGuard ]
+      },
+      {
         path: ':username/:cuid/:version',
         component: DetailsComponent,
         canActivate: [ RouteBackwardsCompatGuard ]


### PR DESCRIPTION
This PR adds back the :username/:cuid route to the details module so that the details component can be hit. There is existing logic on the details page that displays the released learning object. 