### PR TITLE
feature/sc-36824/ecs-service-fargate-otel-deployment

### DIFF
--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -1,13 +1,13 @@
 export const environment = {
   production: true,
   experimental: false,
-  apiURL: 'https://api.yeetbot.click',
+  apiURL: 'https://clark-gateway.clark.center',
   s3Bucket: 'clark-staging-file-uploads',
   s3BucketRegion: 'us-east-1',
   cognitoRegion: 'us-east-1',
   cognitoIdentityPoolId: 'us-east-1:3388292f-c48a-4257-aa55-d1816617b38f',
   cognitoAdminIdentityPoolId: 'us-east-1:a265148e-7418-4a40-aee2-78f5ae7cbf43',
-  cardUrl: 'https://api.clark.center',
+  cardUrl: 'https://clark-gateway.clark.center/',
   downtimeUrl: 'https://oyrmr4e2d5nwt3l33ifk4ezgcq0mhnax.lambda-url.us-east-1.on.aws',
 };
 


### PR DESCRIPTION
Changed the api url for the staging configuration to now be https://clark-gateway.clark.center, which is the new production api url after the fargate and otel deployment. This is to test the new infrastructure in staging, afterwards another PR will be up reverting these changes, and applying them to the production env config instead, with the versioning on it. 