### PR TITLE
feat: [sc-36562] Add ability to filter learning objects by a date range

### DIFF
--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -12,7 +12,8 @@
           class="button neutral filters-button"
           (activate)="toggleDateSearchMenu(true)"
         >
-        <span>Search by Date Range</span>
+          <div [ngClass]="{ 'indicator': dateSearchStart || dateSearchEnd }"></div>
+          <span>Search by Date Range</span>
         </button>
         <button
           #toggleTopicMenuElement
@@ -139,7 +140,7 @@
     </div>
     <div class="btn-group select">
       <div>
-        <button *ngIf="filterSelected" class="button bad" (activate)="clearDateSearch()">Clear Filter</button>
+        <button class="button bad" *ngIf="dateSearchStart || dateSearchEnd" (activate)="clearDateSearch()">Clear</button>
       </div>
       <div>
         <button class="button neutral" (activate)="toggleDateSearchMenu(false)">Cancel</button>

--- a/src/app/admin/components/filter-search/filter-search.component.html
+++ b/src/app/admin/components/filter-search/filter-search.component.html
@@ -9,6 +9,12 @@
         <span *ngIf="!startNextCheck">Filter By Relevancy Check Dates</span>
         </button>
         <button
+          class="button neutral filters-button"
+          (activate)="toggleDateSearchMenu(true)"
+        >
+        <span>Search by Date Range</span>
+        </button>
+        <button
           #toggleTopicMenuElement
           class="button neutral filters-button"
           (activate)="toggleTopicMenu(true)"
@@ -116,6 +122,32 @@
   </div>
 </div>
 
+<clark-popup *ngIf="dateSearchMenuDown" (closed)="toggleDateSearchMenu(false)">
+  <div class="modal-container" #popupInner>
+    <div class="modal-title">Search by Date Range</div>
+    <div class="modal__inner">
+      <mat-form-field class="input">
+        <input matInput [matDatepicker]="startPicker" placeholder="Choose a start date" [(ngModel)]="dateSearchStart">
+        <mat-datepicker-toggle matSuffix [for]="startPicker"></mat-datepicker-toggle>
+        <mat-datepicker #startPicker startView="year" [startAt]="dateSearchStart"></mat-datepicker>
+      </mat-form-field>
+      <mat-form-field class="input">
+        <input matInput [matDatepicker]="endPicker" placeholder="Choose an end date" [(ngModel)]="dateSearchEnd">
+        <mat-datepicker-toggle matSuffix [for]="endPicker"></mat-datepicker-toggle>
+        <mat-datepicker #endPicker startView="year" [startAt]="dateSearchEnd"></mat-datepicker>
+      </mat-form-field>
+    </div>
+    <div class="btn-group select">
+      <div>
+        <button *ngIf="filterSelected" class="button bad" (activate)="clearDateSearch()">Clear Filter</button>
+      </div>
+      <div>
+        <button class="button neutral" (activate)="toggleDateSearchMenu(false)">Cancel</button>
+        <button class="button good" (activate)="setDateSearch()">Apply</button>
+      </div>
+    </div>
+  </div>
+</clark-popup>
 
 <clark-popup *ngIf="relevancyMenuDown" (closed)="toggleRelevancyMenu(false)">
   <div class="modal-container" #popupInner>

--- a/src/app/admin/components/filter-search/filter-search.component.scss
+++ b/src/app/admin/components/filter-search/filter-search.component.scss
@@ -46,7 +46,7 @@
     $lighter-blue: rgba(red($light-blue), green($light-blue), blue($light-blue), 0.1);
     background: $lighter-blue;
     color: $light-blue;
-    
+
     & > .svg-inline--fa {
       transform: rotate(180deg);
     }
@@ -54,6 +54,19 @@
     &:after {
       border-color: transparent;
     }
