### PR TITLE
fix: [sc-37965] Fix Admin Dashboard Search Filters

### DIFF
--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -32,7 +32,7 @@ export class FilterSearchComponent implements OnInit {
   filtersModified$: Subject<void> = new Subject();
   filters: Set<string> = new Set();
   filterTopics: Set<string> = new Set();
-  statuses = Object.values(LearningObject.Status).filter(status => status !== "rejected");
+  statuses = Object.values(LearningObject.Status).filter(status => status !== 'rejected');
   dateError = false;
 
   private _selectedCollection: Collection;

--- a/src/app/admin/components/filter-search/filter-search.component.ts
+++ b/src/app/admin/components/filter-search/filter-search.component.ts
@@ -32,7 +32,7 @@ export class FilterSearchComponent implements OnInit {
   filtersModified$: Subject<void> = new Subject();
   filters: Set<string> = new Set();
   filterTopics: Set<string> = new Set();
-  statuses = Object.values(LearningObject.Status);
+  statuses = Object.values(LearningObject.Status).filter(status => status !== "rejected");
   dateError = false;
 
   private _selectedCollection: Collection;

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -27,7 +27,7 @@
             <div>Author</div>
             <div>Length</div>
             <div>Date
-              <button class="sort" (activate)="sortByDate()">
+              <button *ngIf="!this.query.text" class="sort" (activate)="sortByDate()">
                 <span *ngIf="!_query.sortType else sortArrows">
                   <i style="font-size: 18px;" class="far fa-sort"></i>
                 </span>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.html
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.html
@@ -27,7 +27,7 @@
             <div>Author</div>
             <div>Length</div>
             <div>Date
-              <button *ngIf="!this.query.text" class="sort" (activate)="sortByDate()">
+              <button class="sort" (activate)="sortByDate()">
                 <span *ngIf="!_query.sortType else sortArrows">
                   <i style="font-size: 18px;" class="far fa-sort"></i>
                 </span>

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -375,11 +375,19 @@ export class LearningObjectsComponent
     value ? this.selectLearningObject(l) : this.deselectLearningObject(l);
   }
 
-  handleFilterQuery(filters: { status: string[], topic: string[], collection: string }) {
+  handleFilterQuery(filters: { status: string[], topic: string[], collection: string, start: Date, end: Date }) {
 
-    const query = { status: filters.status, topics: filters.topic, collection: filters.collection, currPage: 1 };
+    const query = {
+      status: filters.status,
+      topics: filters.topic,
+      collection: filters.collection,
+      currPage: 1,
+      start: filters.start ? filters.start : "",
+      end: filters.end ? filters.end : ""
+    };
+
     if(this.query.collection && query.collection.length === 0) {
-      query.collection = this.query.collection;
+      this.query.collection = query.collection;
     }
     this.query = query;
     this.learningObjects = [];

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -389,6 +389,8 @@ export class LearningObjectsComponent
     status: string[];
     topic: string[];
     collection: string;
+    start: Date;
+    end: Date;
   }) {
     const query = {
       status: filters.status,

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -148,10 +148,8 @@ export class LearningObjectsComponent
             orderBy: OrderBy.Date,
           };
         } else {
-          this.query = {
-            sortType: undefined,
-            orderBy: undefined,
-          };
+          delete this.query.sortType;
+          delete this.query.orderBy;
         }
         this.learningObjects = [];
 
@@ -286,8 +284,8 @@ export class LearningObjectsComponent
         orderBy: OrderBy.Date,
       };
     }
-
     this.learningObjects = [];
+    this.allResultsReceived = false;
 
     this.getLearningObjects();
   }

--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -382,8 +382,8 @@ export class LearningObjectsComponent
       topics: filters.topic,
       collection: filters.collection,
       currPage: 1,
-      start: filters.start ? filters.start : "",
-      end: filters.end ? filters.end : ""
+      start: filters.start ? filters.start : '',
+      end: filters.end ? filters.end : ''
     };
 
     if(this.query.collection && query.collection.length === 0) {


### PR DESCRIPTION
Fixes the admin dashboard date filters on the learning objects component ( this is different from the featured component of the admin dashboard that we just fixed recently, but looks really similar ). So similar scenario as why the featured component was broken, the data for the dates selected by the user were just not being passed through from the search-filters component back to the parent component. Once I added the 'start' and 'end' date parameters to the query object thats passed through the filter handler function, it started working.

Also, I removed the 'unreleased' status from the status dropdown menu. The clark service search route does not ever allow this status to be a parameter, and always throws a 400 bad request even if the requester is the admin. Leah says they never have the need to search through unreleased or rejected objects, so I just removed it from the filters and kept the clark service logic the same. 

Video to show all filters work: 

https://github.com/user-attachments/assets/9b6965d5-0e87-48c9-85e8-4e71ebb0e21c

