### PR TITLE
Disable sortBy date as default value

### DIFF
--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -34,7 +34,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     guidelines: [],
     level: [],
     standardOutcomes: [],
-    orderBy: OrderBy.Date,
+    orderBy: '',
     sortType: -1,
     collection: '',
     topics: [],
@@ -72,7 +72,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
   sortMenuDown: boolean;
   showClearSort: boolean;
-  sortText = 'Newest';
+  sortText = '';
 
   @HostListener('window:resize', ['$event'])
   handelResize(event) {
@@ -86,7 +86,6 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     private router: Router,
     private cd: ChangeDetectorRef,
     private navService: NavbarService,
-    private searchService: SearchService,
   ) {
     this.windowWidth = window.innerWidth;
     this.cd.detach();
@@ -180,17 +179,15 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     this.query.text = '';
     this.query.standardOutcomes = [];
     this.query.currPage = 1;
-    this.query.sortType = -1;
-    this.query.orderBy = OrderBy.Date;
     this.router.navigate(['browse'], { queryParams: {} });
   }
 
   get sortString() {
     return this.query.orderBy
       ? this.query.orderBy.replace(/_/g, '') +
-          ' (' +
-          (this.query.sortType > 0 ? 'Asc' : 'Desc') +
-          ')'
+      ' (' +
+      (this.query.sortType > 0 ? 'Asc' : 'Desc') +
+      ')'
       : '';
   }
 

--- a/src/app/interfaces/query.ts
+++ b/src/app/interfaces/query.ts
@@ -20,7 +20,7 @@ export interface Query {
   level?: string[];
   guidelines?: string[];
   noGuidelines?: string;
-  orderBy?: OrderBy;
+  orderBy?: OrderBy | string;
   sortType?: SortType;
   text?: string;
   standardOutcomes?:


### PR DESCRIPTION
Sort by date is set as the default value on browse component creation, so I set `orderBy` to an empty string to avoid sorting by date by default. 

I'm going to assume that the intent is to show the newest learning objects when a user visits the browse page.

Should we change this behavior?

After performing a search query, the `sortBy` and `sortType` query param is still being passed, so the exact match is never at the top of the search results since sorting by date gets prioritized. 

It's evident when you search then go to the next page as the URL gets updated to show those query params.