+  }
+
+  .indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    display: inline-block;
+    background: $light-blue;
+    position: absolute;
+    left: 15px;
+    top: 0;
+    bottom: 0;
+    margin: auto;
   }
 }
 .addEvaluators,

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -275,7 +275,7 @@ export class FilterSearchComponent implements OnInit {
   clearDateSearch() {
     this.dateSearchStart = undefined;
     this.dateSearchEnd = undefined;
-    this.dateSearchFilter.emit({ start: undefined, end: undefined });
+    this.dateSearchFilter.emit({ start: '', end: '' });
     this.toggleDateSearchMenu(false);
   }
 

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -47,6 +47,10 @@ export class FilterSearchComponent implements OnInit {
     collection: string,
   }>();
   @Output() relevancyCheck = new EventEmitter<{ start: string; end: string }>();
+  @Output() dateSearchFilter = new EventEmitter<{
+    start: string;
+    end: string;
+  }>();
   @Output() clearAll = new EventEmitter<void>();
   @ViewChild('searchInput') searchInput: ElementRef;
 
@@ -56,7 +60,10 @@ export class FilterSearchComponent implements OnInit {
 
   relevancyStart: Date;
   relevancyEnd: Date;
+  dateSearchStart: Date;
+  dateSearchEnd: Date;
   relevancyMenuDown: boolean;
+  dateSearchMenuDown: boolean;
 
   constructor(
     private collectionService: CollectionService,
@@ -217,6 +224,15 @@ export class FilterSearchComponent implements OnInit {
   }
 
   /**
+   * Toggles the date select modal menu
+   *
+   * @param value
+   */
+  toggleDateSearchMenu(value?: boolean) {
+    this.dateSearchMenuDown = value;
+  }
+
+  /**
    * Sets the relevancy date filters
    */
   setDates() {
@@ -233,6 +249,17 @@ export class FilterSearchComponent implements OnInit {
   }
 
   /**
+   * Sets the date search filters
+   */
+  setDateSearch() {
+    this.dateSearchFilter.emit({
+      start: this.dateSearchStart ? this.dateSearchStart.toISOString() : '',
+      end: this.dateSearchEnd ? this.dateSearchEnd.toISOString() : '',
+    });
+    this.toggleDateSearchMenu(false);
+  }
+
+  /**
    * Clears the relevancy date filters
    */
   clearDates() {
@@ -240,6 +267,16 @@ export class FilterSearchComponent implements OnInit {
     this.relevancyEnd = undefined;
     this.relevancyCheck.emit({ start: undefined, end: undefined });
     this.toggleRelevancyMenu(false);
+  }
+
+  /**
+   * Clears the date search filters
+   */
+  clearDateSearch() {
+    this.dateSearchStart = undefined;
+    this.dateSearchEnd = undefined;
+    this.dateSearchFilter.emit({ start: undefined, end: undefined });
+    this.toggleDateSearchMenu(false);
   }
 
   /**

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -42,9 +42,9 @@ export class FilterSearchComponent implements OnInit {
   @Input() showStatus: boolean;
   @Output() collectionFilter = new EventEmitter<string>();
   @Output() filterQuery = new EventEmitter<{
-    status: string[],
-    topic: string[],
-    collection: string,
+    status: string[];
+    topic: string[];
+    collection: string;
   }>();
   @Output() relevancyCheck = new EventEmitter<{ start: string; end: string }>();
   @Output() dateSearchFilter = new EventEmitter<{
@@ -342,12 +342,14 @@ export class FilterSearchComponent implements OnInit {
   filter() {
     // Emit the selected filters
     const filters = {
-       status:  Array.from(this.filters || []),
-       topic: Array.from(this.filterTopics || []),
-       collection: this.selectedCollection ? this.selectedCollection.abvName : '',
-      };
-      this.filterQuery.emit(filters);
-   }
+      status: Array.from(this.filters || []),
+      topic: Array.from(this.filterTopics || []),
+      collection: this.selectedCollection
+        ? this.selectedCollection.abvName
+        : '',
+    };
+    this.filterQuery.emit(filters);
+  }
 
   /**
    * Remove all applied status filters

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -10,13 +10,14 @@
     filter-options
     (filterQuery)="handleFilterQuery($event)"
     (relevancyCheck)="getRelevancyFilteredLearningObjects($event)"
+    (dateSearchFilter)="getDateFilteredLearningObjects($event)"
     (clearAll)="clearStatusAndCollectionFilters()"
     [adminOrEditor]="isAdminOrEditor"
     [showStatus]="true"
   ></clark-admin-filter-search>
-  
-  <div #list class="list" main>  
-    <div #listInner>  
+
+  <div #list class="list" main>
+    <div #listInner>
       <div class="list__body">
         <div *ngIf="learningObjects?.length; else emptyTemplate" >
           <div #headers class="body__column-headers">

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -301,6 +301,8 @@ export class LearningObjectsComponent
     this.query = {
       startNextCheck: dates.start,
       endNextCheck: dates.end,
+      start: '',
+      end: '',
       currPage: 1,
     };
     this.learningObjects = [];
@@ -317,6 +319,8 @@ export class LearningObjectsComponent
     this.query = {
       start: dates.start,
       end: dates.end,
+      startNextCheck: '',
+      endNextCheck: '',
       currPage: 1,
     };
     this.learningObjects = [];

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -309,6 +309,22 @@ export class LearningObjectsComponent
   }
 
   /**
+   * Updates the queries start and end values
+   *
+   * @param dates The start and end dates for the date search filter
+   */
+  getDateFilteredLearningObjects(dates: {start: Date, end: Date}) {
+    this.query = {
+      start: dates.start,
+      end: dates.end,
+      currPage: 1,
+    };
+    this.learningObjects = [];
+
+    this.getLearningObjects();
+  }
+
+  /**
    * Clear the filters of both collection and status and reset the Learning Objects query
    *
    * @memberof LearningObjectsComponent

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -281,8 +281,8 @@ export class LearningObjectsComponent
       this.query.sortType = SortType.Ascending;
     } else if (this.query.sortType.toString() === '1') {
       this.query = {
-        sortType: undefined,
-        orderBy: undefined,
+        sortType: SortType.Descending,
+        orderBy: OrderBy.Date,
       };
     }
 

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -28,6 +28,8 @@ export interface Query {
   collection?: string;
   status?: string[];
   fileTypes?: string[];
+  start?: Date | string;
+  end?: Date | string;
   startNextCheck?: string;
   endNextCheck?: string;
   topics?: string[];


### PR DESCRIPTION
Admins and editors can now search by query learning objects using a date range filter. This can be used in conjunction with other filters including text search, EXCEPT the relevancy check date filter.

https://github.com/user-attachments/assets/2acde699-eea1-4576-8d75-739483506503

Story details: https://app.shortcut.com/clarkcan/story/36562