### PR TITLE
Add popup for date selection and implement CSV Gen 

### DIFF
--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -122,12 +122,12 @@
     <div class="modal-title">Filter Learning Objects by Next Check Date</div>
     <div class="modal__inner">
       <mat-form-field class="input">
-        <input matInput [matDatepicker]="startPicker" placeholder="Choose a start date" [(ngModel)]="relevancyStart" >
+        <input matInput [matDatepicker]="startPicker" placeholder="Choose a start date" [(ngModel)]="relevancyStart">
         <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
         <mat-datepicker #startPicker startView="year" [startAt]="relevancyStart"></mat-datepicker>
       </mat-form-field>
       <mat-form-field class="input">
-        <input matInput [matDatepicker]="endPicker" placeholder="Choose an end date" [(ngModel)]="relevancyEnd" >
+        <input matInput [matDatepicker]="endPicker" placeholder="Choose an end date" [(ngModel)]="relevancyEnd">
         <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
         <mat-datepicker #endPicker startView="year" [startAt]="relevancyEnd"></mat-datepicker>
       </mat-form-field>
@@ -140,6 +140,6 @@
         <button class="button neutral" (activate)="toggleRelevancyMenu()">Cancel</button>
         <button class="button good" (activate)="setDates()">Apply</button>
       </div>
-  </div>
+    </div>
   </div>
 </clark-popup>

--- a/src/app/collection/collection.module.ts
+++ b/src/app/collection/collection.module.ts
@@ -40,6 +40,7 @@ import { CyberskillsDashboardComponent } from './cyberskills-dashboard/cyberskil
 import { UsageStatsModule } from '../cube/usage-stats/usage-stats.module';
 import { DetailsModule } from '../cube/details/details.module';
 import { LibraryModule } from '../cube/library/library.module';
