### PR TITLE
:sparkles: Fix the profile info panel

### DIFF
--- a/src/app/cube/user-profile/components/profile-header/profile-header.component.html
+++ b/src/app/cube/user-profile/components/profile-header/profile-header.component.html
@@ -8,7 +8,7 @@
         </div>
         <div class="edit" *ngIf="isUser" (activate)="editProfile = true">
             <i class="far fa-pencil"></i>
-            <span id="edit-profile">EDIT PROFILE</span>
+            <span id="edit-profile">EDIT</span>
         </div>
     </div>
     <div class="user-profile-bio_wrapper">

--- a/src/app/cube/user-profile/components/profile-header/profile-header.component.scss
+++ b/src/app/cube/user-profile/components/profile-header/profile-header.component.scss
@@ -46,7 +46,6 @@
             display: flex;
             flex-direction: column;
             vertical-align: top;
-            line-height: 5px;
             margin: 20px;
             color: $dark-grey;
             z-index: 2;


### PR DESCRIPTION
This PR just removes the line height requirement that was causing organizations stretching across 2 lines to be put on top of one another. 