### PR TITLE
json.parse for error message in profile update component

### DIFF
--- a/src/app/cube/user-profile/components/edit-profile/edit-profile.component.ts
+++ b/src/app/cube/user-profile/components/edit-profile/edit-profile.component.ts
@@ -159,7 +159,7 @@ export class EditProfileComponent implements OnChanges, OnInit {
     } catch (e) {
       // FIXME: No errors are being caught/thrown from user service
       if (e.status === 400) {
-        this.noteService.error('Error!', e.error);
+        this.noteService.error('Error!', JSON.parse(e.error).message);
       } else {
         this.noteService.error('Error!', 'We couldn\'t update your user information!');
       }


### PR DESCRIPTION
Fixed the issue of the unparsed error message being shown to the user on the post user/:username route when sending no new info to update their profile, this change does not affect the other error messages so other errors are still shown properly.