+import { CsvGenModalComponent } from './cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component';
 
 @NgModule({
   declarations: [
@@ -62,7 +63,8 @@ import { LibraryModule } from '../cube/library/library.module';
     TitleComponent,
     FeaturedComponent,
     NcyteDashboardComponent,
-    CyberskillsDashboardComponent
+    CyberskillsDashboardComponent,
+    CsvGenModalComponent
   ],
   schemas: [
     NO_ERRORS_SCHEMA,

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.html
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.html
@@ -1,0 +1,21 @@
+<clark-popup *ngIf="showModal" (closed)="onCancel()">
+    <div class="modal-container" #popupInner>
+        <div class="modal-title">CSV Report of CyberSkills2Work Learning Objects</div>
+        <div class="modal__inner">
+            <mat-form-field>
+                <mat-label>Select a date range</mat-label>
+                <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
+                    <input matStartDate formControlName="start" placeholder="Start date">
+                    <input matEndDate formControlName="end" placeholder="End date">
+                </mat-date-range-input>
+                <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
+                <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+                <mat-date-range-picker #picker></mat-date-range-picker>
+            </mat-form-field>
+        </div>
+        <div class="btn-group select">
+            <button class="button neutral" (click)="onCancel()">Cancel</button>
+            <button class="button good" (click)="generateCSV()">Download</button>
+        </div>
+    </div>
+</clark-popup>

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.html
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.html
@@ -15,7 +15,7 @@
         </div>
         <div class="btn-group select">
             <button class="button neutral" (click)="onCancel()">Cancel</button>
-            <button class="button good" (click)="generateCSV()">Download</button>
+            <button class="button good" (click)="onDownload()">Download</button>
         </div>
     </div>
 </clark-popup>

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.scss
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.scss
@@ -1,0 +1,72 @@
+@import "vars.scss";
+@import "../../../collection-globals.scss";
+
+.modal-container {
+    margin: 0 auto;
+    background-color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem;
+    border-radius: 8px;
+
+    .modal-title {
+        text-align: center;
+        color: $ncyte-blue;
+        font-size: $largest;
+        font-weight: 600;
+        margin-bottom: 1rem;
+    }
+
+    .modal__inner {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-bottom: 1.5rem;
+
+        mat-form-field {
+            width: 100%;
+            max-width: 400px;
+        }
+    }
+
+    .btn-group.select {
+        display: flex;
+        justify-content: center;
+        gap: 1rem;
+        margin-top: 1rem;
+    }
+
+    .button {
+        padding: 16px 27px;
+        background-color: $homepage-light-blue;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        box-shadow: 0px 6px 12px -6px $homepage-light-blue;
+        width: fit-content;
+
+        &:hover {
+            opacity: 80%;
+        }
+
+        &:active {
+            opacity: 100%;
+        }
+
+        &.neutral {
+            background-color: #999;
+        }
+    }
+}
+
+@media (max-width: 480px) {
+    .modal-container {
+        padding: 1rem;
+    }
+
+    .button {
+        padding: 10px 16px;
+    }
+}

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.spec.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CsvGenModalComponent } from './csv-gen-modal.component';
+
+describe('CsvGenModalComponent', () => {
+  let component: CsvGenModalComponent;
+  let fixture: ComponentFixture<CsvGenModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CsvGenModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CsvGenModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+
+@Component({
+  selector: 'clark-csv-gen-modal',
+  templateUrl: './csv-gen-modal.component.html',
+  styleUrls: ['./csv-gen-modal.component.scss'],
+})
+export class CsvGenModalComponent implements OnInit {
+  @Output() generateCSV = new EventEmitter<{ start: Date; end: Date }>();
+  @Output() closed = new EventEmitter<void>();
+
+  range: FormGroup;
+  filterSelected = false;
+  showModal = true;
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.range = this.fb.group({
+      start: [null],
+      end: [null],
+    });
+  }
+
+  clearDates(): void {
+    this.range.reset();
+    this.filterSelected = false;
+  }
+
+  generateCsv(): void {}
+
+  onCancel(): void {
+    this.closeModal();
+  }
+
+  closeModal(): void {
+    this.showModal = false;
+    this.closed.emit();
+  }
+}

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -27,6 +27,7 @@ export class CsvGenModalComponent implements OnInit {
       start: [null],
       end: [null],
     });
+    document.body.classList.add('no-scroll');
   }
 
   clearDates(): void {
@@ -60,10 +61,12 @@ export class CsvGenModalComponent implements OnInit {
 
   onCancel(): void {
     this.closeModal();
+    document.body.classList.remove('no-scroll');
   }
 
   closeModal(): void {
     this.showModal = false;
+    document.body.classList.remove('no-scroll');
     this.closed.emit();
   }
 }

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -27,7 +27,6 @@ export class CsvGenModalComponent implements OnInit {
       start: [null],
       end: [null],
     });
-    document.body.classList.add('no-scroll');
   }
 
   clearDates(): void {
@@ -61,12 +60,10 @@ export class CsvGenModalComponent implements OnInit {
 
   onCancel(): void {
     this.closeModal();
-    document.body.classList.remove('no-scroll');
   }
 
   closeModal(): void {
     this.showModal = false;
-    document.body.classList.remove('no-scroll');
     this.closed.emit();
   }
 }

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -51,7 +51,7 @@ export class CsvGenModalComponent implements OnInit {
         end: end,
       },
     );
