### PR TITLE
Remove admin from query

### DIFF
--- a/src/app/admin/pages/learning-objects/learning-objects.component.ts
+++ b/src/app/admin/pages/learning-objects/learning-objects.component.ts
@@ -47,7 +47,6 @@ export class LearningObjectsComponent
     orderBy: OrderBy.Date,
     text: '',
     collection: '',
-    admin: 'true',
   };
 
   displayStatusModal = false;


### PR DESCRIPTION
Return the same result as the browse query in the admin search since clark-service aggregation conditional with `admin` in the query is outdated with a strict fuzzy config, resulting in little to no results since the introduction with changes from https://github.com/Cyber4All/clark-service/pull/443

```ts
 // Filter out anything with a score less than the threshold to remove irrelevant results
                    {
                        $match: {
                            score: { $gte: 2 },
...
```                      

## Service Aggregation issues

`author.name` no longer exists in the `objects-search` index
```ts
text: {
  query: query.text.toString(),
  path: ["name", "author.name"],
  score: { boost: { value: 10 } },
},
```

`maxEdits: 1` match if it's only a single character off
`prefixLength: 4` first 4 characters must match
```ts
text: {
  query: query.text.toString(),
  path: ["name", "author.name"],
  fuzzy: {
  maxEdits: 1,
  prefixLength: 4,
  },
  score: { boost: { value: 5 } },
}
```