### PR TITLE
feat: [sc-36529] Decouple downtime route from Gateways

### DIFF
--- a/src/app/core/utility-module/utility.routes.ts
+++ b/src/app/core/utility-module/utility.routes.ts
@@ -31,7 +31,7 @@ export const UTILITY_ROUTES = {
    * @returns downtime information and/or banner message
    */
   GET_DOWNTIME() {
-    return `${environment.apiURL}/downtime?service=clark`;
+    return `${environment.downtimeUrl}/downtime?service=clark`;
   },
   /**
    * Request to search organizations on CARD

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -8,6 +8,7 @@ export const environment = {
   cognitoIdentityPoolId: 'us-east-1:1ad4e60a-9773-4a67-92b5-6cc2c7b3328f',
   cognitoAdminIdentityPoolId: 'us-east-1:6691336e-11a1-48db-9774-5f5a2c8dc270',
   cardUrl: 'https://api.clark.center',
+  downtimeUrl: 'https://oyrmr4e2d5nwt3l33ifk4ezgcq0mhnax.lambda-url.us-east-1.on.aws',
 };
 
 export enum LearningObjectStatus {

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -8,6 +8,7 @@ export const environment = {
   cognitoIdentityPoolId: 'us-east-1:3388292f-c48a-4257-aa55-d1816617b38f',
   cognitoAdminIdentityPoolId: 'us-east-1:a265148e-7418-4a40-aee2-78f5ae7cbf43',
   cardUrl: 'https://api.clark.center',
+  downtimeUrl: 'https://oyrmr4e2d5nwt3l33ifk4ezgcq0mhnax.lambda-url.us-east-1.on.aws',
 };
 
 export enum LearningObjectStatus {

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -12,6 +12,7 @@ export const environment = {
   cognitoIdentityPoolId: '',
   cognitoAdminIdentityPoolId: '',
   cardUrl: 'http://localhost:3000',
+  downtimeUrl: '',
 };
 
 export enum LearningObjectStatus {


### PR DESCRIPTION
This PR adds a `downtimeUrl` variable to the env file for getting downtime status. See story for other PRs.

This was tested in dev and it works :)

Story details: https://app.shortcut.com/clarkcan/story/36529