-    
+
     this.toaster.alert(
       'We\'re working on it!',
       'Please wait while we generate the report.',

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { FormGroup, FormBuilder } from '@angular/forms';
+import { ReportService } from '../../../../core/report-module/report.service';
+import { ToastrOvenService } from '../../../../shared/modules/toaster/notification.service';
 
 @Component({
   selector: 'clark-csv-gen-modal',
@@ -14,7 +16,11 @@ export class CsvGenModalComponent implements OnInit {
   filterSelected = false;
   showModal = true;
 
-  constructor(private fb: FormBuilder) {}
+  constructor(
+    private fb: FormBuilder,
+    private toaster: ToastrOvenService,
+    private reportService: ReportService,
+  ) {}
 
   ngOnInit(): void {
     this.range = this.fb.group({
@@ -28,7 +34,28 @@ export class CsvGenModalComponent implements OnInit {
     this.filterSelected = false;
   }
 
-  generateCsv(): void {}
+  onDownload(): void {
+    if (!this.range.value.start && !this.range.value.end) {
+      this.toaster.error('Error!', 'Please enter a date range.');
+      return;
+    }
+
+    const start = `${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`;
+    const end = `${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`;
+
+    this.reportService.generateCollectionReport(
+      ['cyberskills2work'],
+      `cyberskills2work_from_${start}_to_${end}`,
+      {
+        start: start,
+        end: end,
+      },
+    );
+    this.toaster.alert(
+      "We're working on it!",
+      'Please wait while we generate the report.',
+    );
+  }
 
   onCancel(): void {
     this.closeModal();

--- a/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
+++ b/src/app/collection/cyberskills-dashboard/components/csv-gen-modal/csv-gen-modal.component.ts
@@ -51,8 +51,9 @@ export class CsvGenModalComponent implements OnInit {
         end: end,
       },
     );
+    
     this.toaster.alert(
-      "We're working on it!",
+      'We\'re working on it!',
       'Please wait while we generate the report.',
     );
   }

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -79,21 +79,6 @@
   </div>
   <clark-pagination [lastPageNumber]="lastPage" [currentPageNumber]="currPage"
     (newPageNumberClicked)='handlePaginationAndLoadItems($event)'></clark-pagination>
-  <!-- <h2 class="downloads-header">Individual Learning Object Report</h2>
-    <div class="downloads-body">
-      <mat-form-field>
-        <mat-label>Enter a date range</mat-label>
-        <mat-date-range-input [formGroup]="range" [rangePicker]="picker">
-          <input matStartDate formControlName="start" placeholder="Start date">
-          <input matEndDate formControlName="end" placeholder="End date">
-        </mat-date-range-input>
-        <mat-hint>MM/DD/YYYY - MM/DD/YYYY</mat-hint>
-        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-        <mat-date-range-picker #picker></mat-date-range-picker>
-      </mat-form-field>
-      <br>
-      <button (click)="onDownload()">Download a CSV of All Individual Learning Objects</button>
-    </div> -->
 </div>
 <cube-footer></cube-footer>
 

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -8,7 +8,7 @@
     <div class="buttons">
       <button id="status" class="button neutral">Status <i class="fa fa-caret-down"></i></button>
       <button id="status" class="button neutral">Length <i class="fa fa-caret-down"></i></button>
-      <button class="button good" (click)="openCsvGenModal()">Download a CSV of All Learning Objects</button>
+      <button class="button good" (click)="openCsvGenModal()">Download CSV of Released Learning Objects</button>
     </div>
   </div>
 

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -1,75 +1,79 @@
 <div class="container">
-    <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
-  
-    <clark-ncyte-stats [collectionName]="'cyberskills2work'"></clark-ncyte-stats>
+  <h1 class="title">CyberSkills2Work Collection Statistics Dashboard</h1>
 
-    <div class="downloads-header">
-      <h2>All Learning Objects</h2>
-      <div class="buttons">
-        <button id="status" class="button neutral">Status <i class="fa fa-caret-down"></i></button>
-        <button id="status" class="button neutral">Length <i class="fa fa-caret-down"></i></button>
-        <button class="button good" (click)="onDownload()">Download a CSV of All Learning Objects</button>
-      </div>
+  <clark-ncyte-stats [collectionName]="'cyberskills2work'"></clark-ncyte-stats>
+
+  <div class="downloads-header">
+    <h2>All Learning Objects</h2>
+    <div class="buttons">
+      <button id="status" class="button neutral">Status <i class="fa fa-caret-down"></i></button>
+      <button id="status" class="button neutral">Length <i class="fa fa-caret-down"></i></button>
+      <button class="button good" (click)="openCsvGenModal()">Download a CSV of All Learning Objects</button>
+    </div>
+  </div>
+
+  <div class="learning-object-table">
+    <div class="header">
+      <span>Status</span>
+      <span>Length</span>
+      <span>Name</span>
+      <span>Last Updated <i class="fa fa-caret-down"></i></span>
+      <span>Downloads</span>
+      <span>Rating <i class="fa fa-caret-down"></i></span>
+      <span></span>
     </div>
 
-    <div class="learning-object-table">
-      <div class="header">
-        <span>Status</span>
-        <span>Length</span>
-        <span>Name</span>
-        <span>Last Updated <i class="fa fa-caret-down"></i></span>
-        <span>Downloads</span>
-        <span>Rating <i class="fa fa-caret-down"></i></span>
-        <span></span>
+    <div *ngFor="let learningObject of learningObjects" class="row">
+      <!-- Status -->
+      <div class="status" tabindex="0"
+        [attr.aria-label]="'Learning Object Status: ' + learningObject.status + '. ' + statusDescription"
+        [ngClass]="learningObject.status">
+        <span *ngIf="learningObject.status === 'unreleased'"><i class="fas fa-eye-slash"></i></span>
+        <span *ngIf="learningObject.status === 'waiting'"><i class="fas fa-hourglass"></i></span>
+        <span *ngIf="learningObject.status === 'review'"><i class="fas fa-sync"></i></span>
+        <span *ngIf="learningObject.status === 'proofing'"><i class="fas fa-shield"></i></span>
+        <span *ngIf="learningObject.status === 'released'"><i class="fas fa-eye"></i></span>
+        <span *ngIf="learningObject.status === 'rejected'"><i class="fas fa-ban"></i></span>
+        <span *ngIf="learningObject.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
+        <span *ngIf="learningObject.status === 'accepted_major'"><i class="fas fa-check"></i></span>
       </div>
-    
-      <div *ngFor="let learningObject of learningObjects" class="row">
-        <!-- Status -->
-        <div class="status" tabindex="0" [attr.aria-label]="'Learning Object Status: ' + learningObject.status + '. ' + statusDescription" [ngClass]="learningObject.status">
-          <span *ngIf="learningObject.status === 'unreleased'"><i class="fas fa-eye-slash"></i></span>
-          <span *ngIf="learningObject.status === 'waiting'"><i class="fas fa-hourglass"></i></span>
-          <span *ngIf="learningObject.status === 'review'"><i class="fas fa-sync"></i></span>
-          <span *ngIf="learningObject.status === 'proofing'"><i class="fas fa-shield"></i></span>
-          <span *ngIf="learningObject.status === 'released'"><i class="fas fa-eye"></i></span>
-          <span *ngIf="learningObject.status === 'rejected'"><i class="fas fa-ban"></i></span>
-          <span *ngIf="learningObject.status === 'accepted_minor'"><i class="fas fa-check-double"></i></span>
-          <span *ngIf="learningObject.status === 'accepted_major'"><i class="fas fa-check"></i></span>
-        </div>
-    
-        <!-- Length -->
-        <div class="info">
-          <clark-details-splash-length [length]="learningObject.length"></clark-details-splash-length>
-        </div>
 
-        <!-- Name -->
-        <div class="info name">{{ learningObject.name }}</div>
-    
-        <!-- Last Updated -->
-        <div class="info date">
-          {{ learningObject.date | date:'MM/dd/yyyy' }}
-        </div>
-    
-        <!-- Downloads (only if released) -->
-        <div class="info">
-          <span *ngIf="learningObject.status === 'released'">{{ learningObject.metrics.downloads }}</span>
-        </div>
-    
-        <!-- Rating (only if released) -->
-        <div class="info">
-          <clark-rating-stars *ngIf="learningObject.status === 'released'" [rating]="learningObject.rating ? learningObject.rating : 0" color="gold"></clark-rating-stars>
-        </div>
-    
-        <!-- Actions -->
-        <div class="info">
-          <a [routerLink]="['/details', learningObject.author.username, learningObject.cuid]" class="details-link">View Details ></a>
-        </div>
+      <!-- Length -->
+      <div class="info">
+        <clark-details-splash-length [length]="learningObject.length"></clark-details-splash-length>
+      </div>
+
+      <!-- Name -->
+      <div class="info name">{{ learningObject.name }}</div>
+
+      <!-- Last Updated -->
+      <div class="info date">
+        {{ learningObject.date | date:'MM/dd/yyyy' }}
+      </div>
+
+      <!-- Downloads (only if released) -->
+      <div class="info">
+        <span *ngIf="learningObject.status === 'released'">{{ learningObject.metrics.downloads }}</span>
+      </div>
+
+      <!-- Rating (only if released) -->
+      <div class="info">
+        <clark-rating-stars *ngIf="learningObject.status === 'released'"
+          [rating]="learningObject.rating ? learningObject.rating : 0" color="gold"></clark-rating-stars>
+      </div>
+
+      <!-- Actions -->
+      <div class="info">
+        <a [routerLink]="['/details', learningObject.author.username, learningObject.cuid]" class="details-link">View
+          Details ></a>
       </div>
     </div>
-    
-      <clark-pagination [lastPageNumber]="lastPage" [currentPageNumber]="currPage"></clark-pagination>
+  </div>
+
+  <clark-pagination [lastPageNumber]="lastPage" [currentPageNumber]="currPage"></clark-pagination>
 
 
-    <!-- <h2 class="downloads-header">Individual Learning Object Report</h2>
+  <!-- <h2 class="downloads-header">Individual Learning Object Report</h2>
     <div class="downloads-body">
       <mat-form-field>
         <mat-label>Enter a date range</mat-label>
@@ -84,6 +88,8 @@
       <br>
       <button (click)="onDownload()">Download a CSV of All Individual Learning Objects</button>
     </div> -->
-  </div>
-  <cube-footer></cube-footer>
-  
+</div>
+<cube-footer></cube-footer>
+
+<clark-csv-gen-modal *ngIf="showCsvModal" (closed)="closeCsvModal()">
+</clark-csv-gen-modal>

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.scss
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.scss
@@ -5,7 +5,6 @@
   min-height: 100vh;
   padding: 20px 50px;
   background-color: white;
-
   display: flex;
   flex-direction: column;
 }
@@ -23,6 +22,7 @@
     font-size: $largest;
     font-weight: 600;
   }
+
   display: flex;
   justify-content: space-between; // Pushes elements to opposite sides
   align-items: center; // Aligns items vertically
@@ -65,11 +65,11 @@
     width: fit-content;
 
     &:hover {
-        opacity: 80%;
+      opacity: 80%;
     }
 
     &:active {
-        opacity: 100%;
+      opacity: 100%;
     }
   }
 }
@@ -84,7 +84,9 @@
 #status {
   margin-right: 10px;
 }
-.header, .row {
+
+.header,
+.row {
   display: grid;
   grid-template-columns: 70px 100px 2fr 1fr 1fr 1fr 1fr;
   align-items: center;
@@ -176,4 +178,3 @@
     box-shadow: 0 0 20px 2px rgba(0, 0, 0, 0.08);
   }
 }
-

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.ts
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit, ViewContainerRef } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
 import { AuthValidationService } from '../../core/auth-module/auth-validation.service';
 import { ReportService } from '../../core/report-module/report.service';
 import { ToastrOvenService } from '../../shared/modules/toaster/notification.service';
