### PR TITLE
Feature/sc 36166/implement learning objects by length chart

### DIFF
--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
     <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
   
-    <clark-ncyte-stats [collectionName]="'cyberskills2work'" [dashboardView]="true"></clark-ncyte-stats>
+    <clark-dashboard-stats [collectionName]="'cyberskills2work'" [dashboardView]="true"></clark-dashboard-stats>
 
     <div class="downloads-header">
       <h2>All Learning Objects</h2>

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
     <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
   
-    <clark-dashboard-stats [collectionName]="'cyberskills2work'" [dashboardView]="true"></clark-dashboard-stats>
+    <clark-dashboard-stats [collectionName]="'cyberskills2work'" [displayCharts]="true"></clark-dashboard-stats>
 
     <div class="downloads-header">
       <h2>All Learning Objects</h2>

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
     <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
   
-    <clark-ncyte-stats [collectionName]="'cyberskills2work'"></clark-ncyte-stats>
+    <clark-ncyte-stats [collectionName]="'cyberskills2work'" [dashboard]="true"></clark-ncyte-stats>
 
     <div class="downloads-header">
       <h2>All Learning Objects</h2>

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
     <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
   
-    <clark-ncyte-stats [collectionName]="'cyberskills2work'" [dashboard]="true"></clark-ncyte-stats>
+    <clark-ncyte-stats [collectionName]="'cyberskills2work'" [dashboardView]="true"></clark-ncyte-stats>
 
     <div class="downloads-header">
       <h2>All Learning Objects</h2>

--- a/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
+++ b/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
@@ -3,7 +3,7 @@
   <clark-collection-feature [collection]="'ncyte'" [learningObjects]="learningObjects" [primaryColor]="'#00305c'"></clark-collection-feature>
   <clark-ncyte-about></clark-ncyte-about>
   <clark-ncyte-curators></clark-ncyte-curators>
-  <clark-ncyte-stats [collectionName]="abvCollection"></clark-ncyte-stats>
+  <clark-ncyte-stats [collectionName]="abvCollection" [dashboard]="false"></clark-ncyte-stats>
 <div>
 <cube-footer></cube-footer>
 

--- a/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
+++ b/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
@@ -3,7 +3,7 @@
   <clark-collection-feature [collection]="'ncyte'" [learningObjects]="learningObjects" [primaryColor]="'#00305c'"></clark-collection-feature>
   <clark-ncyte-about></clark-ncyte-about>
   <clark-ncyte-curators></clark-ncyte-curators>
-  <clark-dashboard-stats [collectionName]="abvCollection" [dashboardView]="false"></clark-dashboard-stats>
+  <clark-dashboard-stats [collectionName]="abvCollection" [displayCharts]="false"></clark-dashboard-stats>
 <div>
 <cube-footer></cube-footer>
 

--- a/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
+++ b/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
@@ -3,7 +3,7 @@
   <clark-collection-feature [collection]="'ncyte'" [learningObjects]="learningObjects" [primaryColor]="'#00305c'"></clark-collection-feature>
   <clark-ncyte-about></clark-ncyte-about>
   <clark-ncyte-curators></clark-ncyte-curators>
-  <clark-ncyte-stats [collectionName]="abvCollection" [dashboardView]="false"></clark-ncyte-stats>
+  <clark-dashboard-stats [collectionName]="abvCollection" [dashboardView]="false"></clark-dashboard-stats>
 <div>
 <cube-footer></cube-footer>
 

--- a/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
+++ b/src/app/collection/pages/collection-ncyte/collection-ncyte.component.html
@@ -3,7 +3,7 @@
   <clark-collection-feature [collection]="'ncyte'" [learningObjects]="learningObjects" [primaryColor]="'#00305c'"></clark-collection-feature>
   <clark-ncyte-about></clark-ncyte-about>
   <clark-ncyte-curators></clark-ncyte-curators>
-  <clark-ncyte-stats [collectionName]="abvCollection" [dashboard]="false"></clark-ncyte-stats>
+  <clark-ncyte-stats [collectionName]="abvCollection" [dashboardView]="false"></clark-ncyte-stats>
 <div>
 <cube-footer></cube-footer>
 

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
@@ -43,7 +43,7 @@
     </div>
 
 
-<div class="bottom" *ngIf="this.dashboard === true">
+<div class="bottom" *ngIf="this.dashboardView === true">
     <clark-top-downloads [learningObjects]="learningObjects"></clark-top-downloads>
     <cube-distribution-chart 
       class="chart"

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
@@ -43,7 +43,7 @@
     </div>
 
 
-<div class="bottom" *ngIf="this.dashboardView === true">
+<div class="bottom" *ngIf="this.displayCharts === true">
     <clark-top-downloads [learningObjects]="learningObjects"></clark-top-downloads>
     <cube-distribution-chart 
       class="chart"

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.html
@@ -43,7 +43,7 @@
     </div>
 
 
