### PR TITLE
Add admin to query on admin dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "6.6.0",
+      "version": "6.7.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^14.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -46,6 +46,7 @@ export class LearningObjectsComponent
     orderBy: OrderBy.Date,
     text: '',
     collection: '',
+    admin: 'true'
   };
 
   displayStatusModal = false;

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -35,6 +35,7 @@ export interface Query {
   topics?: string[];
   tags?: string[]
   username?: string;
+  admin?: string;
 }
 
 export interface MappingQuery extends Query {


### PR DESCRIPTION
This PR adds the admin query parameter to all the requests sent from the admin dashboard learning objects page. 