### PR TITLE
This adjusts some wording for Symposium 

### DIFF
--- a/src/app/cube/details/components/outcome/outcome.component.html
+++ b/src/app/cube/details/components/outcome/outcome.component.html
@@ -14,7 +14,7 @@
       <div class='text-container__mapped-to'>
         {{ outcome?.mappings.length ? 'Mapped to' : 'No Mappings' }}
         <span *ngFor='let mapping of mappingsFrameworks let i = index'>
-          {{ mapping?.frameworkName }}<span *ngIf='i < mappingsFrameworks.length - 1'>,</span>
+          {{ mapping?.frameworkName }}<span *ngIf="i < mappingsFrameworks.length - 1">,</span>
         </span>
       </div>
     </div>
@@ -23,7 +23,7 @@
         {{ outcome?.mappings.length }}
       </div>
       <div class='mapped-outcomes-count-container__text'>
-        Mapped Outcomes
+        Mapping<span *ngIf="outcome?.mappings.length > 1 || outcome?.mappings.length == 0">s</span>
       </div>
     </div>
     <div 
@@ -38,7 +38,7 @@
     <ul class='outcome__mappings-display__list'>
       <li [@outcome] class='mappings-display__list__item' *ngFor='let mapping of outcome?.mappings'>
         <div class='list__item__header-text'>
-          {{ mapping?.author }} - {{ mapping?.guidelineName }} - {{ mapping?.year }}
+          {{ mapping?.frameworkName }} - {{ mapping?.guidelineName }} - {{ mapping?.year }}
         </div>
         <div class='list__item__outcome-text'>
           {{ mapping?.guidelineDescription }}

--- a/src/app/cube/details/components/outcome/outcome.component.html
+++ b/src/app/cube/details/components/outcome/outcome.component.html
@@ -23,7 +23,7 @@
         {{ outcome?.mappings.length }}
       </div>
       <div class='mapped-outcomes-count-container__text'>
-        Mapping<span *ngIf="outcome?.mappings.length > 1 || outcome?.mappings.length == 0">s</span>
+        Mapping<span *ngIf="outcome?.mappings.length > 1 || outcome?.mappings.length === 0">s</span>
       </div>
     </div>
     <div 

--- a/src/app/cube/details/components/outcome/outcome.component.scss
+++ b/src/app/cube/details/components/outcome/outcome.component.scss
@@ -33,6 +33,7 @@
 
 .mapped-outcomes-count-container__text {
     color: $dark-grey;
+    text-align: center;
 }
 
 .outcome__grid-container__toggle-container {


### PR DESCRIPTION
This PR adjusts the wording for mappings on the details page. This helps us align better with the wording being used on the rest of the application. 

<img width="1056" alt="Screenshot 2025-03-31 at 8 47 26 AM" src="https://github.com/user-attachments/assets/d0357414-9c35-4787-ad42-d3b24c973701" />