-import { LearningObjectRatings, RatingService } from '../../core/rating-module/rating.service';
+import {
+  LearningObjectRatings,
+  RatingService,
+} from '../../core/rating-module/rating.service';
 import { SearchService } from '../../core/learning-object-module/search/search.service';
 import { MetricService } from '../../core/metric-module/metric.service';
 import { OrderBy } from '../../interfaces/query';
@@ -11,19 +13,17 @@ import { OrderBy } from '../../interfaces/query';
 @Component({
   selector: 'clark-cyberskills-dashboard',
   templateUrl: './cyberskills-dashboard.component.html',
-  styleUrls: ['./cyberskills-dashboard.component.scss']
+  styleUrls: ['./cyberskills-dashboard.component.scss'],
 })
 export class CyberskillsDashboardComponent implements OnInit {
-  range = new FormGroup({
-    start: new FormControl(null),
-    end: new FormControl(null),
-  });
   name = this.authValidationService.getInputFormControl('text');
 
   learningObjects: any = [];
 
-  lastPage=8;
+  lastPage = 8;
   currPage = 3;
+  showCsvModal = false;
+
   constructor(
     private toaster: ToastrOvenService,
     private view: ViewContainerRef,
@@ -31,50 +31,43 @@ export class CyberskillsDashboardComponent implements OnInit {
     private reportService: ReportService,
     private ratingService: RatingService,
     private learningObjectService: SearchService,
-    private metricsService: MetricService
-  ) { }
+    private metricsService: MetricService,
+  ) {}
 
   async ngOnInit(): Promise<void> {
     this.toaster.init(this.view);
-    this.learningObjects = (await this.learningObjectService.getLearningObjects(
-      { collection: 'cyberskills2work',
+    this.learningObjects = (
+      await this.learningObjectService.getLearningObjects({
+        collection: 'cyberskills2work',
         limit: 20,
         status: ['released', 'waiting', 'proofing', 'review', 'accepted_major'],
         sortType: 1,
-        orderBy: OrderBy.Date
-      })).learningObjects;
+        orderBy: OrderBy.Date,
+      })
+    ).learningObjects;
     this.learningObjects.forEach(async (lo) => {
       const ratings = await this.getRatings(lo);
-      if(ratings) {
+      if (ratings) {
         lo.ratings = ratings.avgValue;
       }
-      if(lo.status === 'released') {
-        lo.metrics = await this.metricsService.getLearningObjectMetrics(lo.cuid);
+      if (lo.status === 'released') {
+        lo.metrics = await this.metricsService.getLearningObjectMetrics(
+          lo.cuid,
+        );
       }
     });
   }
 
-  onDownload(): void {
-    if (!this.range.value.start && !this.range.value.end) {
-      this.toaster.error('Error!', 'Please enter a date range.');
-      return;
-    }
-
-    const start = `${this.range.value.start.getFullYear()}-${this.range.value.start.getMonth() + 1}-${this.range.value.start.getDate()}`;
-    const end = `${this.range.value.end.getFullYear()}-${this.range.value.end.getMonth() + 1}-${this.range.value.end.getDate()}`;
-
-    this.reportService.generateCollectionReport(['cyberskills2work'], this.name.value, { start: start, end: end });
-    this.toaster.alert('We\'re working on it!', 'Please wait while we generate the report.');
+  openCsvGenModal(): void {
+    this.showCsvModal = true;
   }
 
+  closeCsvModal(): void {
+    this.showCsvModal = false;
+  }
 
   async getRatings(learningObject: any): Promise<any> {
     const { cuid, version } = learningObject;
-    return await this.ratingService.getLearningObjectRatings(
-      cuid,
-      version,
-    );
+    return await this.ratingService.getLearningObjectRatings(cuid, version);
   }
-
 }
-

--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.ts
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.ts
@@ -64,7 +64,7 @@ export class CyberskillsDashboardComponent implements OnInit {
   closeCsvModal(): void {
     this.showCsvModal = false;
   }
-  
+
   async getRatings(learningObject: any): Promise<any> {
     const { cuid, version } = learningObject;
     return await this.ratingService.getLearningObjectRatings(cuid, version);

--- a/src/app/shared/modules/popups/popup.component.ts
+++ b/src/app/shared/modules/popups/popup.component.ts
@@ -63,6 +63,9 @@ export class PopupComponent implements OnInit, AfterViewInit, OnDestroy {
       // no last-focused-element existed on the DOM, set the trigger element instead to the document's activeElement
       this.triggerElement = new ElementRef(document.activeElement as HTMLElement);
     }
+
+    // Prevents scrolling while in this popup
+    document.body.classList.add('no-scroll');
   }
 
   ngAfterViewInit() {
@@ -119,6 +122,8 @@ export class PopupComponent implements OnInit, AfterViewInit, OnDestroy {
     this.close();
 
     this.triggerElement.nativeElement.focus();
+    
+    document.body.classList.remove('no-scroll');
   }
 
   close() {

--- a/src/app/shared/modules/popups/popup.component.ts
+++ b/src/app/shared/modules/popups/popup.component.ts
@@ -122,7 +122,7 @@ export class PopupComponent implements OnInit, AfterViewInit, OnDestroy {
     this.close();
 
     this.triggerElement.nativeElement.focus();
-    
+
     document.body.classList.remove('no-scroll');
   }
 

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -21,6 +21,10 @@ body {
   &.hide-outlines * {
     outline: 0 !important;
   }
+
+  &.no-scroll {
+    overflow-y: hidden;
+  }
 }
 
 a,


### PR DESCRIPTION
This PR lets users download a CSV of all released learning objects in the Cyberskills2Work collection (contains the total download, saves, and page view counts). Clicking the button opens a modal where users can select a date range before proceeding with the download. 

Story: https://app.shortcut.com/clarkcan/story/36164/add-popup-for-date-selection-and-implement-csv-generation-in-cyberskills2work-dashboard

This PR also addresses this story: https://app.shortcut.com/clarkcan/story/35946/lock-scroll-when-pop-up-is-open-on-clark

Video Demo:

https://github.com/user-attachments/assets/c8ab8dcf-1110-4417-b7f8-833fcc346bf4




