### PR TITLE
outcome verb lowercase

### DIFF
--- a/src/app/onion/learning-object-builder/builder-store.service.ts
+++ b/src/app/onion/learning-object-builder/builder-store.service.ts
@@ -1056,6 +1056,8 @@ export class BuilderStore {
     // retrieve current cached Map from storage and get the current cached value for given id
     const cache = this.objectCache$.getValue();
     const newValue = cache ? Object.assign(cache, data) : data;
+    // make verb full lowercase before sending in request for taxonomy comparison
+    newValue.verb = newValue.verb.toLowerCase();
 
 
     // if delay is true, combine the new properties with the object in the cache subject


### PR DESCRIPTION
The builder was throwing a snackbar warning when sending the patch request whenever the text of the learning outcome gets updated, because when it gets to the route in the service and checks if the verb exists in the taxonomy, having the first letter of the verb uppercase wouldn't pass the check on if it exists as a match on there. 

Bug: 

https://github.com/user-attachments/assets/2fd9da47-00f3-4ac9-9e1b-bb31695a7400

After:


https://github.com/user-attachments/assets/225969bb-fd8d-45a7-b5ae-8cc0372bc3a3

