### PR TITLE
Swap author name for the framework name

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -1056,6 +1056,8 @@ export class BuilderStore {
     // retrieve current cached Map from storage and get the current cached value for given id
     const cache = this.objectCache$.getValue();
     const newValue = cache ? Object.assign(cache, data) : data;
+    // make verb full lowercase before sending in request for taxonomy comparison
+    newValue.verb = newValue.verb.toLowerCase();
 
 
     // if delay is true, combine the new properties with the object in the cache subject

--- a/src/app/onion/learning-object-builder/components/standard-outcomes/outcomes-list-item/outcomes-list-item.component.html
+++ b/src/app/onion/learning-object-builder/components/standard-outcomes/outcomes-list-item/outcomes-list-item.component.html
@@ -3,7 +3,7 @@
     <span *ngIf="guideline.suggested" class="suggested-icon">
       <i class="fas fa-lightbulb"></i>
     </span>
-    {{ guideline.author }} - {{ guideline.guidelineName }} - {{guideline.year}}
+    {{ guideline.frameworkName }} - {{ guideline.guidelineName }} - {{guideline.year}}
   </div>
   <div class="bar"></div>
   {{ guideline.guidelineDescription }}


### PR DESCRIPTION
# Description 
As the data model for the guidelines has evolved with the updates to the various KUs and KSAT frameworks we never updated the suggestion cards on the builder to be the name of the framework rather than the name of the author. This PR swaps these values with the goal of making it easier for our authors and content team to find the right guidelines to align to. This PR also includes a fix the outcomes not saving when a learning outcome is pasted in.

<img width="448" alt="Screenshot 2025-03-26 at 7 17 28 PM" src="https://github.com/user-attachments/assets/fb1785c4-a775-478d-ac4e-2b1ef279ee92" />
