### PR TITLE
fix: [sc-36240] [Browse] LO Description appears to be truncated/removed incorrectly due to anchor tag

### DIFF
--- a/src/app/cube/shared/learning-object/learning-object.component.ts
+++ b/src/app/cube/shared/learning-object/learning-object.component.ts
@@ -118,7 +118,7 @@ export class LearningObjectListingComponent implements OnInit, OnChanges, OnDest
     // The top regex is used for matching tags such as <br />
     // The bottom regex will catch tags such as </p>
     str = str.replace(/<[0-z\s\'\"=]*[\/]+>/gi, ' ');
-    return str.replace(/<[\/]*[0-z\s\'\"=]+>/gi, ' ');
+    return str.replace(/<(?!\/?a\s+href="[^"\/\"]*")[^>]+>/gi, ' ');
   }
 
   get date() {


### PR DESCRIPTION
There is an issue on the client where descriptions are prematurely cut off because of closing anchor tags, which cause the entirety of the text beyond that tag to be stripped as a result of the regex.

The fix was to edit the regex to match all tags and strip them accordingly.

Story details: https://app.shortcut.com/clarkcan/story/36240