### PR TITLE
Add to note to registration for other

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "6.9.1",
+  "version": "6.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "6.9.1",
+      "version": "6.10.0",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^15.2.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "6.9.1",
+  "version": "6.10.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -44,6 +44,9 @@
                         (onBlur)="closeDropdown()"
                         class="org-dropdown_list"
                         >
+                        <p class="organization-message">
+                            If you don't see your organization please register under <b>Other</b> and reach out to us to have your organization added to our list.
+                        </p>
                         <ng-container
                         *ngTemplateOutlet="loading ? loadingTemplate : resultsTemplate"
                         ></ng-container>

--- a/src/app/auth/register/register.component.scss
+++ b/src/app/auth/register/register.component.scss
@@ -93,4 +93,9 @@
         box-sizing: border-box;
         display: block;
       }
+
+      .organization-message {
+        font-size: $smaller;
+        padding: 15px;
+      }
 }


### PR DESCRIPTION
This PR adds a note to the dropdown for registration for users to select Other as their organization if they don't see their org. 