### PR TITLE
fix: [sc-35850] Look into collection statistics issues

### DIFF
--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -32,7 +32,7 @@ export class StatsComponent implements OnInit {
     await this.metricService.getCollectionMetrics(this.collectionName).then((res: any) => {
       this.objDownload = res.downloads;
       this.objSaved = res.saves;
-      this.objReleased = res.statusMetrics[0].count;
+      this.objReleased = res.statusMetrics[0].released;
       const num = res.statusMetrics[0].waiting + res.statusMetrics[0].peerReview + res.statusMetrics[0].proofing;
       this.objReview = num;
       this.authorCollection = res.authors.length;


### PR DESCRIPTION
The NCyTE dashboard stats would return an incorrect count of released learning objects because we were using a total count of learning objects, instead of the count for released learning objects.

See clark-service PR [here](https://github.com/Cyber4All/clark-service/pull/342)
Story details: https://app.shortcut.com/clarkcan/story/35850