### PR TITLE
update-competency-redirect-links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "6.3.0",
+      "version": "6.3.1",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/core/client-module/navBarDropdown.service.ts
+++ b/src/app/core/client-module/navBarDropdown.service.ts
@@ -33,13 +33,12 @@ export class NavbarDropdownService {
     public showNavbars = new BehaviorSubject<boolean>(true);
 
     public externalResources = [
-    {name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.clark.center'},
-    {name: 'Standard Guidelines Tool', link: 'https://standard-guidelines.clark.center'},
-    {name: 'Competency Library', link: 'https://lib.cybercompetencies.com'},
-    {name: 'CPNC Competency Constructor', link: 'https://cybercompetencies.com'},
-    {name: 'Curriculum Task Force', link: 'https://cyberedtaskforce.org'},
-    {name: 'Task Tool', link: 'https://tasktool.clark.center'},
-    {name: 'CAE Community Site', link: 'https://www.caecommunity.org/'},
+        { name: 'CAE Resource Directory (CARD)', link: 'https://caeresource.clark.center' },
+        { name: 'Standard Guidelines Tool', link: 'https://standard-guidelines.clark.center' },
+        { name: 'CPNC Competency Constructor', link: 'https://cybercompetencies.com' },
+        { name: 'Curriculum Task Force', link: 'https://cyberedtaskforce.org' },
+        { name: 'Task Tool', link: 'https://tasktool.clark.center' },
+        { name: 'CAE Community Site', link: 'https://www.caecommunity.org/' },
     ];
     public topics = new BehaviorSubject<Topic[]>([]);
     public topicSelection = new BehaviorSubject<Topic>({ _id: '', name: '' });
@@ -84,7 +83,7 @@ export class NavbarDropdownService {
         if (this.resourcesDropdown.getValue()) {
             this.resourcesDropdown.next(false);
         }
-        if(this.browseDropdown.getValue()) {
+        if (this.browseDropdown.getValue()) {
             this.browseDropdown.next(false);
         }
 


### PR DESCRIPTION
Clark was pointing to an outdated competencies link in the "Other Resources" dropdown tab of the navBar. This was simply removed since it is no longer needed after the client and library merge.