### PR TITLE
Feature/sc 37585/frontend filter by no guidelines

### DIFF
--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -30,7 +30,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     currPage: 1,
     limit: 10,
     length: [],
-    noguidelines: '',
+    noGuidelines: '',
     guidelines: [],
     level: [],
     standardOutcomes: [],
@@ -227,7 +227,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
       'fileTypes',
       'level',
       'guidelines',
-      'noguidelines',
+      'noGuidelines',
       'comes',
     ].forEach((category) => {
       if (!this.filters[category]) {
@@ -402,7 +402,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
         q.topics?.length ||
         q.level?.length ||
         q.guidelines?.length ||
-        q.noguidelines ||
+        q.noGuidelines ||
         q.standardOutcomes?.length ||
         q.fileTypes?.length
       )

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -227,8 +227,8 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
       'fileTypes',
       'level',
       'guidelines',
+      'standardOutcomes',
       'noGuidelines',
-      'comes',
     ].forEach((category) => {
       if (!this.filters[category]) {
         this.filters.removed.push(category);

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -30,6 +30,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     currPage: 1,
     limit: 10,
     length: [],
+    noguidelines: '',
     guidelines: [],
     level: [],
     standardOutcomes: [],
@@ -186,9 +187,9 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
   get sortString() {
     return this.query.orderBy
       ? this.query.orderBy.replace(/_/g, '') +
-          ' (' +
-          (this.query.sortType > 0 ? 'Asc' : 'Desc') +
-          ')'
+      ' (' +
+      (this.query.sortType > 0 ? 'Asc' : 'Desc') +
+      ')'
       : '';
   }
 
@@ -226,7 +227,8 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
       'fileTypes',
       'level',
       'guidelines',
-      'standardOutcomes',
+      'noguidelines',
+      'comes',
     ].forEach((category) => {
       if (!this.filters[category]) {
         this.filters.removed.push(category);
@@ -400,6 +402,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
         q.topics?.length ||
         q.level?.length ||
         q.guidelines?.length ||
+        q.noguidelines ||
         q.standardOutcomes?.length ||
         q.fileTypes?.length
       )

--- a/src/app/cube/browse/components/filter/filter.component.html
+++ b/src/app/cube/browse/components/filter/filter.component.html
@@ -19,6 +19,13 @@
 
 <div>
   <br>
+  <p>Admin/Editor Filters</p>
+  <clark-filter-section [info]="noGuidelineFilter"
+      (change)="registerChange()"></clark-filter-section>
+</div>
+
+<div>
+  <br>
   <p>FILTER BY TAG <a href="https://forms.gle/j8jp5Qqvm3yxwPei8" target="_blank"class="beta" tip="Click to learn more about tagging in CLARK and provide feedback. This will open in a new tab.">[Beta]</a></p>
   <!-- Dynamic tag type filter sections -->
   <clark-filter-section *ngFor="let tagType of tagTypes" [info]="getFilteredTags(tagType)" (change)="registerChange()"></clark-filter-section>

--- a/src/app/cube/browse/components/filter/filter.component.html
+++ b/src/app/cube/browse/components/filter/filter.component.html
@@ -1,74 +1,44 @@
 <div>
   <!-- Collection Filters -->
-  <clark-filter-section
-    [info]="collectionFilter"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section [info]="collectionFilter" (change)="registerChange()"></clark-filter-section>
 
   <!-- Length Filters -->
-  <clark-filter-section
-    [info]="lengthFilter"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section [info]="lengthFilter" (change)="registerChange()"></clark-filter-section>
 
   <!-- Topics Filters -->
-  <clark-filter-section
-    [info]="topicFilter"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section [info]="topicFilter" (change)="registerChange()"></clark-filter-section>
 
   <!-- Level Filters -->
-  <clark-filter-section
-    [info]="levelFilter"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section [info]="levelFilter" (change)="registerChange()"></clark-filter-section>
 
   <!-- Guidelines Filters -->
   <clark-filter-section [info]="frameworkFilter" (change)="registerChange()">
-    <a (click)="openAdvancedSearch()"
-      >Advanced
-      <span *ngIf="guidelineFilter.length > 0"
-        >({{ guidelineFilter.length }} Selected)</span
-      ></a
-    >
+    <a (click)="openAdvancedSearch()">Advanced
+      <span *ngIf="guidelineFilter.length > 0">({{ guidelineFilter.length }} Selected)</span></a>
   </clark-filter-section>
 </div>
 
 <div *ngIf="isAdminOrEditor()">
   <br />
   <p>Admin/Editor Filters</p>
-  <clark-filter-section
-    [info]="noGuidelineFilter"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section [info]="noGuidelineFilter" (change)="registerChange()"></clark-filter-section>
 </div>
 
 <div>
   <br />
   <p>
     FILTER BY TAG
-    <a
-      href="https://forms.gle/j8jp5Qqvm3yxwPei8"
-      target="_blank"
-      class="beta"
-      tip="Click to learn more about tagging in CLARK and provide feedback. This will open in a new tab."
-      >[Beta]</a
-    >
+    <a href="https://forms.gle/j8jp5Qqvm3yxwPei8" target="_blank" class="beta"
+      tip="Click to learn more about tagging in CLARK and provide feedback. This will open in a new tab.">[Beta]</a>
   </p>
   <!-- Dynamic tag type filter sections -->
-  <clark-filter-section
-    *ngFor="let tagType of tagTypes"
-    [info]="getFilteredTags(tagType)"
-    (change)="registerChange()"
-  ></clark-filter-section>
+  <clark-filter-section *ngFor="let tagType of tagTypes" [info]="getFilteredTags(tagType)"
+    (change)="registerChange()"></clark-filter-section>
 </div>
 
 <clark-popup *ngIf="showAdvancedSearch" (closed)="closeAdvancedSearch()">
   <div class="modal-container center" #popupInner>
-    <clark-guideline-filter
-      [selectedGuidelines]="guidelineFilter.slice()"
-      (close)="closeAdvancedSearch()"
-      (changed)="filterGuidelines($event)"
-    ></clark-guideline-filter>
+    <clark-guideline-filter [selectedGuidelines]="guidelineFilter.slice()" (close)="closeAdvancedSearch()"
+      (changed)="filterGuidelines($event)"></clark-guideline-filter>
   </div>
 </clark-popup>

--- a/src/app/cube/browse/components/filter/filter.component.html
+++ b/src/app/cube/browse/components/filter/filter.component.html
@@ -11,6 +11,12 @@
   <!-- Level Filters -->
   <clark-filter-section [info]="levelFilter" (change)="registerChange()"></clark-filter-section>
 
+
+  <!-- No Guidelines Filter -->
+  <!-- <clark-filter-section *ngIf="isAdminOrEditor()" [info]="noGuidelineFilter"
+      (change)="registerChange()"></clark-filter-section> -->
+
+
   <!-- Guidelines Filters -->
   <clark-filter-section [info]="frameworkFilter" (change)="registerChange()">
     <a (click)="openAdvancedSearch()">Advanced <span *ngIf="guidelineFilter.length > 0">({{ guidelineFilter.length }} Selected)</span></a>

--- a/src/app/cube/browse/components/filter/filter.component.html
+++ b/src/app/cube/browse/components/filter/filter.component.html
@@ -1,44 +1,74 @@
 <div>
   <!-- Collection Filters -->
-  <clark-filter-section [info]="collectionFilter" (change)="registerChange()"></clark-filter-section>
+  <clark-filter-section
+    [info]="collectionFilter"
+    (change)="registerChange()"
+  ></clark-filter-section>
 
   <!-- Length Filters -->
-  <clark-filter-section [info]="lengthFilter" (change)="registerChange()"></clark-filter-section>
+  <clark-filter-section
+    [info]="lengthFilter"
+    (change)="registerChange()"
+  ></clark-filter-section>
 
   <!-- Topics Filters -->
-  <clark-filter-section [info]="topicFilter" (change)="registerChange()"></clark-filter-section>
+  <clark-filter-section
+    [info]="topicFilter"
+    (change)="registerChange()"
+  ></clark-filter-section>
 
   <!-- Level Filters -->
-  <clark-filter-section [info]="levelFilter" (change)="registerChange()"></clark-filter-section>
-
-
-  <!-- No Guidelines Filter -->
-  <!-- <clark-filter-section *ngIf="isAdminOrEditor()" [info]="noGuidelineFilter"
-      (change)="registerChange()"></clark-filter-section> -->
-
+  <clark-filter-section
+    [info]="levelFilter"
+    (change)="registerChange()"
+  ></clark-filter-section>
 
   <!-- Guidelines Filters -->
   <clark-filter-section [info]="frameworkFilter" (change)="registerChange()">
-    <a (click)="openAdvancedSearch()">Advanced <span *ngIf="guidelineFilter.length > 0">({{ guidelineFilter.length }} Selected)</span></a>
+    <a (click)="openAdvancedSearch()"
+      >Advanced
+      <span *ngIf="guidelineFilter.length > 0"
+        >({{ guidelineFilter.length }} Selected)</span
+      ></a
+    >
   </clark-filter-section>
 </div>
 
-<div>
-  <br>
+<div *ngIf="isAdminOrEditor()">
+  <br />
   <p>Admin/Editor Filters</p>
-  <clark-filter-section [info]="noGuidelineFilter"
-      (change)="registerChange()"></clark-filter-section>
+  <clark-filter-section
+    [info]="noGuidelineFilter"
+    (change)="registerChange()"
+  ></clark-filter-section>
 </div>
 
 <div>
-  <br>
-  <p>FILTER BY TAG <a href="https://forms.gle/j8jp5Qqvm3yxwPei8" target="_blank"class="beta" tip="Click to learn more about tagging in CLARK and provide feedback. This will open in a new tab.">[Beta]</a></p>
+  <br />
+  <p>
+    FILTER BY TAG
+    <a
+      href="https://forms.gle/j8jp5Qqvm3yxwPei8"
+      target="_blank"
+      class="beta"
+      tip="Click to learn more about tagging in CLARK and provide feedback. This will open in a new tab."
+      >[Beta]</a
+    >
+  </p>
   <!-- Dynamic tag type filter sections -->
-  <clark-filter-section *ngFor="let tagType of tagTypes" [info]="getFilteredTags(tagType)" (change)="registerChange()"></clark-filter-section>
+  <clark-filter-section
+    *ngFor="let tagType of tagTypes"
+    [info]="getFilteredTags(tagType)"
+    (change)="registerChange()"
+  ></clark-filter-section>
 </div>
 
 <clark-popup *ngIf="showAdvancedSearch" (closed)="closeAdvancedSearch()">
   <div class="modal-container center" #popupInner>
-    <clark-guideline-filter [selectedGuidelines]="guidelineFilter.slice()" (close)="closeAdvancedSearch()" (changed)="filterGuidelines($event)"></clark-guideline-filter>
+    <clark-guideline-filter
+      [selectedGuidelines]="guidelineFilter.slice()"
+      (close)="closeAdvancedSearch()"
+      (changed)="filterGuidelines($event)"
+    ></clark-guideline-filter>
   </div>
 </clark-popup>

--- a/src/app/cube/browse/components/filter/filter.component.ts
+++ b/src/app/cube/browse/components/filter/filter.component.ts
@@ -86,7 +86,7 @@ export class FilterComponent implements OnInit, OnDestroy {
       this.parseCategorySelected(this.selected.tags, this.tagFilter.filters);
       this.parseCategorySelected(this.selected.fileTypes, this.materialFilter.filters);
       this.parseCategorySelected(this.selected.guidelines, this.frameworkFilter.filters);
-      this.parseCategorySelected(this.selected.noGuideline, this.noGuidelineFilter.filters);
+      this.parseCategorySelected(this.selected.noguidelines, this.noGuidelineFilter.filters);
       this.parseCategorySelected(this.selected.collection, this.collectionFilter.filters);
     }
   }
@@ -346,11 +346,14 @@ export class FilterComponent implements OnInit, OnDestroy {
     };
   }
 
+  /**
+   * Gets the no guidelines filter 🤪
+   */
   getNoGuidelinesFilter() {
     this.noGuidelineFilter = {
       section: 'No Guidelines',
       filters: [
-        { name: 'No Guidelines', value: 'yep', active: false }
+        { name: 'No Guidelines', value: 'true', active: false }
       ]
     };
   }

--- a/src/app/cube/browse/components/filter/filter.component.ts
+++ b/src/app/cube/browse/components/filter/filter.component.ts
@@ -8,6 +8,7 @@ import { FilterSectionInfo } from '../filter-section/filter-section.component';
 import { Query } from '../../../../interfaces/query';
 import { TopicsService } from 'app/core/learning-object-module/topics/topics.service';
 import { TagsService } from 'app/core/learning-object-module/tags/tags.service';
+import { AuthService } from 'app/core/auth-module/auth.service';
 
 @Component({
   selector: 'clark-filter',
@@ -27,6 +28,7 @@ export class FilterComponent implements OnInit, OnDestroy {
   materialFilter: FilterSectionInfo;
   levelFilter: FilterSectionInfo;
   frameworkFilter: FilterSectionInfo;
+  noGuidelineFilter: FilterSectionInfo;
   guidelineFilter: string[] = [];
   tagTypes: { name: string, value: string }[] = [];
 
@@ -42,7 +44,8 @@ export class FilterComponent implements OnInit, OnDestroy {
     private topicsService: TopicsService,
     private tagsService: TagsService,
     private guidelineService: GuidelineService,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private authService: AuthService
   ) { }
 
   async ngOnInit(): Promise<void> {
@@ -54,6 +57,7 @@ export class FilterComponent implements OnInit, OnDestroy {
     await this.getTagTypes();
     this.getMaterialFilters();
     this.getLevelFilters();
+    this.getNoGuidelinesFilter();
     await this.getFrameworkFilters();
     this.parseSelected();
 
@@ -82,6 +86,7 @@ export class FilterComponent implements OnInit, OnDestroy {
       this.parseCategorySelected(this.selected.tags, this.tagFilter.filters);
       this.parseCategorySelected(this.selected.fileTypes, this.materialFilter.filters);
       this.parseCategorySelected(this.selected.guidelines, this.frameworkFilter.filters);
+      this.parseCategorySelected(this.selected.noGuideline, this.noGuidelineFilter.filters);
       this.parseCategorySelected(this.selected.collection, this.collectionFilter.filters);
     }
   }
@@ -127,6 +132,7 @@ export class FilterComponent implements OnInit, OnDestroy {
     this.clearFilterCategory(this.materialFilter.filters);
     this.clearFilterCategory(this.topicFilter.filters);
     this.clearFilterCategory(this.tagFilter.filters);
+    this.clearFilterCategory(this.noGuidelineFilter.filters);
     this.clearFilterCategory(this.frameworkFilter.filters);
     this.guidelineFilter = [];
 
@@ -158,6 +164,7 @@ export class FilterComponent implements OnInit, OnDestroy {
     this.checkFilter('topics', this.topicFilter.filters, query);
     this.checkFilter('tags', this.tagFilter.filters, query);
     this.checkFilter('guidelines', this.frameworkFilter.filters, query);
+    this.checkFilter('noguidelines', this.noGuidelineFilter.filters, query);
     if (this.guidelineFilter && this.guidelineFilter.length > 0) {
       query['standardOutcomes'] = this.guidelineFilter;
     }
@@ -339,6 +346,15 @@ export class FilterComponent implements OnInit, OnDestroy {
     };
   }
 
+  getNoGuidelinesFilter() {
+    this.noGuidelineFilter = {
+      section: 'No Guidelines',
+      filters: [
+        { name: 'No Guidelines', value: 'yep', active: false }
+      ]
+    };
+  }
+
   /**
    * Closes the advanced search popup
    */
@@ -356,6 +372,10 @@ export class FilterComponent implements OnInit, OnDestroy {
     this.guidelineFilter = guidelineIds;
     this.closeAdvancedSearch();
     this.registerChange();
+  }
+
+  isAdminOrEditor(): boolean {
+    return this.authService.isAdminOrEditor();
   }
 
   ngOnDestroy() {

--- a/src/app/cube/browse/components/filter/filter.component.ts
+++ b/src/app/cube/browse/components/filter/filter.component.ts
@@ -86,7 +86,7 @@ export class FilterComponent implements OnInit, OnDestroy {
       this.parseCategorySelected(this.selected.tags, this.tagFilter.filters);
       this.parseCategorySelected(this.selected.fileTypes, this.materialFilter.filters);
       this.parseCategorySelected(this.selected.guidelines, this.frameworkFilter.filters);
-      this.parseCategorySelected(this.selected.noguidelines, this.noGuidelineFilter.filters);
+      this.parseCategorySelected(this.selected.noGuidelines, this.noGuidelineFilter.filters);
       this.parseCategorySelected(this.selected.collection, this.collectionFilter.filters);
     }
   }
@@ -164,7 +164,7 @@ export class FilterComponent implements OnInit, OnDestroy {
     this.checkFilter('topics', this.topicFilter.filters, query);
     this.checkFilter('tags', this.tagFilter.filters, query);
     this.checkFilter('guidelines', this.frameworkFilter.filters, query);
-    this.checkFilter('noguidelines', this.noGuidelineFilter.filters, query);
+    this.checkFilter('noGuidelines', this.noGuidelineFilter.filters, query);
     if (this.guidelineFilter && this.guidelineFilter.length > 0) {
       query['standardOutcomes'] = this.guidelineFilter;
     }

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -19,6 +19,7 @@ export interface Query {
   length?: string[] | string;
   level?: string[];
   guidelines?: string[];
+  noguidelines?: string;
   orderBy?: OrderBy;
   sortType?: SortType;
   text?: string;
@@ -36,7 +37,6 @@ export interface Query {
   tags?: string[]
   username?: string;
   admin?: string;
-  noGuideline?: string;
 }
 
 export interface MappingQuery extends Query {

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -36,6 +36,7 @@ export interface Query {
   tags?: string[]
   username?: string;
   admin?: string;
+  noGuideline?: string;
 }
 
 export interface MappingQuery extends Query {

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -19,13 +19,13 @@ export interface Query {
   length?: string[] | string;
   level?: string[];
   guidelines?: string[];
-  noguidelines?: string;
+  noGuidelines?: string;
   orderBy?: OrderBy;
   sortType?: SortType;
   text?: string;
   standardOutcomes?:
-    | string[]
-    | { id: string; name: string; date: string; outcome: string }[];
+  | string[]
+  | { id: string; name: string; date: string; outcome: string }[];
   collection?: string;
   status?: string[];
   fileTypes?: string[];
@@ -41,8 +41,8 @@ export interface Query {
 
 export interface MappingQuery extends Query {
   standardOutcomes?:
-    | string[]
-    | { id: string; name: string; date: string; outcome: string }[];
+  | string[]
+  | { id: string; name: string; date: string; outcome: string }[];
 }
 
 export interface FilterQuery extends Query {
@@ -50,7 +50,7 @@ export interface FilterQuery extends Query {
   level?: string[];
 }
 
-export interface UserQuery extends querystring.ParsedUrlQueryInput{
+export interface UserQuery extends querystring.ParsedUrlQueryInput {
   accessGroups?: string[],
   sortType?: string,
   page?: number,


### PR DESCRIPTION
Adds an admin/editor only filter in the browse page for the content team to filter by learning objects that have an empty guidelines array since they'd like to map those learning objects.

https://github.com/user-attachments/assets/ec361e8e-4b03-4b14-bffa-abbb3ddc7eb4

