### PR TITLE
Fix Ratings in Cyberskills2Work Dashboard

### DIFF
--- a/src/app/collection/cyberskills-dashboard/components/cyberskills-card/cyberskills-card.component.html
+++ b/src/app/collection/cyberskills-dashboard/components/cyberskills-card/cyberskills-card.component.html
@@ -38,7 +38,7 @@
   <!-- Rating (only if released) -->
   <div class="info" data-label="Rating">
     <clark-rating-stars *ngIf="learningObject.status === 'released'"
-      [rating]="learningObject.rating ? learningObject.rating : 0" color="gold">
+      [rating]="learningObject.averageRating ? learningObject.averageRating : 0" color="gold">
     </clark-rating-stars>
   </div>
 


### PR DESCRIPTION
The rating stars weren't filling in because I wasn't using averageRating.
<img width="1442" alt="Screenshot 2025-03-25 at 1 45 32 PM" src="https://github.com/user-attachments/assets/5fd1c782-96d7-4002-8e57-081add74e4f8" />
