### PR TITLE
fix: [sc-35723] Look into password requirement errors on CLARK

### DIFF
--- a/src/app/auth/change-password/change-password.component.html
+++ b/src/app/auth/change-password/change-password.component.html
@@ -24,9 +24,9 @@
                     ngModel
                 >
                 </clark-input-field>
-                <button>Reset Password</button>
+                <button [disabled]="!passwords.valid">Reset Password</button>
             </form>
-            
+
         </div>
 
         <div *ngIf="done" class="second-view" @fadeIn>

--- a/src/app/auth/change-password/change-password.component.scss
+++ b/src/app/auth/change-password/change-password.component.scss
@@ -67,6 +67,11 @@
             opacity: 100%;
         }
 
+        button:disabled {
+          opacity: 50%;
+          cursor: default;
+        }
+
         .first-view {
             width: 75%;
         }
@@ -85,6 +90,6 @@
                 margin-bottom: 30px;
             }
         }
-    }    
+    }
 }
 


### PR DESCRIPTION
The client was not checking for invalid password input so the button stayed enabled. This PR fixes that issue, and will conditionally disable the button based on validator status

![image](https://github.com/user-attachments/assets/c26263e7-daa6-4b23-8656-da21aafc53cd)

Story details: https://app.shortcut.com/clarkcan/story/35723