### PR TITLE
:sparkles: Add specifications for deprecated query

### DIFF
--- a/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
+++ b/src/app/core/standard-guidelines-module/standard-guidelines.service.ts
@@ -16,6 +16,7 @@ interface GuidelinesFilter {
   limit?: number;
   type?: string;
   frameworks?: string | string[];
+  deprecated?: string
 }
 
 @Injectable({
@@ -68,6 +69,7 @@ export class GuidelineService {
       limit: filter.limit ? filter.limit : undefined,
       type: filter.type !== '' ? filter.type : undefined,
       frameworks: filter.frameworks !== '' ? filter.frameworks : undefined,
+      deprecated: filter.deprecated !== '' ? filter.deprecated: 'all'
     };
   }
 

--- a/src/app/cube/browse/components/guideline-filter/guideline-filter.component.ts
+++ b/src/app/cube/browse/components/guideline-filter/guideline-filter.component.ts
@@ -121,6 +121,7 @@ export class GuidelineFilterComponent implements OnInit, OnDestroy {
     const query: any = {
       text: this.query,
       page: this.page,
+      deprecated: 'all'
     };
     const framework = this.getSelectedFramework();
     if (framework) {

--- a/src/app/cube/home/help/build-program/build-program.component.ts
+++ b/src/app/cube/home/help/build-program/build-program.component.ts
@@ -101,7 +101,8 @@ export class BuildProgramComponent implements OnInit {
   handleFrameworkClicked(event: string) {
     this.buildProgramComponentService.updateCurrentFramework(event);
     this.guidelineService.getGuidelines({
-      frameworks: this.currentFramework
+      frameworks: this.currentFramework,
+      deprecated: 'all'
     })
       .then(result => {
         this.currentFrameworkGuidelines = result.results

--- a/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.ts
+++ b/src/app/onion/learning-object-builder/components/standard-outcomes/standard-outcomes.component.ts
@@ -127,6 +127,7 @@ export class StandardOutcomesComponent implements OnChanges, OnDestroy {
       this.guidelineService
         .getGuidelines({
           text: this.searchStringValue,
+          deprecated: 'false'
         })
         .then((res) => {
           if (this.suggestions.length) {
@@ -153,7 +154,8 @@ export class StandardOutcomesComponent implements OnChanges, OnDestroy {
       this.guidelineService
         .getGuidelines({
           text: val,
-          levels: this.levels
+          levels: this.levels,
+          deprecated: 'false'
         })
         .then((res) => {
           this.suggestions = res.results.map((o) => {

--- a/src/app/onion/relevancy-builder/components/standard-outcomes/standard-outcomes.component.ts
+++ b/src/app/onion/relevancy-builder/components/standard-outcomes/standard-outcomes.component.ts
@@ -101,6 +101,7 @@ export class StandardOutcomesComponent implements OnChanges, OnDestroy {
       this.guidelineService
         .getGuidelines({
           text: this.searchStringValue,
+          deprecated: 'false'
         })
         .then((res) => {
           if (this.suggestions.length) {
@@ -127,6 +128,7 @@ export class StandardOutcomesComponent implements OnChanges, OnDestroy {
       this.guidelineService
         .getGuidelines({
           text: val,
+          deprecated: 'false'
         })
         .then((res) => {
           this.suggestions = res.results.map((o) => {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,7 +5,7 @@
 export const environment = {
   production: false,
   experimental: false,
-  apiURL: 'https://api.clark.center',
+  apiURL: 'http://localhost:3000',
   s3Bucket: 'clark-dev-file-uploads',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',


### PR DESCRIPTION
# Description 
This PR adds the deprecated query to areas of the client where we are querying for the guidelines. 

# Details
In the builder we want to only return non-deprecated alignments for new learning objects or learning objects that are being updated. 

On the browse page we want to return all alignments since there are learning objects still mapped to the old stuff and people should still be able to search by it. 