### PR TITLE
feature/sc-37961/user-dashboard-only-returns-10-released

### DIFF
--- a/src/app/onion/dashboard/dashboard.component.ts
+++ b/src/app/onion/dashboard/dashboard.component.ts
@@ -97,7 +97,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }, 1100);
     // retrieve released learning objects
     setTimeout(async () => {
-      await this.getReleasedLearningObjects({ status: LearningObject.Status.RELEASED });
+      await this.getReleasedLearningObjects({ status: LearningObject.Status.RELEASED, limit: 1000 });
       this.loading = false;
     }, 1100);
 


### PR DESCRIPTION
Just needed to add a limit because the service dto hardcodes the limit to 10 if there is no limit passed into the query.

<img width="2278" height="1376" alt="Screenshot 2025-09-16 at 1 53 43 PM" src="https://github.com/user-attachments/assets/ab57ad0d-1e3a-4df0-8110-1b1a1f41023b" />
