### PR TITLE
Add UI to Add Tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ FROM node:16 as build
 COPY . /build
 WORKDIR /build
 # Install dependencies and run the build command
+RUN npm install -g node-gyp
 RUN npm install
 RUN npm run build
 

--- a/src/app/core/learning-object-module/editorial.service.ts
+++ b/src/app/core/learning-object-module/editorial.service.ts
@@ -144,8 +144,7 @@ export class EditorialService {
    */
   canMapAndTag(learningObject: LearningObject) {
     const userIsAuthor = learningObject.author.username === this.auth.username;
-    const untaggable = learningObject.status === LearningObject.Status.RELEASED
-      || learningObject.status === LearningObject.Status.UNRELEASED;
+    const untaggable = learningObject.status === LearningObject.Status.UNRELEASED;
 
     if (this.auth.user && this.auth.user.accessGroups && !userIsAuthor && !untaggable) {
       const privileges = ['admin', 'editor', 'mapper'];

--- a/src/app/core/learning-object-module/tags/tags.routes.ts
+++ b/src/app/core/learning-object-module/tags/tags.routes.ts
@@ -5,6 +5,7 @@ export const TAGS_ROUTES = {
     /**
      * Request to get all topics
      * @method GET
+     * @param query the text, type, limit, and sort values
      */
     GET_ALL_TAGS(query?: any) {
         return `${environment.apiURL}/tags?${querystring.stringify(query)}`;
@@ -20,4 +21,12 @@ export const TAGS_ROUTES = {
             learningObjectCuid
         )}/tags`;
     },
+
+    /**
+     * Request to get all types
+     * @method GET
+     */
+    GET_ALL_TAG_TYPES() {
+        return `${environment.apiURL}/tags/types`;
+    }
 };

--- a/src/app/core/learning-object-module/tags/tags.routes.ts
+++ b/src/app/core/learning-object-module/tags/tags.routes.ts
@@ -1,0 +1,23 @@
+import { environment } from '../../../../environments/environment';
+import * as querystring from 'querystring';
+
+export const TAGS_ROUTES = {
+    /**
+     * Request to get all topics
+     * @method GET
+     */
+    GET_ALL_TAGS(query?: any) {
+        return `${environment.apiURL}/tags?${querystring.stringify(query)}`;
+    },
+    /**
+     * Request to update a topic for a learning object
+     * @method PATCH
+     * @auth required
+     * @param learningObjectId - The id of the learning object
+     */
+    UPDATE_TAG(learningObjectCuid: string) {
+        return `${environment.apiURL}/learning-objects/${encodeURIComponent(
+            learningObjectCuid
+        )}/tags`;
+    },
+};

--- a/src/app/core/learning-object-module/tags/tags.routes.ts
+++ b/src/app/core/learning-object-module/tags/tags.routes.ts
@@ -3,7 +3,7 @@ import * as querystring from 'querystring';
 
 export const TAGS_ROUTES = {
     /**
-     * Request to get all topics
+     * Request to get all tags
      * @method GET
      * @param query the text, type, limit, and sort values
      */
@@ -11,10 +11,10 @@ export const TAGS_ROUTES = {
         return `${environment.apiURL}/tags?${querystring.stringify(query)}`;
     },
     /**
-     * Request to update a topic for a learning object
+     * Request to update tags  for a learning object
      * @method PATCH
      * @auth required
-     * @param learningObjectId - The id of the learning object
+     * @param learningObjectCuid - The cuid of the learning object
      */
     UPDATE_TAG(learningObjectCuid: string) {
         return `${environment.apiURL}/learning-objects/${encodeURIComponent(

--- a/src/app/core/learning-object-module/tags/tags.service.ts
+++ b/src/app/core/learning-object-module/tags/tags.service.ts
@@ -81,7 +81,7 @@ export class TagsService {
 
   /**
    * Returns all the valid types for a tag
-   * 
+   *
    * @returns A list of type tags
    */
   async getTypes(): Promise<{[key: string]: boolean}[]> {

--- a/src/app/core/learning-object-module/tags/tags.service.ts
+++ b/src/app/core/learning-object-module/tags/tags.service.ts
@@ -21,6 +21,7 @@ export class TagsService {
    */
   async getTags(query?: any): Promise<Topic[]> {
     query = {
+      type: query?.type,
       text: query?.text,
       sort: 1,
       limit: 40
@@ -77,6 +78,29 @@ export class TagsService {
         );
     });
   }
+
+
+  async getTypes(): Promise<{[key: string]: boolean}[]> {
+    return await new Promise((resolve, reject) => {
+      this.http
+        .get<Topic[]>(TAGS_ROUTES.GET_ALL_TAG_TYPES())
+        .pipe(
+
+          catchError(this.handleError)
+        )
+        .toPromise()
+        .then(
+          (res: any) => {
+            resolve(res.types);
+          },
+          (err) => {
+            reject(err);
+          }
+        );
+    });
+  }
+
+
 
   private handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {

--- a/src/app/core/learning-object-module/tags/tags.service.ts
+++ b/src/app/core/learning-object-module/tags/tags.service.ts
@@ -3,12 +3,12 @@ import { Topic } from '@entity';
 import { catchError } from 'rxjs/operators';
 import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { throwError } from 'rxjs';
-import { TOPICS_ROUTES } from './topics.routes';
+import { TAGS_ROUTES } from './tags.routes';
 
 @Injectable({
   providedIn: 'root'
 })
-export class TopicsService {
+export class TagsService {
   private headers = new HttpHeaders();
 
   constructor(private http: HttpClient) {
@@ -19,10 +19,15 @@ export class TopicsService {
    *
    * @returns A list of topics
    */
-  async getTopics(): Promise<Topic[]> {
+  async getTags(query?: any): Promise<Topic[]> {
+    query = {
+      text: query?.text,
+      sort: 1,
+      limit: 40
+    };
     return await new Promise((resolve, reject) => {
       this.http
-        .get<Topic[]>(TOPICS_ROUTES.GET_ALL_TOPICS(),
+        .get<Topic[]>(TAGS_ROUTES.GET_ALL_TAGS(query),
           {
             headers: this.headers,
             withCredentials: true,
@@ -35,8 +40,7 @@ export class TopicsService {
         .toPromise()
         .then(
           (res: any) => {
-            const sorted = res.sort((a, b) => (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0));
-            resolve(sorted);
+            resolve(res.tags);
           },
           (err) => {
             reject(err);
@@ -52,12 +56,11 @@ export class TopicsService {
    * @param learningObjectId  user id
    * @param topicIds  id of Topic object
    */
-  async updateObjectTopics(learningObjectId: string, topicIds: string[]): Promise<void> {
-    console.log('We gucci');
+  async updateObjectTags(learningObjectCuid: string, tags: string[]): Promise<void> {
     return await new Promise((resolve, reject) => {
       this.http
-        .patch(TOPICS_ROUTES.UPDATE_TOPIC(learningObjectId),
-          { topicIds },
+        .put(TAGS_ROUTES.UPDATE_TAG(learningObjectCuid),
+          { tags },
           {
             headers: this.headers,
             withCredentials: true,

--- a/src/app/core/learning-object-module/tags/tags.service.ts
+++ b/src/app/core/learning-object-module/tags/tags.service.ts
@@ -15,9 +15,9 @@ export class TagsService {
   }
 
   /**
-   * This gets the list of object topics from the backend to display
+   * This gets the list of object tags from the backend to display
    *
-   * @returns A list of topics
+   * @returns A list of tags
    */
   async getTags(query?: any): Promise<Topic[]> {
     query = {
@@ -51,11 +51,10 @@ export class TagsService {
   }
 
   /**
-   *  This function updates the learning the object with the selected tagged topics
+   *  This function updates the learning the object with the selected tags
    *
-   * @param username  username of learning object owner
-   * @param learningObjectId  user id
-   * @param topicIds  id of Topic object
+   * @param learningObjectCuid  the learningObjectCuid
+   * @param tags  array of ids of tag objects
    */
   async updateObjectTags(learningObjectCuid: string, tags: string[]): Promise<void> {
     return await new Promise((resolve, reject) => {
@@ -80,6 +79,11 @@ export class TagsService {
   }
 
 
+  /**
+   * Returns all the valid types for a tag
+   * 
+   * @returns A list of type tags
+   */
   async getTypes(): Promise<{[key: string]: boolean}[]> {
     return await new Promise((resolve, reject) => {
       this.http

--- a/src/app/core/learning-object-module/topics/topics.service.ts
+++ b/src/app/core/learning-object-module/topics/topics.service.ts
@@ -53,7 +53,6 @@ export class TopicsService {
    * @param topicIds  id of Topic object
    */
   async updateObjectTopics(learningObjectId: string, topicIds: string[]): Promise<void> {
-    console.log('We gucci');
     return await new Promise((resolve, reject) => {
       this.http
         .patch(TOPICS_ROUTES.UPDATE_TOPIC(learningObjectId),

--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -119,9 +119,4 @@
       <i class="fal fa-spinner-third fa-spin"></i>
     </span>
   </button>
-  <button
-    *ngIf="canMapAndTag"
-    class="button neutral"
-    aria-label="Map and Tag"
-    (activate)="mapAndTagObject()">Map and Tag</button>
 </ng-template>

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -113,10 +113,6 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     });
   }
 
-  get canMapAndTag() {
-    return this.editorialService.canMapAndTag(this.learningObject);
-  }
-
   get isReleased(): boolean {
     return this.learningObject.status === LearningObject.Status.RELEASED;
   }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.html
@@ -1,0 +1,33 @@
+<div class="search">
+  <div class="input-container">
+    <i class="fas fa-search"></i> 
+    <input 
+      type="text"
+      aria-label="Find for tags"
+      class="tag-dropdown__search-input"
+      placeholder="Search for Tags"
+      (input)="search()"
+      [(ngModel)]="query"
+      >
+  </div>
+</div>
+<div class="filter-results">
+  <div class="filters">
+    option 1
+    <br>
+    option 2
+    <br>
+    option 3
+  </div>
+  <div *ngIf="tags.length > 0" class="pill-container">
+      <div *ngFor="let item of tags">
+        <button
+          [class.selected]="selectedTags.includes(item)"
+          (click)="toggleTags(item)"
+        >
+          {{ item.name }}
+        </button>
+      </div>
+    </div>
+</div>
+

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.html
@@ -1,7 +1,8 @@
 <div class="search">
-  <div class="input-container">
+  <div class="input-container" (click)="focusInput()">
     <i class="fas fa-search"></i> 
     <input 
+      #searchInput
       type="text"
       aria-label="Find for tags"
       class="tag-dropdown__search-input"
@@ -13,16 +14,26 @@
 </div>
 <div class="filter-results">
   <div class="filters">
-    option 1
-    <br>
-    option 2
-    <br>
-    option 3
+    <p>Types</p>
+    <form *ngIf="types.length > 0">
+      <div *ngFor="let type of types">
+          <input
+            type="checkbox"
+            [value]="type.value"
+            (change)="filter(type.value)"
+            name="filterCheckbox"
+          />
+          <label>
+          {{ type?.name }}
+        </label>
+        <br />
+      </div>
+    </form>
   </div>
   <div *ngIf="tags.length > 0" class="pill-container">
       <div *ngFor="let item of tags">
         <button
-          [class.selected]="selectedTags.includes(item)"
+          [class.selected]="selected(item)"
           (click)="toggleTags(item)"
         >
           {{ item.name }}

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
@@ -1,0 +1,65 @@
+@import 'vars.scss';
+.filter-results {
+  display: flex; /* Enable Flexbox layout */
+  gap: 16px; /* Add spacing between the filters and the pill-container */
+  width: 100%; /* Ensure the container spans the full width of the parent */
+}
+
+.filters {
+  flex: 0 0 30%; /* Fix width to 30% of the parent container */
+  padding: 16px; /* Optional: Add some padding */
+}
+
+.pill-container {
+    flex: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-start;
+    margin: 10px 0;
+  }
+  
+  button {
+    padding: 5px 10px;
+    border: 1px solid $light-blue;
+    border-radius: 5px;
+    cursor: pointer;
+    background-color: $primary-white;
+    white-space: nowrap;
+    color: $light-blue;
+  }
+  
+  button.selected {
+    background-color: $light-blue;
+    color: $primary-white;
+    border-color: $light-blue;
+  }
+
+  .input-container{
+    background-color: $light-grey;
+    position: relative;
+    padding: 8px 10px;
+    border-radius: 5px;
+    i {
+      position: absolute; 
+      padding: 10px;
+    }
+  }
+  
+  .tag-dropdown__search-input {
+    appearance: none;
+    font-size: $small;
+    border: none;   
+    color: $medium-grey;
+    background-color: inherit;
+    outline: 0;
+    max-width: 550px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0px 15px;
+  
+    &:focus {
+      border-color: $light-blue;
+    }
+  }
+

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
@@ -1,62 +1,18 @@
 @import 'vars.scss';
-.filter-results {
-  display: flex;
-  gap: 16px;
-  width: 100%;
-}
-
-.filters {
-  flex: 0 0 30%;
-  padding: 10px;
-
-  label {
-    font-size: $small;
-  }
-}
-
-.pill-container {
-  max-height: 300px; /* Set a max height to enable scrolling */
-  overflow-y: auto; /* Enables vertical scrolling */
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: flex-start;
-  align-content: flex-start;
-  padding: 5px;
-  min-height: auto;
-  margin-top: 10px;
-}
-
-button {
-  padding: 5px 10px;
-  border: 1px solid $light-blue;
+// Search CSS
+.input-container{
+  background-color: $light-grey;
+  position: relative;
+  padding: 8px 10px;
   border-radius: 5px;
-  cursor: pointer;
-  background-color: $primary-white;
-  white-space: nowrap;
-  color: $light-blue;
-}
-
-button.selected {
-  background-color: $light-blue;
-  color: $primary-white;
-  border-color: $light-blue;
-}
-
-  .input-container{
-    background-color: $light-grey;
-    position: relative;
-    padding: 8px 10px;
-    border-radius: 5px;
-    
-    i {
-      position: absolute; 
-      padding: 10px;
-      margin-right: 5px;
-      pointer-events: none;
-    }
-  }
   
+  i {
+    position: absolute; 
+    padding: 10px;
+    margin-right: 5px;
+    pointer-events: none;
+  }
+
   .tag-dropdown__search-input {
     appearance: none;
     font-size: $small;
@@ -73,4 +29,50 @@ button.selected {
       border-color: $light-blue;
     }
   }
+}
+// Lower portion of UI
+.filter-results {
+  display: flex;
+  gap: 16px;
+  width: 100%;
+
+  .filters {
+    flex: 0 0 30%;
+    padding: 10px;
+  
+    label {
+      font-size: $small;
+    }
+  }
+
+  .pill-container {
+    max-height: 300px; /* Set a max height to enable scrolling */
+    overflow-y: auto; /* Enables vertical scrolling */
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: flex-start;
+    align-content: flex-start;
+    padding: 5px;
+    min-height: auto;
+    margin-top: 10px;
+
+    button {
+      padding: 5px 10px;
+      border: 1px solid $light-blue;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: $primary-white;
+      white-space: nowrap;
+      color: $light-blue;
+    }
+    
+    button.selected {
+      background-color: $light-blue;
+      color: $primary-white;
+      border-color: $light-blue;
+    }
+  }
+}
+  
 

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.scss
@@ -1,48 +1,59 @@
 @import 'vars.scss';
 .filter-results {
-  display: flex; /* Enable Flexbox layout */
-  gap: 16px; /* Add spacing between the filters and the pill-container */
-  width: 100%; /* Ensure the container spans the full width of the parent */
+  display: flex;
+  gap: 16px;
+  width: 100%;
 }
 
 .filters {
-  flex: 0 0 30%; /* Fix width to 30% of the parent container */
-  padding: 16px; /* Optional: Add some padding */
+  flex: 0 0 30%;
+  padding: 10px;
+
+  label {
+    font-size: $small;
+  }
 }
 
 .pill-container {
-    flex: 1;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    justify-content: flex-start;
-    margin: 10px 0;
-  }
-  
-  button {
-    padding: 5px 10px;
-    border: 1px solid $light-blue;
-    border-radius: 5px;
-    cursor: pointer;
-    background-color: $primary-white;
-    white-space: nowrap;
-    color: $light-blue;
-  }
-  
-  button.selected {
-    background-color: $light-blue;
-    color: $primary-white;
-    border-color: $light-blue;
-  }
+  max-height: 300px; /* Set a max height to enable scrolling */
+  overflow-y: auto; /* Enables vertical scrolling */
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-start;
+  align-content: flex-start;
+  padding: 5px;
+  min-height: auto;
+  margin-top: 10px;
+}
+
+button {
+  padding: 5px 10px;
+  border: 1px solid $light-blue;
+  border-radius: 5px;
+  cursor: pointer;
+  background-color: $primary-white;
+  white-space: nowrap;
+  color: $light-blue;
+}
+
+button.selected {
+  background-color: $light-blue;
+  color: $primary-white;
+  border-color: $light-blue;
+}
 
   .input-container{
     background-color: $light-grey;
     position: relative;
     padding: 8px 10px;
     border-radius: 5px;
+    
     i {
       position: absolute; 
       padding: 10px;
+      margin-right: 5px;
+      pointer-events: none;
     }
   }
   

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.spec.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TagsComponent } from './tags.component';
+
+describe('TagsComponent', () => {
+  let component: TagsComponent;
+  let fixture: ComponentFixture<TagsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TagsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TagsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/tags/tags.component.ts
@@ -1,0 +1,59 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { TagsService } from 'app/core/learning-object-module/tags/tags.service';
+import { TaggingService } from '../../services/tagging.service';
+import { Tag } from '@entity';
+import { Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'clark-tagging',
+  templateUrl: './tags.component.html',
+  styleUrls: ['./tags.component.scss']
+})
+export class TagsComponent implements OnInit, OnDestroy {
+  tags: Tag[];
+  selectedTags: Tag[];
+  query: string;
+  types: string;
+
+  private destroy$ = new Subject<void>();
+  private searchSubject$ = new Subject<string>();
+
+  constructor(
+    private tagsService: TagsService,
+    private taggingService: TaggingService
+  ) {
+  }
+
+  async ngOnInit(): Promise<void> {
+    // Subscribe to the source arrays
+    this.taggingService.tags$.pipe(takeUntil(this.destroy$)).subscribe((items: any) => {
+      this.tags = items;
+    });
+
+    this.taggingService.selectedTags$.pipe(takeUntil(this.destroy$)).subscribe((selected: any) => {
+      this.selectedTags = selected;
+    });
+  }
+
+  // Toggle item selection for Array One
+  toggleTags(item: any): void {
+    this.taggingService.toggleItemInArray('tags', item);
+  }
+
+  async search(): Promise<void> {
+    const tags = await this.tagsService.getTags({ text: this.query});
+    this.taggingService.setSourceArray('tags', tags);
+  }
+
+  async filter(): Promise<void> {
+    const tags = await this.tagsService.getTags({ text: this.query, type: this.types });
+    this.taggingService.setSourceArray('tags', tags);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+}

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.html
@@ -1,0 +1,11 @@
+<div *ngIf="topics.length > 0" class="pill-container">
+    <div *ngFor="let item of topics">
+      <button
+        [class.selected]="selectedTopics.includes(item)"
+        (click)="toggleTopics(item)"
+      >
+        {{ item.name }}
+      </button>
+    </div>
+  </div>
+

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.scss
@@ -1,0 +1,24 @@
+@import 'vars.scss';
+.pill-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-start;
+    margin: 10px 0;
+  }
+  
+  button {
+    padding: 5px 10px;
+    border: 1px solid $light-blue;
+    border-radius: 5px;
+    cursor: pointer;
+    background-color: $primary-white;
+    white-space: nowrap;
+    color: $light-blue;
+  }
+  
+  button.selected {
+    background-color: $light-blue;
+    color: $primary-white;
+    border-color: $light-blue;
+  }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.scss
@@ -5,20 +5,21 @@
     gap: 10px;
     justify-content: flex-start;
     margin: 10px 0;
+
+    button {
+      padding: 5px 10px;
+      border: 1px solid $light-blue;
+      border-radius: 5px;
+      cursor: pointer;
+      background-color: $primary-white;
+      white-space: nowrap;
+      color: $light-blue;
+    }
+    
+    button.selected {
+      background-color: $light-blue;
+      color: $primary-white;
+      border-color: $light-blue;
+    }
   }
   
-  button {
-    padding: 5px 10px;
-    border: 1px solid $light-blue;
-    border-radius: 5px;
-    cursor: pointer;
-    background-color: $primary-white;
-    white-space: nowrap;
-    color: $light-blue;
-  }
-  
-  button.selected {
-    background-color: $light-blue;
-    color: $primary-white;
-    border-color: $light-blue;
-  }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.spec.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TopicsComponent } from './topics.component';
+
+describe('TopicsComponent', () => {
+  let component: TopicsComponent;
+  let fixture: ComponentFixture<TopicsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TopicsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TopicsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { TaggingService } from '../../services/tagging.service';
+import { Topic } from '@entity';
+import { TopicsService } from 'app/core/learning-object-module/topics/topics.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'clark-topic-tagging',
+  templateUrl: './topics.component.html',
+  styleUrls: ['./topics.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TopicsComponent implements OnInit, OnDestroy {
+  topics: Topic[];
+  selectedTopics: Topic[];
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private taggingService: TaggingService
+  ) { }
+
+  async ngOnInit(): Promise<void> {
+    // Subscribe to the source arrays
+    this.taggingService.topics$.pipe(takeUntil(this.destroy$)).subscribe((items: any) => {
+      this.topics = items;
+    });
+
+    this.taggingService.selectedTopics$.pipe(takeUntil(this.destroy$)).subscribe((selected) => {
+      this.selectedTopics = selected;
+    });
+
+  }
+
+
+  // Toggle item selection for Array One
+  toggleTopics(item: any): void {
+    this.taggingService.toggleItemInArray('topics', item);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+}

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/components/topics/topics.component.ts
@@ -22,7 +22,7 @@ export class TopicsComponent implements OnInit, OnDestroy {
   ) { }
 
   async ngOnInit(): Promise<void> {
-    // Subscribe to the source arrays
+    // Subscribe to the source arrays for topics
     this.taggingService.topics$.pipe(takeUntil(this.destroy$)).subscribe((items: any) => {
       this.topics = items;
     });
@@ -33,8 +33,7 @@ export class TopicsComponent implements OnInit, OnDestroy {
 
   }
 
-
-  // Toggle item selection for Array One
+  // Toggle item selection for selectedTopics array
   toggleTopics(item: any): void {
     this.taggingService.toggleItemInArray('topics', item);
   }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
@@ -16,6 +16,7 @@
 </button>
 
 <button
+  *ngIf="canMapAndTag"
   class="button neutral"
   (activate)="openTaggingModal()"
 >Tag Learning Object

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
@@ -16,6 +16,12 @@
 </button>
 
 <button
+  class="button neutral"
+  (activate)="openTaggingModal()"
+>Tag Learning Object
+</button>
+
+<button
   *ngIf="isNotPermitted"
   class="button neutral disabled"
   aria-label="Released Learning Objects cannot be Revised">
@@ -23,7 +29,13 @@
 </button>
 
 <clark-popup *ngIf="openRevisionModal" (closed)="closeRevisionModal()">
-  <div #popupInner style="max-width: 600px;">
+  <div #popupInner style="width: 600px;">
     <clark-revision-notice-popup (createRevision)="createRevision()" (close)="closeRevisionModal()"></clark-revision-notice-popup>
+  </div>
+</clark-popup>
+
+<clark-popup *ngIf="openTagModal" (closed)="closeTaggingModal()">
+  <div #popupInner style="width: 600px; margin-top: 10px">
+    <clark-tagging-builder [learningObject]="learningObject"></clark-tagging-builder>
   </div>
 </clark-popup>

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.html
@@ -36,6 +36,6 @@
 
 <clark-popup *ngIf="openTagModal" (closed)="closeTaggingModal()">
   <div #popupInner style="width: 600px; margin-top: 10px">
-    <clark-tagging-builder [learningObject]="learningObject"></clark-tagging-builder>
+    <clark-tagging-builder [learningObject]="learningObject" (close)="closeTaggingModal()"></clark-tagging-builder>
   </div>
 </clark-popup>

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -21,6 +21,7 @@ export class EditorialActionPadComponent implements OnInit {
   @Input() learningObject: LearningObject;
   @Input() userIsAuthor: boolean;
   openRevisionModal: boolean;
+  openTagModal: boolean;
   showPopup = false;
 
   @Input() revisedLearningObject: LearningObject;
@@ -63,6 +64,14 @@ export class EditorialActionPadComponent implements OnInit {
   // Handles closing the create revision modal
   closeRevisionModal() {
     this.openRevisionModal = false;
+  }
+
+  openTaggingModal() {
+    this.openTagModal = true;
+  }
+
+  closeTaggingModal() {
+    this.openTagModal = false;
   }
 
   // Redirects the editors and authors to the builder to make edits to a waiting, review, or proofing object

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -76,6 +76,7 @@ export class EditorialActionPadComponent implements OnInit {
 
   closeTaggingModal() {
     this.openTagModal = false;
+    // Easiest way to reload the page so newest data is in the client
     window.location.href = window.location.href;
   }
 

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.component.ts
@@ -54,6 +54,10 @@ export class EditorialActionPadComponent implements OnInit {
     return this.editorialService.isNotPermittedToMakeChanges(this.learningObject, this.revisedLearningObject);
   }
 
+  get canMapAndTag() {
+    return this.editorialService.canMapAndTag(this.learningObject);
+  }
+
   // Handles opening the create revision modal
   openCreateRevisionModal() {
     if (!this.openRevisionModal) {
@@ -72,6 +76,7 @@ export class EditorialActionPadComponent implements OnInit {
 
   closeTaggingModal() {
     this.openTagModal = false;
+    window.location.href = window.location.href;
   }
 
   // Redirects the editors and authors to the builder to make edits to a waiting, review, or proofing object

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.module.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.module.ts
@@ -3,15 +3,21 @@ import { CommonModule } from '@angular/common';
 import { EditorialActionPadComponent } from './editorial-action-pad.component';
 import { SharedModule } from 'app/shared/shared.module';
 import { TaggingBuilderComponent } from './tagging-builder/tagging-builder.component';
+import { TopicsComponent } from './components/topics/topics.component';
+import { TagsComponent } from './components/tags/tags.component';
+import { FormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
     EditorialActionPadComponent,
     TaggingBuilderComponent,
+    TopicsComponent,
+    TagsComponent,
   ],
   imports: [
     CommonModule,
     SharedModule,
+    FormsModule
   ],
   exports: [ EditorialActionPadComponent ],
 })

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.module.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/editorial-action-pad.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { EditorialActionPadComponent } from './editorial-action-pad.component';
 import { SharedModule } from 'app/shared/shared.module';
+import { TaggingBuilderComponent } from './tagging-builder/tagging-builder.component';
 
 @NgModule({
   declarations: [
     EditorialActionPadComponent,
+    TaggingBuilderComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/services/tagging.service.spec.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/services/tagging.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TaggingService } from './tagging.service';
+
+describe('TaggingService', () => {
+  let service: TaggingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TaggingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/services/tagging.service.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/services/tagging.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@angular/core';
+import { Topic, Tag } from '@entity';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+
+export class TaggingService {
+  private topics = new BehaviorSubject<Topic[]>([]);
+  private tags = new BehaviorSubject<Tag[]>([]);
+
+  private selectedTopics = new BehaviorSubject<Topic[]>([]);
+  private selectedTags = new BehaviorSubject<Tag[]>([]);
+
+  topics$: Observable<Topic[]> = this.topics.asObservable();
+  tags$: Observable<Tag[]> = this.tags.asObservable();
+
+  selectedTopics$: Observable<Topic[]> = this.selectedTopics.asObservable();
+  selectedTags$: Observable<Tag[]> = this.selectedTags.asObservable();
+
+  constructor() {}
+
+  /**
+   * Getters for topics and tags for final saves
+   */
+
+  get finalTopics() {
+    return this.selectedTopics.value;
+  }
+
+  get finalTags() {
+    return this.selectedTags.value;
+  }
+
+  /**
+   * Initialize the available arrays (topics or tags).
+   */
+  setSourceArray(arrayName: 'topics' | 'tags', sourceArray: Topic[] | Tag[]): void {
+    if (arrayName === 'topics') {
+      this.topics.next(sourceArray as Topic[]);
+    } else {
+      this.tags.next(sourceArray as Tag[]);
+    }
+  }
+
+  /**
+   * Add an item to the selected array (topics or tags).
+   */
+  addItemToArray(arrayName: 'topics' | 'tags', item: Topic | Tag): void {
+    const currentSelected = this.getSelectedArray(arrayName);
+    const sourceArray = this.getSourceArray(arrayName);
+
+    if (arrayName === 'topics') {
+      if (
+        (sourceArray as Topic[]).some((topic) => topic._id === (item as Topic)._id) &&
+        !(currentSelected as Topic[]).some((selected) => selected._id === (item as Topic)._id)
+      ) {
+        const updatedSelected = [...(currentSelected as Topic[]), item as Topic];
+        this.setSelectedArray(arrayName, updatedSelected);
+      }
+    } else if (arrayName === 'tags') {
+      if (
+        (sourceArray as Tag[]).includes(item as Tag) &&
+        !(currentSelected as Tag[]).includes(item as Tag)
+      ) {
+        const updatedSelected = [...(currentSelected as Tag[]), item as Tag];
+        this.setSelectedArray(arrayName, updatedSelected);
+      }
+    }
+  }
+
+  /**
+   * Remove an item from the selected array (topics or tags).
+   */
+  removeItemFromArray(arrayName: 'topics' | 'tags', item: Topic | Tag): void {
+    const currentSelected = this.getSelectedArray(arrayName);
+    if (arrayName === 'topics') {
+      const updatedSelected = (currentSelected as Topic[]).filter(
+        (selected) => selected._id !== (item as Topic)._id
+      );
+      this.setSelectedArray(arrayName, updatedSelected);
+    } else if (arrayName === 'tags') {
+      const updatedSelected = (currentSelected as Tag[]).filter((selected) => selected !== item);
+      this.setSelectedArray(arrayName, updatedSelected);
+    }
+  }
+
+  /**
+   * Toggle an item in the selected array (add if not present, remove if present).
+   */
+  toggleItemInArray(arrayName: 'topics' | 'tags', item: Topic | Tag): void {
+    const currentSelected = this.getSelectedArray(arrayName);
+    if (arrayName === 'topics') {
+      if ((currentSelected as Topic[]).some((selected) => selected._id === (item as Topic)._id)) {
+        this.removeItemFromArray(arrayName, item);
+      } else {
+        this.addItemToArray(arrayName, item);
+      }
+    } else if (arrayName === 'tags') {
+      if ((currentSelected as Tag[]).includes(item as Tag)) {
+        this.removeItemFromArray(arrayName, item);
+      } else {
+        this.addItemToArray(arrayName, item);
+      }
+    }
+  }
+
+  /**
+   * Clear all selected items in a specific array.
+   */
+  clearSelectedArray(arrayName: 'topics' | 'tags'): void {
+    this.setSelectedArray(arrayName, []);
+  }
+
+  /**
+   * Get the selected array values (topics or tags).
+   */
+  private getSelectedArray(arrayName: 'topics' | 'tags'): Topic[] | Tag[] {
+    return arrayName === 'topics' ? this.selectedTopics.value : this.selectedTags.value;
+  }
+
+  /**
+   * Get the source array values (topics or tags).
+   */
+  private getSourceArray(arrayName: 'topics' | 'tags'): Topic[] | Tag[] {
+    return arrayName === 'topics' ? this.topics.value : this.tags.value;
+  }
+
+  /**
+   * Set the selected array values (topics or tags).
+   */
+  setSelectedArray(arrayName: 'topics' | 'tags', updatedArray: Topic[] | Tag[]): void {
+    if (arrayName === 'topics') {
+      this.selectedTopics.next(updatedArray as Topic[]);
+    } else {
+      this.selectedTags.next(updatedArray as Tag[]);
+    }
+  }
+}
+

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.html
@@ -1,0 +1,25 @@
+
+<div class="tabs">
+    <button 
+      class="tab" 
+      [class.active]="currentTab === 'topics'" 
+      (click)="currentTab = 'topics'">
+      Topics
+    </button>
+    <button 
+      class="tab" 
+      [class.active]="currentTab === 'tags'" 
+      (click)="currentTab = 'tags'">
+      Tags
+    </button>
+  </div>
+  
+  <div class="tab-content">
+    <ng-container *ngIf="currentTab === 'topics'">
+      <p>Topics</p>
+    </ng-container>
+  
+    <ng-container *ngIf="currentTab === 'tags'">
+        <p>Tags</p>
+    </ng-container>
+  </div>

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.html
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.html
@@ -3,23 +3,34 @@
     <button 
       class="tab" 
       [class.active]="currentTab === 'topics'" 
-      (click)="currentTab = 'topics'">
+      (click)="switchTab('topics')">
       Topics
     </button>
     <button 
       class="tab" 
       [class.active]="currentTab === 'tags'" 
-      (click)="currentTab = 'tags'">
+      (click)="switchTab('tags')">
       Tags
     </button>
+    <div class="underline" [ngStyle]="{ left: underlineLeft, width: underlineWidth }"></div>
+  </div>
+  <div *ngIf="!loading">
+    <div class="tab-content">
+      <ng-container *ngIf="currentTab === 'topics'">
+          <clark-topic-tagging></clark-topic-tagging>
+      </ng-container>
+    
+      <ng-container *ngIf="currentTab === 'tags'">
+        <clark-tagging></clark-tagging>
+      </ng-container>
+    </div>
+    <div class="buttons">
+      <div class="button neutral" (click)="cancel()">
+        Cancel
+      </div>
+      <div class="button good" (click)="save()">
+        Save
+      </div>
+    </div>
   </div>
   
-  <div class="tab-content">
-    <ng-container *ngIf="currentTab === 'topics'">
-      <p>Topics</p>
-    </ng-container>
-  
-    <ng-container *ngIf="currentTab === 'tags'">
-        <p>Tags</p>
-    </ng-container>
-  </div>

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
@@ -1,27 +1,49 @@
+@import 'vars.scss';
 .tabs {
-    display: flex; // Make buttons align horizontally
-    width: 100%; // Ensure the parent container takes the full width
+    display: flex;
+    position: relative;
+    width: 100%;
+    margin-bottom: 20px;
   
     .tab {
-      flex: 1; // Make each button take equal space within the parent
-      padding: 10px; // Add padding for better usability
-      border: none; // Remove default border
-      text-align: center; // Center the text
-      font-size: 16px; // Adjust font size as needed
-      cursor: pointer; // Change cursor to pointer on hover
-      background-color: #1c70dd; // Default background color
-      color: white; // Default text color
-      transition: background-color 0.3s ease; // Smooth background color transition
+      flex: 1;
+      padding: 10px;
+      border: none;
+      background-color: transparent;
+      text-align: center;
+      font-size: 16px;
+      cursor: pointer;
+      color: $light-blue;
+      position: relative;
+      transition: color 0.3s ease;
   
       &.active {
-        background-color: white; // Active state background
-        color: #1c70dd; // Active state text color
-        font-weight: bold; // Emphasize active button with bold text
+        font-weight: bold;
       }
   
       &:hover {
-        background-color: gray; // Slightly darker shade for hover effect
+        color: $light-blue;
       }
     }
+  
+    .underline {
+      position: absolute;
+      bottom: 0;
+      height: 2px;
+      background-color: $light-blue;
+      transition: left 0.3s ease, width 0.3s ease;
+    }
   }
+  
+  .tab-content {
+    min-height: 300px;
+  }
+
+  .buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+  }
+  
+  
   

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
@@ -36,7 +36,7 @@
   }
   
   .tab-content {
-    min-height: 300px;
+    min-height: 400px;
   }
 
   .buttons {

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.scss
@@ -1,0 +1,27 @@
+.tabs {
+    display: flex; // Make buttons align horizontally
+    width: 100%; // Ensure the parent container takes the full width
+  
+    .tab {
+      flex: 1; // Make each button take equal space within the parent
+      padding: 10px; // Add padding for better usability
+      border: none; // Remove default border
+      text-align: center; // Center the text
+      font-size: 16px; // Adjust font size as needed
+      cursor: pointer; // Change cursor to pointer on hover
+      background-color: #1c70dd; // Default background color
+      color: white; // Default text color
+      transition: background-color 0.3s ease; // Smooth background color transition
+  
+      &.active {
+        background-color: white; // Active state background
+        color: #1c70dd; // Active state text color
+        font-weight: bold; // Emphasize active button with bold text
+      }
+  
+      &:hover {
+        background-color: gray; // Slightly darker shade for hover effect
+      }
+    }
+  }
+  

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.spec.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TaggingBuilderComponent } from './tagging-builder.component';
+
+describe('TaggingBuilderComponent', () => {
+  let component: TaggingBuilderComponent;
+  let fixture: ComponentFixture<TaggingBuilderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ TaggingBuilderComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(TaggingBuilderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { LearningObject } from '@entity';
+
+@Component({
+  selector: 'clark-tagging-builder',
+  templateUrl: './tagging-builder.component.html',
+  styleUrls: ['./tagging-builder.component.scss']
+})
+export class TaggingBuilderComponent implements OnInit {
+
+  @Input() learningObject: LearningObject
+  currentTab = 'topics'
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log(this.learningObject)
+  }
+
+}

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
@@ -8,12 +8,12 @@ import { LearningObject } from '@entity';
 })
 export class TaggingBuilderComponent implements OnInit {
 
-  @Input() learningObject: LearningObject
-  currentTab = 'topics'
+  @Input() learningObject: LearningObject;
+  currentTab = 'topics';
   constructor() { }
 
   ngOnInit(): void {
-    console.log(this.learningObject)
+    console.log(this.learningObject);
   }
 
 }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
@@ -1,19 +1,124 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { LearningObject } from '@entity';
+import { TaggingService } from '../services/tagging.service';
+import { TopicsService } from 'app/core/learning-object-module/topics/topics.service';
+import { TagsService } from 'app/core/learning-object-module/tags/tags.service';
 
 @Component({
   selector: 'clark-tagging-builder',
   templateUrl: './tagging-builder.component.html',
   styleUrls: ['./tagging-builder.component.scss']
 })
-export class TaggingBuilderComponent implements OnInit {
+export class TaggingBuilderComponent implements OnInit, AfterViewInit {
 
   @Input() learningObject: LearningObject;
-  currentTab = 'topics';
-  constructor() { }
+  @Output() close: EventEmitter<void> = new EventEmitter();
 
-  ngOnInit(): void {
-    console.log(this.learningObject);
+  currentTab: 'topics' | 'tags' = 'topics';
+  underlineLeft = '0px';
+  underlineWidth = '300px';
+
+  loading = false;
+
+  constructor(
+    private elRef: ElementRef,
+    private cdr: ChangeDetectorRef,
+    private taggingService: TaggingService,
+    private topicService: TopicsService,
+    private tagsService: TagsService
+  ) { }
+
+  async ngOnInit() {
+    this.loading = true;
+    const topics = await this.topicService.getTopics();
+    this.taggingService.setSourceArray('topics', topics);
+
+    // Set selectedTopics if there is already some topics set
+    if (this.learningObject.topics && this.learningObject.topics.length) {
+      const matchingTopics = topics.filter((topic) => {
+        return this.learningObject.topics.includes(topic._id);
+      });
+
+      this.taggingService.setSelectedArray('topics', matchingTopics);
+    }
+
+    const tags = await this.tagsService.getTags();
+    this.taggingService.setSourceArray('tags', tags);
+
+    if(this.learningObject.tags && this.learningObject.tags.length) {
+      const matchingTags = tags.filter((tag) => {
+        return this.learningObject.tags.includes(tag._id);
+      });
+      this.taggingService.setSelectedArray('tags', matchingTags);
+    }
+    this.loading = false;
+    this.switchTab('topics');
+  }
+
+  ngAfterViewInit() {
+    // Delay the underline calculation until the DOM is fully rendered
+    this.cdr.detectChanges();
+    this.updateUnderline();
+  }
+
+
+  /**
+   * Switches the tab and only has two valid options 'topics' or 'tags'
+   * @param tab
+   */
+  switchTab(tab: 'topics' | 'tags') {
+    this.currentTab = tab;
+    this.updateUnderline();
+  }
+
+  /**
+   * This updates the underline for the focused tab so there
+   * is a visual indicator as to which page the user is on
+   */
+  updateUnderline() {
+    // Select all tabs
+    const tabs = this.elRef.nativeElement.querySelectorAll('.tab');
+
+    // Find the currently active tab using `currentTab`
+    const activeTab: any = Array.from(tabs).find(
+      (tab: HTMLElement) => tab.textContent.trim().toLowerCase() === this.currentTab
+    );
+
+    if (activeTab) {
+      const tabRect = activeTab.getBoundingClientRect();
+      const parentRect = activeTab.parentElement.getBoundingClientRect();
+
+      if(tabRect.x > 0 && parentRect.x > 0) {
+        // Calculate the underline position and width based on the active tab
+        this.underlineLeft = `${tabRect.left - parentRect.left}px`;
+        this.underlineWidth = `${tabRect.width}px`;
+      }
+
+      this.cdr.detectChanges();
+    }
+  }
+
+  async save() {
+    const tagIds = this.taggingService.finalTags.map(tag => {
+ return tag._id;
+});
+    const topicIds = this.taggingService.finalTopics.map(topic => {
+ return topic._id;
+});
+
+    if(topicIds.length > 0) {
+      await this.topicService.updateObjectTopics(this.learningObject.id, topicIds);
+    }
+
+    if(tagIds.length > 0) {
+      await this.tagsService.updateObjectTags(this.learningObject.cuid, tagIds);
+    }
+
+    this.close.emit();
+  }
+
+  cancel() {
+    this.close.emit();
   }
 
 }

--- a/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
+++ b/src/app/cube/details/components/action-panel/editorial-action-pad/tagging-builder/tagging-builder.component.ts
@@ -64,6 +64,7 @@ export class TaggingBuilderComponent implements OnInit, AfterViewInit {
 
   /**
    * Switches the tab and only has two valid options 'topics' or 'tags'
+   * Note: This can be expanded if we need in the future
    * @param tab
    */
   switchTab(tab: 'topics' | 'tags') {
@@ -99,13 +100,15 @@ export class TaggingBuilderComponent implements OnInit, AfterViewInit {
   }
 
   async save() {
+    // Clean the selected arrays into string arrays for the PUT request
     const tagIds = this.taggingService.finalTags.map(tag => {
- return tag._id;
-});
+      return tag._id;
+    });
     const topicIds = this.taggingService.finalTopics.map(topic => {
- return topic._id;
-});
+      return topic._id;
+    });
 
+    // Only send a request if there are selected options to avoid a 400 from the service
     if(topicIds.length > 0) {
       await this.topicService.updateObjectTopics(this.learningObject.id, topicIds);
     }

--- a/src/app/cube/details/details.module.ts
+++ b/src/app/cube/details/details.module.ts
@@ -30,6 +30,7 @@ import { ReviewerPanelComponent } from './components/reviewer-panel/reviewer-pan
 import { CubePatternComponent } from './components/cube-pattern/cube-pattern.component';
 import { RouteBackwardsCompatGuard } from '../core/route-backwards-compat.guard';
 import { OnionCoreModule } from '../../onion/core/core.module';
+
 @NgModule({
   imports: [
     CommonModule,

--- a/src/entity/index.ts
+++ b/src/entity/index.ts
@@ -6,6 +6,7 @@ import { LearningOutcome } from './learning-outcome/learning-outcome';
 import { SubmittableLearningOutcome } from './learning-outcome/submittable-learning-outcome';
 import { Collection } from './collection/collection';
 import { Topic } from './topic/topic';
+import { Tag } from './tags/tag';
 
 // Exports All Interfaces
 export {
@@ -17,4 +18,5 @@ export {
   Guideline,
   Collection,
   Topic,
+  Tag
 };

--- a/src/entity/learning-object/learning-object.ts
+++ b/src/entity/learning-object/learning-object.ts
@@ -287,6 +287,14 @@ export class LearningObject {
     this._topics = topics;
   }
 
+  get tags(): string[] {
+    return this._tags;
+  }
+
+  set tags(tags) {
+    this._tags;
+  }
+
   version = 0;
 
   /**
@@ -369,6 +377,7 @@ export class LearningObject {
   };
   private _nextCheck: Date;
   private _topics: string[];
+  private _tags: string[];
 
   private _revisionUri?: string;
 
@@ -745,6 +754,10 @@ export class LearningObject {
       this._topics = object.topics;
     }
 
+    if (object.tags) {
+      this._tags = object.tags;
+    }
+
     this.collection = object.collection as string || this.collection;
     this.status = object.status as LearningObject.Status || this.status;
     this.metrics = object.metrics as LearningObject.Metrics || this.metrics;
@@ -787,6 +800,7 @@ export class LearningObject {
       revision: this.revision,
       assigned: this.assigned,
       topics: this.topics || [],
+      tags: this.tags || []
     };
     return object;
   }

--- a/src/entity/tags/tag.ts
+++ b/src/entity/tags/tag.ts
@@ -1,0 +1,6 @@
+export interface Tag {
+    _id: string,
+    name: string,
+    type: string,
+    description: string
+}


### PR DESCRIPTION
This PR adds an option to the editor-action-panel to tag a learning object. This option will only be available to admins and editors at the moment, but can be expanded to the mapper access group in the future. 

Please note there is some overlap between this and https://github.com/Cyber4All/clark-client/pull/1958. I will remedy merge conflicts when this is ready to go. 

Video of implementation:

https://github.com/user-attachments/assets/db968458-8de7-46e0-8d17-e275f5bc22f8

