### PR TITLE
chore: [sc-36550] Add HTML regex filter on inputs for Learning Object Builder

### DIFF
--- a/src/entity/learning-object/error-messages.ts
+++ b/src/entity/learning-object/error-messages.ts
@@ -37,5 +37,6 @@ export const LEARNING_OBJECT_ERRORS = {
 export const SUBMITTABLE_LEARNING_OBJECT_ERRORS = {
   INVALID_DESCRIPTION: 'Description must not be an empty string.',
   INVALID_DESCRIPTION_BAD_HTML: 'Description contains bad tags.',
+  INVALID_NOTES_BAD_HTML: 'Notes contain bad tags.',
   INVALID_OUTCOMES: 'Outcomes must contain at least one valid outcome.'
 };

--- a/src/entity/learning-object/error-messages.ts
+++ b/src/entity/learning-object/error-messages.ts
@@ -36,5 +36,6 @@ export const LEARNING_OBJECT_ERRORS = {
 
 export const SUBMITTABLE_LEARNING_OBJECT_ERRORS = {
   INVALID_DESCRIPTION: 'Description must not be an empty string.',
+  INVALID_DESCRIPTION_REGEX: 'Description contains bad tags.',
   INVALID_OUTCOMES: 'Outcomes must contain at least one valid outcome.'
 };

--- a/src/entity/learning-object/error-messages.ts
+++ b/src/entity/learning-object/error-messages.ts
@@ -36,6 +36,6 @@ export const LEARNING_OBJECT_ERRORS = {
 
 export const SUBMITTABLE_LEARNING_OBJECT_ERRORS = {
   INVALID_DESCRIPTION: 'Description must not be an empty string.',
-  INVALID_DESCRIPTION_REGEX: 'Description contains bad tags.',
+  INVALID_DESCRIPTION_BAD_HTML: 'Description contains bad tags.',
   INVALID_OUTCOMES: 'Outcomes must contain at least one valid outcome.'
 };

--- a/src/entity/learning-object/submittable-learning-object.ts
+++ b/src/entity/learning-object/submittable-learning-object.ts
@@ -115,8 +115,8 @@ export class SubmittableLearningObject extends LearningObject {
 
 export namespace SubmittableLearningObject {
   // Matches anything that does not have a closing HTML tag.
-  // Example: https://regex101.com/r/qDSGWv/1
-  const NON_TERMINATING_HTML_REGEX = /<([a-z]+)(\s[^>]*)?(?<!\/)>(?![\s\S]*<\/\1>)/gi;
+  // Example: https://regex101.com/r/TCRXf8/1
+  const NON_TERMINATING_HTML_REGEX = /<(?!(br\b))([a-z]+)(\s[^>]*)?(?<!\/)>(?![\s\S]*<\/\2>)/gi;
 
   export function validateName(name: string) {
     try {

--- a/src/entity/learning-object/submittable-learning-object.ts
+++ b/src/entity/learning-object/submittable-learning-object.ts
@@ -123,8 +123,8 @@ export namespace SubmittableLearningObject {
   }
   export function validateDescription(description: string) {
     // Matches anything that does not have a closing HTML tag.
-    // Example: https://regex101.com/r/yWbTFg/1
-    const nonTerminatingTagRegex = /<([a-z]+)(\s[^>]*)?>(?![\s\S]*<\/\1>)/gi;
+    // Example: https://regex101.com/r/qDSGWv/1
+    const nonTerminatingTagRegex = /<([a-z]+)(\s[^>]*)?(?<!\/)>(?![\s\S]*<\/\1>)/gi;
 
     if (!description || !description.trim()) {
       throw new EntityError(

--- a/src/entity/learning-object/submittable-learning-object.ts
+++ b/src/entity/learning-object/submittable-learning-object.ts
@@ -135,7 +135,7 @@ export namespace SubmittableLearningObject {
 
     // st-editor will always close HTML tags, so theoretically we shouldn't hit this.
     if (description.match(nonTerminatingTagRegex)) {
-      throw new EntityError(SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION_REGEX, 'description');
+      throw new EntityError(SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION_BAD_HTML, 'description');
     }
   }
   export function validateOutcomes(outcomes: LearningOutcome[]) {

--- a/src/entity/learning-object/submittable-learning-object.ts
+++ b/src/entity/learning-object/submittable-learning-object.ts
@@ -114,6 +114,10 @@ export class SubmittableLearningObject extends LearningObject {
 }
 
 export namespace SubmittableLearningObject {
+  // Matches anything that does not have a closing HTML tag.
+  // Example: https://regex101.com/r/qDSGWv/1
+  const NON_TERMINATING_HTML_REGEX = /<([a-z]+)(\s[^>]*)?(?<!\/)>(?![\s\S]*<\/\1>)/gi;
+
   export function validateName(name: string) {
     try {
       new LearningObject({ name });
@@ -122,10 +126,6 @@ export namespace SubmittableLearningObject {
     }
   }
   export function validateDescription(description: string) {
-    // Matches anything that does not have a closing HTML tag.
-    // Example: https://regex101.com/r/qDSGWv/1
-    const nonTerminatingTagRegex = /<([a-z]+)(\s[^>]*)?(?<!\/)>(?![\s\S]*<\/\1>)/gi;
-
     if (!description || !description.trim()) {
       throw new EntityError(
         SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION,
@@ -134,7 +134,7 @@ export namespace SubmittableLearningObject {
     }
 
     // st-editor will always close HTML tags, so theoretically we shouldn't hit this.
-    if (description.match(nonTerminatingTagRegex)) {
+    if (description.match(NON_TERMINATING_HTML_REGEX)) {
       throw new EntityError(SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION_BAD_HTML, 'description');
     }
   }
@@ -169,6 +169,12 @@ export namespace SubmittableLearningObject {
       }
     }
   }
+  export function validateNotes(notes: string) {
+    // st-editor will always close HTML tags, so theoretically we shouldn't hit this.
+    if (notes.match(NON_TERMINATING_HTML_REGEX)) {
+      throw new EntityError(SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_NOTES_BAD_HTML, 'notes');
+    }
+  }
 
   export function validateContributors(contributors: User[]) {
     if (contributors.length <= 0) {
@@ -196,6 +202,10 @@ export namespace SubmittableLearningObject {
       {
         function: SubmittableLearningObject.validateContributors,
         arguments: [object.contributors]
+      },
+      {
+        function: SubmittableLearningObject.validateNotes,
+        arguments: [object.materials.notes]
       }
     ];
     validationFunctions.forEach(func => {

--- a/src/entity/learning-object/submittable-learning-object.ts
+++ b/src/entity/learning-object/submittable-learning-object.ts
@@ -122,11 +122,20 @@ export namespace SubmittableLearningObject {
     }
   }
   export function validateDescription(description: string) {
+    // Matches anything that does not have a closing HTML tag.
+    // Example: https://regex101.com/r/yWbTFg/1
+    const nonTerminatingTagRegex = /<([a-z]+)(\s[^>]*)?>(?![\s\S]*<\/\1>)/gi;
+
     if (!description || !description.trim()) {
       throw new EntityError(
         SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION,
         'description',
       );
+    }
+
+    // st-editor will always close HTML tags, so theoretically we shouldn't hit this.
+    if (description.match(nonTerminatingTagRegex)) {
+      throw new EntityError(SUBMITTABLE_LEARNING_OBJECT_ERRORS.INVALID_DESCRIPTION_REGEX, 'description');
     }
   }
   export function validateOutcomes(outcomes: LearningOutcome[]) {


### PR DESCRIPTION
Adds a regex for non-terminating tags. Prevents users from entering `<a href="googleplex.com">asdadsasd` without a closing tag, and other html tags.

(You can't actually hit this regex in the browser (unless your browser is really old) because st-editor will automagically add the closing tag back if it doesn't find one, which is very neat.)

Check out the example: https://regex101.com/r/yWbTFg/1
Story details: https://app.shortcut.com/clarkcan/story/36550