### PR TITLE
:fire: Unecessary catch

### DIFF
--- a/src/app/auth/email-verified/email-verified.component.ts
+++ b/src/app/auth/email-verified/email-verified.component.ts
@@ -44,12 +44,6 @@ export class EmailVerifiedComponent implements OnInit {
         this.iconSuccess = true;
         this.h1Message = 'Email Verified!';
         this.pMessage = 'Welcome to CLARK!';
-      })
-      .catch(e => {
-        // Unauthenticated login, invalid token
-        this.iconSuccess = false;
-        this.h1Message = 'Invalid Log In';
-        this.pMessage = 'Your token was invalid. Please log in to refresh your token.';
       });
     }
   }


### PR DESCRIPTION
This PR removes an unnecessary catch that was always executing. The check token is meant to refresh the token for the updated emailVerified, we don't care if the login session failed because they go to login anyway. 

Fixes: https://app.shortcut.com/clarkcan/story/35902/verification-of-email-page-shows-a-success-and-a-fail-icon