### PR TITLE
Swapped card api url and updated links to card

### DIFF
--- a/src/app/core/client-module/navBarDropdown.service.ts
+++ b/src/app/core/client-module/navBarDropdown.service.ts
@@ -33,7 +33,7 @@ export class NavbarDropdownService {
     public showNavbars = new BehaviorSubject<boolean>(true);
 
     public externalResources = [
-    {name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.directory'},
+    {name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.clark.center'},
     {name: 'Standard Guidelines Tool', link: 'https://standard-guidelines.clark.center'},
     {name: 'Competency Library', link: 'https://lib.cybercompetencies.com'},
     {name: 'CPNC Competency Constructor', link: 'https://cybercompetencies.com'},

--- a/src/app/core/utility-module/utility.service.ts
+++ b/src/app/core/utility-module/utility.service.ts
@@ -127,7 +127,7 @@ export class UtilityService {
   public openCard() {
     // Ask the user if they are sure they want to leave
     if (confirm('You are now leaving CLARK. You will be redirected to the CAE Resource Directory.')) {
-      window.open('https://caeresource.directory', '_blank');
+      window.open('https://caeresource.clark.center', '_blank');
     }
   }
 

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -29,7 +29,7 @@
             (activate)="toggleFilters()">{{ copy.FILTERS }} <i class="far fa-sliders-h"></i></button>
           <button *ngIf="showClearSort" aria-label="Clear sort selection" tip="Clear sorting criteria"
             tipPosition="bottom" (activate)="clearSort($event)" class="clear"><i class="far fa-times"></i></button>
-          <a class="search-CARD" id="search-CARD" href="https://caeresource.directory/browse?q={{ query?.text }}"
+          <a class="search-CARD" id="search-CARD" href="https://caeresource.clark.center/browse?q={{ query?.text }}"
             target=_blank *ngIf="query?.text?.length > 0">Search for non-curricular resources</a>
           <button #sortMenuButtonElement aria-label="Sort Search Results" class="button sort"
             (activate)="toggleSortMenu(true)">Sort By: {{ sortText }}<i class="far fa-angle-down"></i></button>

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -7,7 +7,7 @@ export const environment = {
   cognitoRegion: 'us-east-1',
   cognitoIdentityPoolId: 'us-east-1:1ad4e60a-9773-4a67-92b5-6cc2c7b3328f',
   cognitoAdminIdentityPoolId: 'us-east-1:6691336e-11a1-48db-9774-5f5a2c8dc270',
-  cardUrl: 'https://api-gateway.caeresource.directory',
+  cardUrl: 'https://api.clark.center',
 };
 
 export enum LearningObjectStatus {


### PR DESCRIPTION
The cardUrl environment variable was swapped from api-gateway.caeresource.directory to api.clark.center, which is used to display the number of resources on the Clark homepage. Also changed the links to card from caeresource.directory to caeresource.clark.center