### PR TITLE
fix: [sc-36625] Curator Cannot See Download Button on CLARK

### DIFF
--- a/src/app/cube/details/components/action-panel/action-panel.component.html
+++ b/src/app/cube/details/components/action-panel/action-panel.component.html
@@ -79,7 +79,7 @@
 </clark-popup>
 
 <ng-template #libraryButtonsTemplate>
-  <button *ngIf="!auth?.hasEditorAccess()"[tip]="tips.DOWNLOAD_NOW" tipPosition="top" [tipDisabled]="hasDownloadAccess || !loggedin" [ngClass]="{'disabled': !auth.user || !hasDownloadAccess || downloading || disableLibraryButtons, 'hide': hasReviewerAccess}"
+  <button *ngIf="!auth?.hasEditorAccess()"[tip]="tips.DOWNLOAD_NOW" tipPosition="top" [tipDisabled]="hasDownloadAccess || !loggedin" [ngClass]="{'disabled': !auth.user || !hasDownloadAccess || downloading || disableLibraryButtons}"
     class="button good" id="download-button" (activate)="addToLibrary(true)" attr.aria-label="{{hasDownloadAccess ? 'Clickable Download Now button' : 'Not Available for Download'}}">
     <span *ngIf="hasDownloadAccess">{{!downloading ? 'Download Now' : 'Downloading'}}
       <span *ngIf="downloading">


### PR DESCRIPTION
This fixes an issue where the "Download Now" button would be hidden if the reviewer has reviewer access. Users, editors and admins would be able to see their respective buttons, but not reviewers. 

**Before...**
![image](https://github.com/user-attachments/assets/d3569983-c0f9-4280-a0b7-3f4a2b8138a8)

**After...**
![image](https://github.com/user-attachments/assets/1bd31a91-3102-42f0-add6-7677a2c02c72)

Story details: https://app.shortcut.com/clarkcan/story/36625