### PR TITLE
Cyberskills2Work Dashboard: Removed filter button when csv modal is opened

### DIFF
--- a/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
+++ b/src/app/collection/cyberskills-dashboard/cyberskills-dashboard.component.html
@@ -5,7 +5,7 @@
 
   <div class="downloads-header">
     <h2>All Learning Objects</h2>
-    <div class="filters-wrap">
+    <div class="filters-wrap" *ngIf="!showCsvModal">
       <!--
         When filterQuery is emitted, we will always load the first page
         because the contents are bound to change and there's no guarantee
@@ -13,7 +13,8 @@
 
         We do the same for clearAll once filterQuery is empty.
       -->
-      <clark-cyberskills-filters (filterQuery)="handlePaginationAndLoadItems(1, $event)"
+      <clark-cyberskills-filters 
+        (filterQuery)="handlePaginationAndLoadItems(1, $event)"
         (clearAll)="handlePaginationAndLoadItems(1, {})">
       </clark-cyberskills-filters>
 


### PR DESCRIPTION
There was an issue in the mobile view of the dashboard where the filter button appeared on top of the CSV generation modal and remained functional. To fix this, I used an ngIf to conditionally show or hide the filter buttons but for both desktop and mobile views. This approach removes the buttons from the background entirely, but I felt it was acceptable since with the release of this dashboard, users won’t be able to scroll/interact with the background while any modal is open.

Video:


https://github.com/user-attachments/assets/e00b9168-20b9-46ce-ae68-0dc25569b316

