### PR TITLE
feat: [sc-35934] Extend ValidateFileNames function in clark-client to check for non-suggested characters before s3 upload

### DIFF
--- a/src/app/onion/learning-object-builder/components/content-upload/app/services/file-management.service.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/services/file-management.service.ts
@@ -84,9 +84,21 @@ export class FileManagementService {
    * @param cuid The cuid of the file
    */
   private validateFileNames(files: FileInput[], cuid: string) {
-    files.forEach(file => {
+    // A pattern matching bad charaters per AWS S3. (https://regex101.com/r/DFTn1M/1)
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+    const badCharPattern = /[&$@=;\/\\:+,?{\^}%`"\[\]~#|]/gm;
+
+    files.forEach((file) => {
+      if (badCharPattern.test(file.name)) {
+        throw new Error(
+          `File name contains one or more invalid characters: & $ @ = ; / : + , ? \\ { ^ } % \` \] \" > [ ~ < # |`,
+        );
+      }
+
       if (file.name === `${cuid}.zip`) {
-        throw new Error(`Cannot upload file with name ${cuid}.zip because this is a reserved file name`);
+        throw new Error(
+          `Cannot upload file with name ${cuid}.zip because this is a reserved file name`,
+        );
       }
     });
   }

--- a/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
+++ b/src/app/onion/learning-object-builder/components/content-upload/app/upload/upload.component.ts
@@ -562,6 +562,8 @@ export class UploadComponent implements OnInit, AfterViewInit, OnDestroy {
     } catch (e) {
       if (e.name === UploadErrorReason.Credentials) {
         this.handleCredentialsError();
+      } else if (e.message.includes('File name contains')) {
+        this.error$.next(e.message);
       } else {
         this.error$.next(UPLOAD_ERRORS.SERVICE_ERROR);
       }


### PR DESCRIPTION
Users can no longer add files with invalid file names

Story details: https://app.shortcut.com/clarkcan/story/35934