### PR TITLE
Bug/sc 35721/look into ratings 404 on the details page

### DIFF
--- a/src/app/core/rating-module/rating.service.ts
+++ b/src/app/core/rating-module/rating.service.ts
@@ -226,10 +226,6 @@ export class RatingService {
           });
           return { avgValue: learningObjectRatings.avgValue, ratings };
         } 
-        // else {
-        //   // return;
-        //   console.log('FIX ME: No ratings found for learning object');
-        // }
       });
   }
 

--- a/src/app/core/rating-module/rating.service.ts
+++ b/src/app/core/rating-module/rating.service.ts
@@ -198,6 +198,8 @@ export class RatingService {
     cuid: string,
     version: number,
   ): Promise<LearningObjectRatings> {
+    // console.log("cuid: " + cuid);
+    // console.log("version: " + version);
     return this.http
       .get(
         RATING_ROUTES.GET_LEARNING_OBJECT_RATINGS(
@@ -223,9 +225,11 @@ export class RatingService {
             return mappedRating;
           });
           return { avgValue: learningObjectRatings.avgValue, ratings };
-        } else {
-          console.log('FIX ME: No ratings found for learning object');
-        }
+        } 
+        // else {
+        //   // return;
+        //   console.log('FIX ME: No ratings found for learning object');
+        // }
       });
   }
 

--- a/src/app/core/rating-module/rating.service.ts
+++ b/src/app/core/rating-module/rating.service.ts
@@ -225,7 +225,7 @@ export class RatingService {
             return mappedRating;
           });
           return { avgValue: learningObjectRatings.avgValue, ratings };
-        } 
+        }
       });
   }
 

--- a/src/app/core/rating-module/rating.service.ts
+++ b/src/app/core/rating-module/rating.service.ts
@@ -198,8 +198,6 @@ export class RatingService {
     cuid: string,
     version: number,
   ): Promise<LearningObjectRatings> {
-    // console.log("cuid: " + cuid);
-    // console.log("version: " + version);
     return this.http
       .get(
         RATING_ROUTES.GET_LEARNING_OBJECT_RATINGS(


### PR DESCRIPTION
404 not found error was originally coming from the get ratings route if a learning object had no ratings, but no longer is an issue and is just returning an empty array as it should be, so the 'fix me' console log has been removed 