-<div class="bottom">
+<div class="bottom" *ngIf="this.dashboard === true">
     <clark-top-downloads [learningObjects]="learningObjects"></clark-top-downloads>
     <cube-distribution-chart 
       class="chart"

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.scss
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.scss
@@ -101,7 +101,7 @@
         display: grid;
         grid-template-columns: 60% 40%;
         justify-content: center;
-        align-items: center;
+        align-items: flex-start;
         gap: 10px;
     }
 }

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -14,7 +14,7 @@ let CHART_HOVERED = false;
 export class StatsComponent implements OnInit {
 
   @Input() collectionName: string;
-  @Input() dashboard: boolean;
+  @Input() dashboardView: boolean;
   name: string;
   // dashboardView: boolean;
 

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -7,7 +7,7 @@ import { PieChart } from 'app/cube/usage-stats/types/chart';
 // If CHART_HOVERED, tooltips are visible and we do not want to render percentages over tooltips
 let CHART_HOVERED = false;
 @Component({
-  selector: 'clark-ncyte-stats',
+  selector: 'clark-dashboard-stats',
   templateUrl: './stats.component.html',
   styleUrls: ['./stats.component.scss']
 })

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -14,7 +14,9 @@ let CHART_HOVERED = false;
 export class StatsComponent implements OnInit {
 
   @Input() collectionName: string;
+  @Input() dashboard: boolean;
   name: string;
+  // dashboardView: boolean;
 
   objDownload: number;
   objReview: number;
@@ -90,11 +92,11 @@ export class StatsComponent implements OnInit {
       type: 'doughnut',
       labels: ['Nanomodule', 'Micromodule', 'Module', 'Unit', 'Course'],
       data: [
-        stats.lengthMetrics.nanomodule,
-        stats.lengthMetrics.micromodule,
-        stats.lengthMetrics.module,
-        stats.lengthMetrics.unit,
-        stats.lengthMetrics.course,
+        stats.lengthMetrics.nanomodules,
+        stats.lengthMetrics.micromodules,
+        stats.lengthMetrics.modules,
+        stats.lengthMetrics.units,
+        stats.lengthMetrics.courses,
       ],
       legend: true,
       options: {

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -14,7 +14,7 @@ let CHART_HOVERED = false;
 export class StatsComponent implements OnInit {
 
   @Input() collectionName: string;
-  @Input() dashboardView: boolean;
+  @Input() displayCharts: boolean;
   name: string;
 
   objDownload: number;

--- a/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
+++ b/src/app/collection/pages/collection-ncyte/components/stats/stats.component.ts
@@ -16,7 +16,6 @@ export class StatsComponent implements OnInit {
   @Input() collectionName: string;
   @Input() dashboardView: boolean;
   name: string;
-  // dashboardView: boolean;
 
   objDownload: number;
   objReview: number;

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="header">NCyTE Statistics Dashboard</h1>
 
-  <clark-ncyte-stats [collectionName]="'ncyte'"></clark-ncyte-stats>
+  <clark-ncyte-stats [collectionName]="'ncyte'" [dashboard]="true"></clark-ncyte-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
   <div class="downloads-body">

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="header">NCyTE Statistics Dashboard</h1>
 
-  <clark-ncyte-stats [collectionName]="'ncyte'" [dashboard]="true"></clark-ncyte-stats>
+  <clark-ncyte-stats [collectionName]="'ncyte'" [dashboardView]="true"></clark-ncyte-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
   <div class="downloads-body">

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="header">NCyTE Statistics Dashboard</h1>
 
-  <clark-ncyte-stats [collectionName]="'ncyte'" [dashboardView]="true"></clark-ncyte-stats>
+  <clark-dashboard-stats [collectionName]="'ncyte'" [dashboardView]="true"></clark-dashboard-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
   <div class="downloads-body">

--- a/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
+++ b/src/app/collection/pages/collection-ncyte/dashboard/dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="container">
   <h1 class="header">NCyTE Statistics Dashboard</h1>
 
-  <clark-dashboard-stats [collectionName]="'ncyte'" [dashboardView]="true"></clark-dashboard-stats>
+  <clark-dashboard-stats [collectionName]="'ncyte'" [displayCharts]="true"></clark-dashboard-stats>
 
   <h2 class="downloads-header">Individual Learning Objects</h2>
   <div class="downloads-body">

--- a/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
+++ b/src/app/cube/usage-stats/top-downloads/top-downloads.component.scss
@@ -6,6 +6,7 @@ $row-gap: 25px;
     color: $dark-grey;
     font-size: $normal;
     padding: 15px 20px 15px;
+    margin-left: 20%;
 
     .title {
       color: $darker-grey;


### PR DESCRIPTION
The pie chart is implemented on the CyberSkills2Work dashboard displaying the length metrics for the learning objects in their collection. The chart displays the correct data from the new lengthMetrics property returned in the GET /metrics route, and is responsive to give exact values when portions of it are clicked. The pie chart along with the top downloads table are integrated with the clark-ncyte-stats component which appears in both the ncyte dashboard and ncyte collection page. The extra boolean value was added to the stats component so that we can toggle between dashboard view which displays the pie chart and top download metrics, and the collection page view which should not.