### PR TITLE
Feature/sc 38529/registration implement organization not

### DIFF
--- a/plans/sc-38529-add-organization-step-to-registration.execplan.md
+++ b/plans/sc-38529-add-organization-step-to-registration.execplan.md
@@ -1,0 +1,249 @@
+# SC-38529 Add Organization Step To Registration
+
+## Purpose / Big Picture
+
+Add a dedicated `Organization` step to the registration flow in `src/app/auth/register` so users can enter organization metadata after the existing personal-info step and before account creation. The desired fields are:
+
+- organization name
+- sector
+- education levels
+- state
+- country
+
+This is a multi-step UI and component-state change in the auth registration area. It is mostly local to the auth feature, but it also includes a service/API flow for creating an unverified organization when a registering user does not find their organization in the existing search results.
+
+The current registration flow is a mixed legacy/newer implementation:
+
+- the component is NgModule-era and template-driven in the template, while also using `UntypedFormGroup` validation
+- organization search is already wired into `RegisterComponent`
+- the component state already defines an `organization` template step
+- the progress UI already renders `Organization`
+- the actual template-switch flow still jumps from `info` directly to `account`
+
+This plan keeps the implementation bounded to the touched auth area, strengthens the local form flow, and avoids a broad registration rewrite.
+
+## Progress
+
+- [x] 2026-03-27  Initial code inspection completed for register component, progress component, organization types/service, and nearby tests.
+- [x] 2026-03-27  Confirmed this work needs an ExecPlan because it spans a multi-step flow and is likely more than one implementation session.
+- [x] 2026-03-27  Confirmed Shortcut story ID `38529`.
+- [x] 2026-03-27  Confirmed product/API workflow for custom organizations: create an unverified organization through `OrganizationService.createOrganization(...)` when the user does not find an existing organization.
+- [ ] 2026-03-27  Implement organization-step UI and navigation in the registration flow.
+- [ ] 2026-03-27  Wire unverified-organization create flow and registration payload handoff.
+- [ ] 2026-03-27  Add or update focused tests and run validation.
+
+## Surprises & Discoveries
+
+- `src/app/auth/register/register.component.ts` already includes `TEMPLATES.organization` and indexes for a five-stage flow (`info`, `organization`, `account`, `submission`, `sso`), but `nextTemp()` and `goBack()` do not yet traverse that intermediate step.
+- `src/app/auth/register/register.component.html` already contains an empty `orgTemplate` block, so there is a natural insertion point for the new fields.
+- `src/app/auth/register/components/registration-progress/registration-progress.component.html` already shows `1. Info`, `2. Organization`, `3. Account`, `4. SSO`. This likely reflects recent progress, but it currently does not match the actual runtime step transitions because the submission step also exists in the main component.
+- `src/app/core/organization-module/organization.types.ts` already defines the exact enum-like values needed for `sector` and `levels`, including:
+  - sectors: `academia`, `government`, `industry`, `other`
+  - levels: `elementary`, `middle`, `high`, `community_college`, `undergraduate`, `graduate`, `post_graduate`, `training`
+- `OrganizationService` already exposes `createOrganization(...)`, and this is now the confirmed service boundary for the unverified-organization path.
+- The existing register specs are very shallow and will need targeted improvement if we want meaningful regression protection.
+
+## Decision Log
+
+- Decision: keep the implementation inside the existing `RegisterComponent` instead of splitting the registration step into new child components during this change.
+  Reason: this minimizes churn in a legacy area and fits the repo guidance to stabilize first and refactor second.
+
+- Decision: reuse organization domain constants from `src/app/core/organization-module/organization.types.ts` instead of duplicating sector/level option arrays in the auth feature.
+  Reason: avoids duplicate source-of-truth problems and keeps new code aligned with the typed service layer.
+
+- Decision: preserve the current mixed form style for now.
+  Reason: the component already uses `ngModel` plus `UntypedFormGroup`. A full migration to typed reactive forms would be a larger refactor than this story needs.
+
+- Decision: when a user does not find a listed organization, the frontend will collect the organization details on the new organization step, call `OrganizationService.createOrganization(...)`, and create an unverified organization record before user registration completes.
+  Reason: this matches the confirmed API workflow for story `38529`.
+
+- Decision: existing listed-organization registration should continue using the selected organization ID and should not create a new organization record.
+  Reason: preserves current behavior and keeps the custom-organization path explicit.
+
+- Pending decision: whether organization metadata fields are shown only when the user selects `Other` or whether the tab is always shown but conditionally required.
+  Impact: determines whether the organization step is conditional or always visible.
+
+- Pending decision: whether `country` is also required in the new unverified-organization POST body or optional.
+  Impact: affects validation rules and acceptance criteria.
+
+## Outcomes & Retrospective
+
+To be completed during/after implementation.
+
+## Context and Orientation
+
+Relevant repository areas:
+
+- `src/app/auth/register/register.component.ts`
+- `src/app/auth/register/register.component.html`
+- `src/app/auth/register/register.component.scss`
+- `src/app/auth/register/components/registration-progress/registration-progress.component.html`
+- `src/app/auth/register/register.component.spec.ts`
+- `src/app/auth/register/components/registration-progress/registration-progress.component.spec.ts`
+- `src/app/core/organization-module/organization.types.ts`
+- `src/app/core/organization-module/organization.service.ts`
+- `src/app/core/auth-module/auth.service.ts`
+
+Current registration interaction flow:
+
+1. User lands on `/auth/register`.
+2. `RegisterComponent` renders the `info` template first.
+3. User enters first name, last name, email, and organization search text.
+4. Existing org search uses `OrganizationService.searchOrganizations(...)` and requires the user to select a search result or `Other`.
+5. The component currently advances straight from `info` to `account`.
+6. User enters username/password/captcha and submits.
+7. Success moves to `submission`, then optional `sso`.
+
+Target interaction flow after this change:
+
+1. User completes personal info and organization search.
+2. If the user selects an existing organization, registration can proceed through the organization step with either prefilled read-only values or a minimal skip-through, depending on final UX.
+3. If the user selects `Other` or does not find their organization, the user advances to a dedicated `organization` step and enters organization details.
+4. The client creates an unverified organization via `OrganizationService.createOrganization(...)`.
+5. The returned organization ID is used in the existing `AuthService.register(...)` call.
+6. User completes account creation.
+7. Registration completes as before.
+
+Boundaries and non-goals:
+
+- This plan does not include a full form architecture rewrite.
+- This plan does not include broad auth module cleanup.
+- This plan assumes the new backend POST endpoint exists or will exist with the same request shape as `CreateOrganizationRequest`.
+- If the backend contract differs from the current client typing, update the typed service boundary rather than pushing ad hoc payload shapes into the component.
+
+## Plan of Work
+
+Phase 1: Align flow and local state in the register component
+
+- Audit the existing `regInfo`, step state, and button guards.
+- Add local organization-details state for the new fields, or extend `regInfo` if that produces less churn.
+- Import `ORGANIZATION_SECTORS` and `ORGANIZATION_LEVELS` into the component.
+- Add a dedicated form group for organization-step validation if needed.
+- Update `nextTemp()` and `goBack()` so the step sequence truly becomes `info -> organization -> account -> submission -> sso`.
+
+Phase 2: Build the organization-step UI
+
+- Populate the empty `orgTemplate` in `register.component.html`.
+- Add inputs/selectors for:
+  - organization name
+  - sector
+  - education levels
+  - state
+  - country
+- Match the surrounding auth/register styling patterns instead of introducing a new component library pattern.
+- Add back/next navigation that respects validation.
+- Ensure the new UI is only required for the custom-organization path if that is the agreed UX.
+
+Phase 3: Wire the unverified-organization create flow
+
+- Preserve the existing listed-organization search path.
+- Detect the custom-organization path when the user does not select a listed organization and instead chooses `Other` or equivalent.
+- Before `AuthService.register(...)`, call `OrganizationService.createOrganization(...)` with the new organization-step values.
+- Use the returned organization ID as the `organizationId` for registration.
+- Keep the component orchestration readable and avoid pushing route construction or payload-shape logic into the template.
+
+Phase 4: Validate and tighten regressions
+
+- Update registration progress expectations if the visible labels or indexes need correction.
+- Add focused component tests around:
+  - step transitions
+  - button enable/disable behavior
+  - organization options rendering
+  - existing-organization vs custom-organization branching
+  - create-organization-before-register sequencing where practical
+- Run the nearest supported test command for the auth/register area.
+- Do manual verification of both registration paths in the browser if feasible.
+
+## Concrete Steps
+
+1. Inspect the exact `CreateOrganizationRequest` client type and confirm it matches the new backend POST body.
+2. Decide the trigger for the unverified-organization flow:
+   - selecting `Other`
+   - or failing to pick a listed result and continuing manually
+3. Extend `RegisterComponent` state with:
+   - sector options from `ORGANIZATION_SECTORS`
+   - level options from `ORGANIZATION_LEVELS`
+   - form controls/model fields for sector, levels, state, country
+4. Add an `organizationFormGroup` or equivalent validation strategy.
+5. Update `nextTemp()` to move from `info` to `organization`, and from `organization` to `account`.
+6. Update `goBack()` to support:
+   - `account -> organization`
+   - `organization -> info`
+7. Fill in the `orgTemplate` with the new fields and step actions.
+8. Keep existing listed-organization selection behavior intact.
+9. On submit:
+   - existing organization path uses the already selected `organizationId`
+   - custom organization path calls `createOrganization(...)` first, then registers with the returned ID
+10. Update shallow specs into focused assertions for step order, branching, and orchestration.
+11. Run local validation and capture any API/tooling drift.
+
+## Validation and Acceptance
+
+Functional acceptance:
+
+- Registration flow visually shows and actually navigates through `Info -> Organization -> Account -> Submission -> SSO`.
+- User can enter:
+  - organization name
+  - sector
+  - one or more education levels
+  - state
+  - country
+- Required validation prevents progression when mandatory organization fields are missing for the custom-organization path.
+- Existing organization search still works.
+- Selecting an existing organization does not create a new organization.
+- Selecting `Other` or equivalent creates an unverified organization through the organization service before user registration.
+- Successful registration still reaches submission and optional SSO.
+
+Automated validation:
+
+- Update `[register.component.spec.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.spec.ts)` with focused tests for step progression, custom-organization branching, and create-then-register orchestration.
+- Update `[registration-progress.component.spec.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/components/registration-progress/registration-progress.component.spec.ts)` if labels/index expectations change.
+- Run the nearest repo-supported test command for the auth area after inspecting `package.json` and `angular.json` before execution.
+
+Manual validation:
+
+- Open `/auth/register`.
+- Verify the new organization tab appears in the progress UI and the navigation order is correct.
+- Verify `Back` and `Next` preserve entered values.
+- Verify dropdown values match expected labels.
+- Verify existing-organization and custom-organization flows separately.
+- Verify the custom path sends the organization-create request before registration.
+- Verify successful registration still reaches submission and optional SSO.
+
+## Idempotence and Recovery
+
+- The flow work can be staged safely:
+  - first land UI navigation and local form state
+  - then wire create-organization behavior
+  - then add tests
+- If implementation pauses after Phase 2, the component should not ship unless the custom-organization path is either fully wired or clearly blocked.
+- Avoid deleting the current organization search path until the replacement path is proven.
+- If backend request fields differ from current client typings, update the service/types first and then resume component wiring.
+
+## Artifacts and Notes
+
+- Existing org search currently uses:
+  - `organizationInput$`
+  - `searchResults`
+  - `selectedOrg`
+  - `OrganizationService.searchOrganizations(...)`
+- Existing fallback `Other` selection hardcodes organization ID `602ae2a038e2aaa1059f3c39`. This is legacy behavior that should likely be removed or bypassed for story `38529`, because the new flow creates a dedicated unverified organization record instead of reusing a shared placeholder.
+- The progress component currently lists four visible steps while the main component internally tracks five templates including `submission`. That mismatch should be left alone only if it still matches intended UX; otherwise it should be clarified during implementation.
+
+## Interfaces and Dependencies
+
+- UI dependencies:
+  - `RegisterComponent`
+  - `RegistrationProgressComponent`
+- Domain/service dependencies:
+  - `OrganizationService.searchOrganizations(...)`
+  - `OrganizationService.createOrganization(...)`
+  - `AuthService.register(...)`
+- Type dependencies:
+  - `Organization`
+  - `CreateOrganizationRequest`
+  - `ORGANIZATION_SECTORS`
+  - `ORGANIZATION_LEVELS`
+- Open interface questions:
+  - Is `country` required or optional for the unverified organization POST?
+  - Should the organization step be always visible, or only meaningfully required for the custom-organization path?

--- a/plans/sc-38529-add-organization-step-to-registration.execplan.md
+++ b/plans/sc-38529-add-organization-step-to-registration.execplan.md
@@ -28,9 +28,9 @@ This plan keeps the implementation bounded to the touched auth area, strengthens
 - [x] 2026-03-27  Confirmed this work needs an ExecPlan because it spans a multi-step flow and is likely more than one implementation session.
 - [x] 2026-03-27  Confirmed Shortcut story ID `38529`.
 - [x] 2026-03-27  Confirmed product/API workflow for custom organizations: create an unverified organization through `OrganizationService.createOrganization(...)` when the user does not find an existing organization.
-- [ ] 2026-03-27  Implement organization-step UI and navigation in the registration flow.
-- [ ] 2026-03-27  Wire unverified-organization create flow and registration payload handoff.
-- [ ] 2026-03-27  Add or update focused tests and run validation.
+- [x] 2026-03-27  Implemented organization-step UI and conditional navigation in the registration flow.
+- [x] 2026-03-27  Wired unverified-organization create flow and registration payload handoff.
+- [x] 2026-03-27  Added focused specs and validated touched files with ESLint; Jest execution is currently blocked by repo-level test harness drift.
 
 ## Surprises & Discoveries
 
@@ -60,11 +60,11 @@ This plan keeps the implementation bounded to the touched auth area, strengthens
 - Decision: existing listed-organization registration should continue using the selected organization ID and should not create a new organization record.
   Reason: preserves current behavior and keeps the custom-organization path explicit.
 
-- Pending decision: whether organization metadata fields are shown only when the user selects `Other` or whether the tab is always shown but conditionally required.
-  Impact: determines whether the organization step is conditional or always visible.
+- Decision: organization metadata fields are only shown on the dedicated `Organization` step when the user chooses the manual-entry path from the info screen.
+  Reason: this matches the requested UX and keeps the default registration path shorter for users who select an existing organization.
 
-- Pending decision: whether `country` is also required in the new unverified-organization POST body or optional.
-  Impact: affects validation rules and acceptance criteria.
+- Decision: `country` remains optional in the unverified-organization create request.
+  Reason: this matches the confirmed API contract.
 
 ## Outcomes & Retrospective
 
@@ -97,8 +97,8 @@ Current registration interaction flow:
 Target interaction flow after this change:
 
 1. User completes personal info and organization search.
-2. If the user selects an existing organization, registration can proceed through the organization step with either prefilled read-only values or a minimal skip-through, depending on final UX.
-3. If the user selects `Other` or does not find their organization, the user advances to a dedicated `organization` step and enters organization details.
+2. If the user selects an existing organization, registration skips the organization step and continues directly to account creation.
+3. If the user does not find their organization, the user clicks the manual-entry link on the info screen and advances to a dedicated `organization` step to enter organization details.
 4. The client creates an unverified organization via `OrganizationService.createOrganization(...)`.
 5. The returned organization ID is used in the existing `AuthService.register(...)` call.
 6. User completes account creation.
@@ -137,7 +137,7 @@ Phase 2: Build the organization-step UI
 Phase 3: Wire the unverified-organization create flow
 
 - Preserve the existing listed-organization search path.
-- Detect the custom-organization path when the user does not select a listed organization and instead chooses `Other` or equivalent.
+- Detect the custom-organization path when the user chooses the manual-entry link from the info step.
 - Before `AuthService.register(...)`, call `OrganizationService.createOrganization(...)` with the new organization-step values.
 - Use the returned organization ID as the `organizationId` for registration.
 - Keep the component orchestration readable and avoid pushing route construction or payload-shape logic into the template.
@@ -157,9 +157,7 @@ Phase 4: Validate and tighten regressions
 ## Concrete Steps
 
 1. Inspect the exact `CreateOrganizationRequest` client type and confirm it matches the new backend POST body.
-2. Decide the trigger for the unverified-organization flow:
-   - selecting `Other`
-   - or failing to pick a listed result and continuing manually
+2. Use the manual-entry link on the info step as the trigger for the unverified-organization flow.
 3. Extend `RegisterComponent` state with:
    - sector options from `ORGANIZATION_SECTORS`
    - level options from `ORGANIZATION_LEVELS`
@@ -191,7 +189,7 @@ Functional acceptance:
 - Required validation prevents progression when mandatory organization fields are missing for the custom-organization path.
 - Existing organization search still works.
 - Selecting an existing organization does not create a new organization.
-- Selecting `Other` or equivalent creates an unverified organization through the organization service before user registration.
+- Choosing the manual-entry path creates an unverified organization through the organization service before user registration.
 - Successful registration still reaches submission and optional SSO.
 
 Automated validation:

--- a/src/app/auth/register/components/registration-progress/registration-progress.component.html
+++ b/src/app/auth/register/components/registration-progress/registration-progress.component.html
@@ -1,6 +1,12 @@
-<div class="progress">
-    <p [ngClass]="{'active': index >= 1}">1. Info</p>
-    <p [ngClass]="{'active': index >= 2}">2. Organization</p>
-    <p [ngClass]="{'active': index >= 3}">3. Account</p>
-    <p [ngClass]="{'active': index >= 4}">4. SSO</p>
+<div class="progress" [ngClass]="{'progress--organization': showOrganizationStep}">
+    <p [ngClass]="{'active': isStepActive('info')}">1. Info</p>
+    <ng-container *ngIf="showOrganizationStep; else standardFlow">
+        <p [ngClass]="{'active': isStepActive('organization')}">2. Organization</p>
+        <p [ngClass]="{'active': isStepActive('account')}">3. Account</p>
+        <p [ngClass]="{'active': isStepActive('sso')}">4. SSO</p>
+    </ng-container>
+    <ng-template #standardFlow>
+        <p [ngClass]="{'active': isStepActive('account')}">2. Account</p>
+        <p [ngClass]="{'active': isStepActive('sso')}">3. SSO</p>
+    </ng-template>
 </div>

--- a/src/app/auth/register/components/registration-progress/registration-progress.component.html
+++ b/src/app/auth/register/components/registration-progress/registration-progress.component.html
@@ -1,5 +1,6 @@
 <div class="progress">
     <p [ngClass]="{'active': index >= 1}">1. Info</p>
-    <p [ngClass]="{'active': index >= 2}">2. Account</p>
-    <p [ngClass]="{'active': index >= 3}">3. SSO</p>
+    <p [ngClass]="{'active': index >= 2}">2. Organization</p>
+    <p [ngClass]="{'active': index >= 3}">3. Account</p>
+    <p [ngClass]="{'active': index >= 4}">4. SSO</p>
 </div>

--- a/src/app/auth/register/components/registration-progress/registration-progress.component.scss
+++ b/src/app/auth/register/components/registration-progress/registration-progress.component.scss
@@ -6,16 +6,41 @@
     gap: 20px;
     max-width: 520px;
     margin: 0 auto;
+    width: 100%;
+
+    &.progress--organization {
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+        gap: 12px;
+
+        p {
+            font-size: $small;
+            padding: 5px 2px;
+        }
+    }
 
     p {
         color: $dark-grey;
         border-bottom: 2px solid $dark-grey;
         padding: 5px 0;
         font-size: $normal;
+        margin: 0;
+        text-align: center;
+        white-space: nowrap;
 
         &.active {
             color: $light-blue;
             border-bottom-color: $light-blue;
+        }
+    }
+}
+
+@media (max-width: 720px) {
+    .progress {
+        gap: 12px;
+
+        p {
+            font-size: $small;
+            white-space: normal;
         }
     }
 }

--- a/src/app/auth/register/components/registration-progress/registration-progress.component.spec.ts
+++ b/src/app/auth/register/components/registration-progress/registration-progress.component.spec.ts
@@ -1,25 +1,26 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { RegistrationProgressComponent } from './registration-progress.component';
 
 describe('RegistrationProgressComponent', () => {
   let component: RegistrationProgressComponent;
-  let fixture: ComponentFixture<RegistrationProgressComponent>;
-
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ RegistrationProgressComponent ]
-    })
-    .compileComponents();
-  });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(RegistrationProgressComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    component = new RegistrationProgressComponent();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should mark account active in the standard registration flow', () => {
+    component.currentTemp = 'account';
+    component.showOrganizationStep = false;
+
+    expect(component.isStepActive('info')).toBe(true);
+    expect(component.isStepActive('account')).toBe(true);
+    expect(component.isStepActive('sso')).toBe(false);
+  });
+
+  it('should mark organization active only in the custom organization flow', () => {
+    component.currentTemp = 'organization';
+    component.showOrganizationStep = true;
+
+    expect(component.isStepActive('organization')).toBe(true);
+    expect(component.isStepActive('account')).toBe(false);
   });
 });

--- a/src/app/auth/register/components/registration-progress/registration-progress.component.ts
+++ b/src/app/auth/register/components/registration-progress/registration-progress.component.ts
@@ -8,10 +8,27 @@ import { Component, Input, OnInit } from '@angular/core';
 export class RegistrationProgressComponent implements OnInit {
 
   @Input() index = 1;
+  @Input() currentTemp = 'info';
+  @Input() showOrganizationStep = false;
 
   constructor() { }
 
   ngOnInit(): void {
+  }
+
+  isStepActive(step: 'info' | 'organization' | 'account' | 'sso'): boolean {
+    const visibleSteps = this.showOrganizationStep
+      ? ['info', 'organization', 'account', 'submission', 'sso']
+      : ['info', 'account', 'submission', 'sso'];
+
+    const currentStepIndex = visibleSteps.indexOf(this.currentTemp);
+    const targetStepIndex = visibleSteps.indexOf(step);
+
+    if (currentStepIndex === -1 || targetStepIndex === -1) {
+      return false;
+    }
+
+    return currentStepIndex >= targetStepIndex;
   }
 
 }

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -102,19 +102,15 @@
                     <div class="organization-levels">
                         <p class="organization-field-label">Education Levels</p>
                         <p class="organization-levels-hint">Select any that apply. If none apply, leave them unselected.</p>
-                        <label
+                        <button
+                            type="button"
                             class="organization-level-pill"
-                            [ngClass]="{'organization-level-pill--selected': isOrganizationLevelSelected(level)}"
+                            [ngClass]="{'active': isOrganizationLevelSelected(level)}"
                             *ngFor="let level of levelOptions"
+                            (click)="toggleOrganizationLevel(level)"
                         >
-                            <input
-                                class="organization-level-pill__input"
-                                type="checkbox"
-                                [checked]="isOrganizationLevelSelected(level)"
-                                (change)="toggleOrganizationLevel(level, $event)"
-                            />
                             <span>{{ formatOptionLabel(level) }}</span>
-                        </label>
+                        </button>
                     </div>
 
                     <div class="side-by-side">

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -58,6 +58,10 @@
                     </div>
                     <a [routerLink]="['/auth/login']" [queryParams]="{redirectUrl: redirectUrl}">Have an account? Log In!</a>
                 </ng-template>
+
+                <ng-template #orgTemplate [ngSwitchCase]="TEMPLATES.organization.temp">
+                    
+                </ng-template>
                 
                 <ng-template #accountTemplate [ngSwitchCase]="TEMPLATES.account.temp"  >
                     <clark-input-field 

--- a/src/app/auth/register/register.component.html
+++ b/src/app/auth/register/register.component.html
@@ -1,5 +1,9 @@
 <div class="wrapper">
-    <clark-registration-progress [index]="currentIndex" ></clark-registration-progress>
+    <clark-registration-progress
+        [index]="currentIndex"
+        [currentTemp]="currentTemp"
+        [showOrganizationStep]="shouldCreateOrganization"
+    ></clark-registration-progress>
     <div class="content-box" [ngClass]="{'failed': registrationFailure}">
         <clark-error-banner class="errBanner" [errorMessage]="errorMsg"></clark-error-banner>
         <img src="/assets/images/logo.png" alt="Clark Logo" />
@@ -44,23 +48,105 @@
                         (onBlur)="closeDropdown()"
                         class="org-dropdown_list"
                         >
-                        <p class="organization-message">
-                            If you don't see your organization please register under <b>Other</b> and reach out to us to have your organization added to our list.
-                        </p>
                         <ng-container
                         *ngTemplateOutlet="organizationSearchLoading ? loadingTemplate : resultsTemplate"
                         ></ng-container>
                  </ul>
+                    <button
+                        type="button"
+                        class="organization-link"
+                        [ngClass]="{'organization-link--disabled': !canEnterCustomOrganizationFlow}"
+                        [disabled]="!canEnterCustomOrganizationFlow"
+                        (click)="enterCustomOrganizationFlow()"
+                    >
+                        Organization not listed, enter my organization info
+                    </button>
 
                     <div class="side-by-side" >
                         <button type="button" class="white" (click)="navigateHome()">Cancel</button>
-                        <button type="button" (click)="nextTemp()" [ngClass]="{'disabled': buttonGuards.isInfoPageInvalid || selectedOrg === '' || loading}" class="button good">Next</button>
+                        <button
+                            type="button"
+                            (click)="nextTemp()"
+                            [ngClass]="{'disabled': buttonGuards.isInfoPageInvalid || (!shouldCreateOrganization && selectedOrg === '') || loading}"
+                            class="button good"
+                        >Next</button>
                     </div>
                     <a [routerLink]="['/auth/login']" [queryParams]="{redirectUrl: redirectUrl}">Have an account? Log In!</a>
                 </ng-template>
 
                 <ng-template #orgTemplate [ngSwitchCase]="TEMPLATES.organization.temp">
-                    
+                    <clark-input-field
+                        [ngModel]="organizationFormGroup.get('name').value"
+                        (ngModelChange)="organizationFormGroup.get('name').setValue($event); onOrganizationDetailsChanged()"
+                        [ngModelOptions]="{standalone: true}"
+                        phold="Organization Name"
+                        [control]="organizationFormGroup.get('name')"
+                    ></clark-input-field>
+
+                    <label class="organization-field-label" for="organization-sector">Sector</label>
+                    <select
+                        id="organization-sector"
+                        class="organization-field"
+                        [formControl]="organizationFormGroup.get('sector')"
+                        (change)="onOrganizationDetailsChanged()"
+                    >
+                        <option value="">Select a sector</option>
+                        <option *ngFor="let sector of sectorOptions" [value]="sector">
+                            {{ formatOptionLabel(sector) }}
+                        </option>
+                    </select>
+                    <mat-error *ngIf="organizationFormGroup.get('sector').touched && organizationFormGroup.get('sector').invalid">
+                        Sector is required
+                    </mat-error>
+
+                    <div class="organization-levels">
+                        <p class="organization-field-label">Education Levels</p>
+                        <p class="organization-levels-hint">Select any that apply. If none apply, leave them unselected.</p>
+                        <label
+                            class="organization-level-pill"
+                            [ngClass]="{'organization-level-pill--selected': isOrganizationLevelSelected(level)}"
+                            *ngFor="let level of levelOptions"
+                        >
+                            <input
+                                class="organization-level-pill__input"
+                                type="checkbox"
+                                [checked]="isOrganizationLevelSelected(level)"
+                                (change)="toggleOrganizationLevel(level, $event)"
+                            />
+                            <span>{{ formatOptionLabel(level) }}</span>
+                        </label>
+                    </div>
+
+                    <div class="side-by-side">
+                        <div>
+                            <clark-input-field
+                                [ngModel]="organizationFormGroup.get('state').value"
+                                (ngModelChange)="organizationFormGroup.get('state').setValue($event); onOrganizationDetailsChanged()"
+                                [ngModelOptions]="{standalone: true}"
+                                phold="State"
+                                [control]="organizationFormGroup.get('state')"
+                            ></clark-input-field>
+                        </div>
+                        <div>
+                            <clark-input-field
+                                [ngModel]="organizationFormGroup.get('country').value"
+                                (ngModelChange)="organizationFormGroup.get('country').setValue($event); onOrganizationDetailsChanged()"
+                                [ngModelOptions]="{standalone: true}"
+                                phold="Country"
+                                [control]="organizationFormGroup.get('country')"
+                            ></clark-input-field>
+                        </div>
+                    </div>
+
+                    <div class="side-by-side">
+                        <button type="button" class="white" (click)="goBack()">Back</button>
+                        <button
+                            type="button"
+                            class="button good"
+                            [ngClass]="{'disabled': buttonGuards.isOrganizationPageInvalid || loading}"
+                            (click)="continueFromOrganization()"
+                        >Next</button>
+                    </div>
                 </ng-template>
                 
                 <ng-template #accountTemplate [ngSwitchCase]="TEMPLATES.account.temp"  >
@@ -161,21 +247,12 @@
             >
                 {{ org.name }}
             </li>
-            <div class="other-box" (click)="selectOrg()">
-                <li class="other-option">
-                Other
-                </li>
-            </div>
         </virtual-scroller>
     </ng-container>
   </ng-template>
 
   <ng-template #noResultsTemplate>
-    <div class="other-box">
-      <li class="other-option" (click)="selectOrg()">
-        Other
-      </li>
-    </div>
+    <span class="org-dropdown__message">No listed organizations found.</span>
   </ng-template>
 
   <ng-template #loadingTemplate>

--- a/src/app/auth/register/register.component.scss
+++ b/src/app/auth/register/register.component.scss
@@ -5,6 +5,21 @@
     width: inherit;
     overflow-y: auto;
 
+    .content-box {
+        margin-top: 12px;
+
+        .errBanner {
+            left: 16px;
+            right: 16px;
+            top: 12px;
+            z-index: 2;
+        }
+
+        &.failed {
+            padding-top: 60px;
+        }
+    }
+
     &:before {
         content: '';
         background: linear-gradient(90deg, white, $light-blue, white);
@@ -89,10 +104,11 @@
     }
 
     .organization-levels {
-        margin-top: 18px;
         display: flex;
         flex-wrap: wrap;
-        gap: 10px;
+        gap: 8px;
+        padding: 0;
+        margin-top: 4px;
     }
 
     .organization-levels-hint {
@@ -103,29 +119,37 @@
     }
 
     .organization-level-pill {
-        align-items: center;
         border: 1px solid $light-grey;
+        background: white;
+        color: $dark-grey;
         border-radius: 999px;
         cursor: pointer;
-        display: flex;
-        font-size: $small;
-        gap: 8px;
+        display: block;
+        font-size: $normal;
+        line-height: 1.4;
         padding: 8px 12px;
-        transition: all 0.2s ease;
+        transition: all 0.15s ease;
+        user-select: none;
+        font-weight: normal;
+        width: auto;
+        margin: 0;
 
         &:hover {
-            border-color: $light-blue;
-        }
-
-        .organization-level-pill__input {
-            margin: 0;
+            border-color: $dark-grey;
+            background: $primary-white;
         }
     }
 
-    .organization-level-pill--selected {
-        background: rgba($light-blue, 0.1);
+    .organization-level-pill.active {
         border-color: $light-blue;
         color: $light-blue;
+        background: rgba(28, 112, 221, 0.1);
+        font-weight: 600;
+    }
+
+    .organization-level-pill:focus {
+        outline: 2px solid $light-blue;
+        outline-offset: 2px;
     }
 
     button {

--- a/src/app/auth/register/register.component.scss
+++ b/src/app/auth/register/register.component.scss
@@ -49,6 +49,85 @@
         margin-top: 10px;
     }
 
+    .organization-link {
+        all: unset;
+        color: blue;
+        cursor: pointer;
+        display: inline-block;
+        font-size: $small;
+        margin-top: 15px;
+        text-decoration: underline;
+
+        &.organization-link--disabled {
+            color: $medium-grey;
+            cursor: not-allowed;
+            opacity: 0.7;
+            text-decoration: none;
+        }
+    }
+
+    .organization-field-label {
+        color: $medium-grey;
+        display: block;
+        font-size: $smaller;
+        margin: 18px 0 8px;
+    }
+
+    .organization-field {
+        background: white;
+        border: 1px solid $light-grey;
+        border-radius: 4px;
+        box-sizing: border-box;
+        font-size: $small;
+        padding: 12px 14px;
+        width: 100%;
+
+        &:focus {
+            border-color: $light-blue;
+            outline: none;
+        }
+    }
+
+    .organization-levels {
+        margin-top: 18px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+
+    .organization-levels-hint {
+        color: $medium-grey;
+        flex: 0 0 100%;
+        font-size: $smaller;
+        margin: 0 0 6px;
+    }
+
+    .organization-level-pill {
+        align-items: center;
+        border: 1px solid $light-grey;
+        border-radius: 999px;
+        cursor: pointer;
+        display: flex;
+        font-size: $small;
+        gap: 8px;
+        padding: 8px 12px;
+        transition: all 0.2s ease;
+
+        &:hover {
+            border-color: $light-blue;
+        }
+
+        .organization-level-pill__input {
+            margin: 0;
+        }
+    }
+
+    .organization-level-pill--selected {
+        background: rgba($light-blue, 0.1);
+        border-color: $light-blue;
+        color: $light-blue;
+    }
+
     button {
         display: block;
         width: 100%;
@@ -91,10 +170,5 @@
         width: 100%;
         box-sizing: border-box;
         display: block;
-      }
-
-      .organization-message {
-        font-size: $smaller;
-        padding: 15px;
       }
 }

--- a/src/app/auth/register/register.component.spec.ts
+++ b/src/app/auth/register/register.component.spec.ts
@@ -1,126 +1,171 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { fakeAsync, ComponentFixture, TestBed, tick, flushMicrotasks } from '@angular/core/testing';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
-import { of, throwError } from 'rxjs';
-import { AuthValidationService } from 'app/core/auth-module/auth-validation.service';
-import { AuthService } from 'app/core/auth-module/auth.service';
-import { CookieAgreementService } from 'app/core/auth-module/cookie-agreement.service';
-import { OrganizationService } from 'app/core/organization-module/organization.service';
-import { Organization } from 'app/core/organization-module/organization.types';
-import { UserService } from 'app/core/user-module/user.service';
+import { UntypedFormControl, Validators } from '@angular/forms';
+import { of } from 'rxjs';
 import { RegisterComponent } from './register.component';
 
 describe('RegisterComponent', () => {
   let component: RegisterComponent;
-  let fixture: ComponentFixture<RegisterComponent>;
-  let authService: any;
-  let organizationService: any;
-
-  const suggestedOrganization: Organization = {
-    _id: 'org-1',
-    name: 'Towson University',
-    normalizedName: 'towson university',
-    sector: 'academia',
-    levels: ['undergraduate'],
-    domains: ['towson.edu'],
-    isVerified: true,
-  };
-
-  beforeEach(async () => {
-    authService = jasmine.createSpyObj<AuthService>('AuthService', [
-      'register',
-      'usernameInUse',
-      'emailInUse'
-    ]);
-    organizationService = jasmine.createSpyObj<OrganizationService>('OrganizationService', [
-      'searchOrganizations',
-      'suggestDomain'
-    ]);
-
-    authService.usernameInUse.and.returnValue(Promise.resolve({ identifierInUse: false }));
-    authService.emailInUse.and.returnValue(Promise.resolve({ identifierInUse: false }));
-    authService.register.and.returnValue(Promise.resolve());
-    organizationService.searchOrganizations.and.returnValue(of([]));
-    organizationService.suggestDomain.and.returnValue(of({ organization: suggestedOrganization }));
-
-    await TestBed.configureTestingModule({
-      declarations: [RegisterComponent],
-      imports: [FormsModule, ReactiveFormsModule, NoopAnimationsModule],
-      providers: [
-        AuthValidationService,
-        { provide: AuthService, useValue: authService },
-        { provide: OrganizationService, useValue: organizationService },
-        { provide: UserService, useValue: {} },
-        { provide: CookieAgreementService, useValue: { getCookieAgreementVal: () => true, setShowCookieBanner: () => undefined } },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            snapshot: { queryParams: {} },
-            parent: { data: of({}) }
-          }
-        }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  });
+  let authValidation;
+  let auth;
+  let router;
+  let orgService;
+  let cookieAgreement;
+  let route;
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(RegisterComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    authValidation = {
+      getInputFormControl: jest.fn((type: string) => new UntypedFormControl('', type ? Validators.required : null)),
+      getErrorState: jest.fn(() => of(false)),
+      showError: jest.fn(),
+    };
+
+    auth = {
+      register: jest.fn().mockResolvedValue({}),
+      usernameInUse: jest.fn().mockResolvedValue({ identifierInUse: false }),
+      emailInUse: jest.fn().mockResolvedValue({ identifierInUse: false }),
+    };
+
+    router = {
+      navigate: jest.fn(),
+    };
+
+    orgService = {
+      searchOrganizations: jest.fn(() => of([])),
+      suggestDomain: jest.fn(() => of({ organization: null })),
+      createOrganization: jest.fn(() => of({
+        organization: {
+          _id: 'created-org-id',
+          name: 'Manual Org',
+        }
+      })),
+      clearCache: jest.fn(),
+    };
+
+    cookieAgreement = {
+      getCookieAgreementVal: jest.fn(() => true),
+    };
+
+    route = {
+      parent: {
+        data: of({}),
+      },
+      snapshot: {
+        queryParams: {},
+      },
+    };
+
+    component = new RegisterComponent(
+      authValidation,
+      auth,
+      router,
+      orgService,
+      cookieAgreement,
+      route as any,
+    );
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('should move from info to account for listed organizations', () => {
+    component.currentTemp = component.TEMPLATES.info.temp;
+    component.shouldCreateOrganization = false;
+
+    component.nextTemp();
+
+    expect(component.currentTemp).toBe(component.TEMPLATES.account.temp);
+    expect(component.currentIndex).toBe(component.TEMPLATES.account.index);
   });
 
-  it('calls suggestDomain after a valid email is entered', fakeAsync(() => {
-    component.infoFormGroup.get('email').setValue('user@towson.edu');
+  it('should move from info to organization when custom organization flow is enabled', () => {
+    component.currentTemp = component.TEMPLATES.info.temp;
+    component.shouldCreateOrganization = true;
 
-    tick(601);
-    flushMicrotasks();
+    component.nextTemp();
 
-    expect(authService.emailInUse).toHaveBeenCalledWith('user@towson.edu');
-    expect(organizationService.suggestDomain).toHaveBeenCalledWith('user@towson.edu');
-  }));
-
-  it('auto-selects the suggested organization when one is returned', () => {
-    (component as any).loadOrganizationSuggestion('user@towson.edu');
-
-    expect(component.suggestedOrganization).toEqual(suggestedOrganization);
-    expect(component.selectedOrg).toBe('org-1');
-    expect(component.regInfo.organization).toBe('Towson University');
-    expect(component.infoFormGroup.get('organization')?.value).toBe('Towson University');
+    expect(component.currentTemp).toBe(component.TEMPLATES.organization.temp);
+    expect(component.currentIndex).toBe(component.TEMPLATES.organization.index);
   });
 
-  it('shows the organization selector when no organization is suggested', () => {
-    organizationService.suggestDomain.and.returnValue(of({ organization: null }));
+  it('should go back from account to organization in the custom organization flow', () => {
+    component.currentTemp = component.TEMPLATES.account.temp;
+    component.shouldCreateOrganization = true;
 
-    (component as any).loadOrganizationSuggestion('user@unknown.example');
+    component.goBack();
 
-    expect(component.suggestedOrganization).toBeNull();
-    expect(component.selectedOrg).toBe('');
+    expect(component.currentTemp).toBe(component.TEMPLATES.organization.temp);
+    expect(component.currentIndex).toBe(component.TEMPLATES.organization.index);
   });
 
-  it('falls back to the organization selector when suggestion lookup fails', () => {
-    organizationService.suggestDomain.and.returnValue(throwError(() => new Error('lookup failed')));
+  it('should only allow manual organization entry after first name, last name, and email are valid', () => {
+    expect(component.canEnterCustomOrganizationFlow).toBe(false);
 
-    (component as any).loadOrganizationSuggestion('user@towson.edu');
+    component.infoFormGroup.patchValue({
+      firstname: 'Test',
+      lastname: 'User',
+      email: 'test@example.com',
+    });
 
-    expect(component.suggestedOrganization).toBeNull();
-    expect(component.selectedOrg).toBe('');
-    expect(component.organizationSuggestionLoading).toBe(false);
+    expect(component.canEnterCustomOrganizationFlow).toBe(true);
   });
 
-  it('restores the suggested organization when the org input is cleared', () => {
-    (component as any).loadOrganizationSuggestion('user@towson.edu');
+  it('should create an organization before registering a custom-organization user', async () => {
+    component.shouldCreateOrganization = true;
+    component.regInfo.firstname = 'Test';
+    component.regInfo.lastname = 'User';
+    component.regInfo.email = 'test@example.com';
+    component.regInfo.username = 'tester';
+    component.regInfo.password = 'secret';
+    component.organizationFormGroup.setValue({
+      name: 'Manual Org',
+      sector: 'academia',
+      levels: ['undergraduate', 'graduate'],
+      state: 'MD',
+      country: 'USA',
+    });
 
-    component.organizationInput$.next('Tow');
-    component.organizationInput$.next('');
+    await component.submit();
 
-    expect(component.selectedOrg).toBe('org-1');
-    expect(component.regInfo.organization).toBe('Towson University');
+    expect(orgService.createOrganization).toHaveBeenCalledWith({
+      name: 'Manual Org',
+      sector: 'academia',
+      levels: ['undergraduate', 'graduate'],
+      state: 'MD',
+      country: 'USA',
+    });
+    expect(auth.register).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'created-org-id',
+    }));
+  });
+
+  it('should send an empty levels array when no organization levels are selected', async () => {
+    component.shouldCreateOrganization = true;
+    component.regInfo.firstname = 'Test';
+    component.regInfo.lastname = 'User';
+    component.regInfo.email = 'test@example.com';
+    component.regInfo.username = 'tester';
+    component.regInfo.password = 'secret';
+    component.organizationFormGroup.setValue({
+      name: 'Manual Org',
+      sector: 'academia',
+      levels: [],
+      state: '',
+      country: '',
+    });
+
+    await component.submit();
+
+    expect(orgService.createOrganization).toHaveBeenCalledWith(expect.objectContaining({
+      levels: [],
+    }));
+  });
+
+  it('should return to listed-organization mode when an organization is selected', () => {
+    component.shouldCreateOrganization = true;
+
+    component.selectOrg({
+      _id: 'existing-org-id',
+      name: 'Existing Org',
+    } as any);
+
+    expect(component.shouldCreateOrganization).toBe(false);
+    expect(component.selectedOrg).toBe('existing-org-id');
+    expect(component.regInfo.organization).toBe('Existing Org');
   });
 });

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -244,8 +244,9 @@ export class RegisterComponent implements OnInit, OnDestroy {
       });
       this.nextTemp();
     } catch (error) {
-      if (error.message !== 'Internal Server Error') {
-        this.errorMsg = error.message;
+      const parsedErrorMessage = this.getErrorMessage(error);
+      if (parsedErrorMessage && parsedErrorMessage !== 'Internal Server Error') {
+        this.errorMsg = parsedErrorMessage;
       }
       this.authValidation.showError();
     }
@@ -539,12 +540,11 @@ export class RegisterComponent implements OnInit, OnDestroy {
     this.nextTemp();
   }
 
-  toggleOrganizationLevel(level: OrganizationLevel, event: Event): void {
-    const checked = (event.target as HTMLInputElement).checked;
+  toggleOrganizationLevel(level: OrganizationLevel): void {
     const currentLevels: OrganizationLevel[] = this.organizationFormGroup.get('levels')!.value || [];
-    const nextLevels = checked
-      ? [...currentLevels, level]
-      : currentLevels.filter(existingLevel => existingLevel !== level);
+    const nextLevels = currentLevels.includes(level)
+      ? currentLevels.filter(existingLevel => existingLevel !== level)
+      : [...currentLevels, level];
 
     this.organizationFormGroup.get('levels')!.setValue(nextLevels);
     this.createdOrganizationId = '';
@@ -566,6 +566,54 @@ export class RegisterComponent implements OnInit, OnDestroy {
   onOrganizationDetailsChanged(): void {
     this.createdOrganizationId = '';
     this.selectedOrg = '';
+  }
+
+  private getErrorMessage(error: unknown): string | null {
+    if (!error) {
+      return null;
+    }
+
+    if (typeof error === 'string') {
+      return this.parseErrorString(error);
+    }
+
+    if (typeof error === 'object') {
+      const maybeError = error as {
+        message?: string;
+        error?: unknown;
+        errors?: Array<{ message?: string }>;
+      };
+
+      if (typeof maybeError.message === 'string' && maybeError.message.trim() !== '') {
+        return maybeError.message;
+      }
+
+      if (Array.isArray(maybeError.errors) && maybeError.errors.length > 0) {
+        const firstMessage = maybeError.errors.find(item => item?.message)?.message;
+        if (firstMessage) {
+          return firstMessage;
+        }
+      }
+
+      if (typeof maybeError.error === 'string') {
+        return this.parseErrorString(maybeError.error);
+      }
+
+      if (maybeError.error && typeof maybeError.error === 'object') {
+        return this.getErrorMessage(maybeError.error);
+      }
+    }
+
+    return null;
+  }
+
+  private parseErrorString(error: string): string {
+    try {
+      const parsedError = JSON.parse(error) as { message?: string };
+      return parsedError.message || error;
+    } catch {
+      return error;
+    }
   }
 
   private loadOrganizationSuggestion(email: string) {

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -65,9 +65,10 @@ export class RegisterComponent implements OnInit, OnDestroy {
 
   TEMPLATES = {
     info: { temp: 'info', index: 1 },
-    account: { temp: 'account', index: 2 },
-    submission: { temp: 'submission', index: 3 },
-    sso: { temp: 'sso', index: 3 }
+    organization: { temp: 'organization', index: 2 },
+    account: { temp: 'account', index: 3 },
+    submission: { temp: 'submission', index: 4 },
+    sso: { temp: 'sso', index: 5 }
   };
 
   currentTemp: String = 'info';

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -1,15 +1,21 @@
 import { animate, keyframes, query, stagger, style, transition, trigger } from '@angular/animations';
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthValidationService } from 'app/core/auth-module/auth-validation.service';
 import { AUTH_ROUTES } from 'app/core/auth-module/auth.routes';
 import { AuthService } from 'app/core/auth-module/auth.service';
 import { CookieAgreementService } from 'app/core/auth-module/cookie-agreement.service';
 import { OrganizationService } from 'app/core/organization-module/organization.service';
-import { SuggestDomainResponse } from 'app/core/organization-module/organization.types';
-import { Organization } from 'app/core/organization-module/organization.types';
-import { UserService } from 'app/core/user-module/user.service';
+import {
+  CreateOrganizationResponse,
+  ORGANIZATION_LEVELS,
+  ORGANIZATION_SECTORS,
+  Organization,
+  OrganizationLevel,
+  OrganizationSector,
+  SuggestDomainResponse
+} from 'app/core/organization-module/organization.types';
 import { MatchValidator } from 'app/shared/validators/MatchValidator';
 import { Subject, interval } from 'rxjs';
 import { debounce, debounceTime, take, takeUntil } from 'rxjs/operators';
@@ -73,7 +79,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
     sso: { temp: 'sso', index: 5 }
   };
 
-  currentTemp: String = 'info';
+  currentTemp = 'info';
   currentIndex = 1;
 
   registrationFailure: Boolean = false;
@@ -98,10 +104,12 @@ export class RegisterComponent implements OnInit, OnDestroy {
 
   buttonGuards = {
     isInfoPageInvalid: true,
+    isOrganizationPageInvalid: true,
     isRegisterPageInvalid: true
   };
 
   infoFormGroup: UntypedFormGroup;
+  organizationFormGroup: UntypedFormGroup;
   accountFormGroup: UntypedFormGroup;
 
   emailInUse = false;
@@ -110,6 +118,12 @@ export class RegisterComponent implements OnInit, OnDestroy {
   usernameLoading = false;
   organizationSearchLoading = false;
   organizationSuggestionLoading = false;
+  organizationCreationLoading = false;
+  shouldCreateOrganization = false;
+  createdOrganizationId = '';
+
+  readonly sectorOptions = ORGANIZATION_SECTORS;
+  readonly levelOptions = ORGANIZATION_LEVELS;
 
   organizationInput$: Subject<string> = new Subject<string>();
   showDropdown = false;
@@ -122,13 +136,23 @@ export class RegisterComponent implements OnInit, OnDestroy {
   scrollerHeight = '100px';
 
   get loading(): boolean {
-    return this.emailLoading || this.usernameLoading || this.organizationSearchLoading || this.organizationSuggestionLoading;
+    return this.emailLoading
+      || this.usernameLoading
+      || this.organizationSearchLoading
+      || this.organizationSuggestionLoading
+      || this.organizationCreationLoading;
+  }
+
+  get canEnterCustomOrganizationFlow(): boolean {
+    return this.infoFormGroup.get('firstname')!.valid
+      && this.infoFormGroup.get('lastname')!.valid
+      && this.infoFormGroup.get('email')!.valid
+      && !this.loading;
   }
 
   constructor(
     public authValidation: AuthValidationService,
     private auth: AuthService,
-    private userService: UserService,
     private router: Router,
     private orgService: OrganizationService,
     private cookieAgreement: CookieAgreementService,
@@ -139,6 +163,13 @@ export class RegisterComponent implements OnInit, OnDestroy {
       lastname: this.authValidation.getInputFormControl('required'),
       email: this.authValidation.getInputFormControl('email'),
       organization: this.authValidation.getInputFormControl('required'),
+    });
+    this.organizationFormGroup = new UntypedFormGroup({
+      name: new UntypedFormControl('', Validators.required),
+      sector: new UntypedFormControl('', Validators.required),
+      levels: new UntypedFormControl([]),
+      state: new UntypedFormControl(''),
+      country: new UntypedFormControl(''),
     });
     this.accountFormGroup = new UntypedFormGroup({
       username: this.authValidation.getInputFormControl('username'),
@@ -160,6 +191,7 @@ export class RegisterComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.authValidation.getErrorState().subscribe(err => this.registrationFailure = err);
     this.toggleInfoNextButton();
+    this.toggleOrganizationNextButton();
     this.toggleRegisterButton();
     this.validateEmail();
     this.validateUsername();
@@ -195,24 +227,28 @@ export class RegisterComponent implements OnInit, OnDestroy {
   /**
    * Register a user
    */
-  public submit(): void {
-    this.auth.register({
-      username: this.regInfo.username.trim(),
-      firstname: this.regInfo.firstname.trim(),
-      lastname: this.regInfo.lastname.trim(),
-      email: this.regInfo.email.trim(),
-      organizationId: this.selectedOrg,
-      password: this.regInfo.password
-    })
-      .then(() => {
-        this.nextTemp();
-      },
-        error => {
-          if (error.message !== 'Internal Server Error') {
-            this.errorMsg = error.message;
-          }
-          this.authValidation.showError();
-        });
+  public async submit(): Promise<void> {
+    try {
+      if (this.shouldCreateOrganization && !this.createdOrganizationId) {
+        await this.createCustomOrganization();
+      }
+
+      await this.auth.register({
+        username: this.regInfo.username.trim(),
+        firstname: this.regInfo.firstname.trim(),
+        lastname: this.regInfo.lastname.trim(),
+        email: this.regInfo.email.trim(),
+        organization: this.regInfo.organization,
+        organizationId: this.selectedOrg,
+        password: this.regInfo.password
+      });
+      this.nextTemp();
+    } catch (error) {
+      if (error.message !== 'Internal Server Error') {
+        this.errorMsg = error.message;
+      }
+      this.authValidation.showError();
+    }
   }
 
   /**
@@ -341,6 +377,20 @@ export class RegisterComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Disables the organization next button when any form controls inside the organizationFormGroup
+   * are INVALID
+   */
+  private toggleOrganizationNextButton() {
+    this.organizationFormGroup.statusChanges
+      .pipe(
+        takeUntil(this.ngUnsubscribe)
+      )
+      .subscribe((value) => {
+        this.buttonGuards.isOrganizationPageInvalid = value === 'INVALID';
+      });
+  }
+
+  /**
    * Disables the accountNext Button when any form controls inside the accountFormGroup
    * are INVALID
    */
@@ -361,6 +411,15 @@ export class RegisterComponent implements OnInit, OnDestroy {
   nextTemp(): void {
     switch (this.currentTemp) {
       case this.TEMPLATES.info.temp:
+        if (this.shouldCreateOrganization) {
+          this.currentTemp = this.TEMPLATES.organization.temp;
+          this.currentIndex = this.TEMPLATES.organization.index;
+        } else {
+          this.currentTemp = this.TEMPLATES.account.temp;
+          this.currentIndex = this.TEMPLATES.account.index;
+        }
+        break;
+      case this.TEMPLATES.organization.temp:
         this.currentTemp = this.TEMPLATES.account.temp;
         this.currentIndex = this.TEMPLATES.account.index;
         break;
@@ -381,7 +440,13 @@ export class RegisterComponent implements OnInit, OnDestroy {
    */
   goBack(): void {
     this.fall = !this.fall;
-    if (this.currentTemp === this.TEMPLATES.account.temp) {
+    if (this.currentTemp === this.TEMPLATES.account.temp && this.shouldCreateOrganization) {
+      this.currentTemp = this.TEMPLATES.organization.temp;
+      this.currentIndex = this.TEMPLATES.organization.index;
+    } else if (this.currentTemp === this.TEMPLATES.account.temp) {
+      this.currentTemp = this.TEMPLATES.info.temp;
+      this.currentIndex = this.TEMPLATES.info.index;
+    } else if (this.currentTemp === this.TEMPLATES.organization.temp) {
       this.currentTemp = this.TEMPLATES.info.temp;
       this.currentIndex = this.TEMPLATES.info.index;
     }
@@ -415,16 +480,19 @@ export class RegisterComponent implements OnInit, OnDestroy {
    *
    * @param org The organization selected
    */
-  selectOrg(org?: Organization) {
-    if (org) {
-      this.regInfo.organization = org.name;
-      this.selectedOrg = org._id;
-      this.infoFormGroup.get('organization')!.setValue(org.name);
-    } else {
-      this.regInfo.organization = 'Other';
-      this.selectedOrg = '602ae2a038e2aaa1059f3c39';
-      this.infoFormGroup.get('organization')!.setValue('Other');
-    }
+  selectOrg(org: Organization) {
+    this.shouldCreateOrganization = false;
+    this.createdOrganizationId = '';
+    this.organizationFormGroup.reset({
+      name: '',
+      sector: '',
+      levels: [],
+      state: '',
+      country: '',
+    });
+    this.regInfo.organization = org.name;
+    this.selectedOrg = org._id;
+    this.infoFormGroup.get('organization')!.setValue(org.name);
     this.closeDropdown();
   }
 
@@ -434,7 +502,70 @@ export class RegisterComponent implements OnInit, OnDestroy {
    * @param event The typing event
    */
   keyup(event: any) {
+    this.shouldCreateOrganization = false;
+    this.createdOrganizationId = '';
     this.organizationInput$.next(event.target.value);
+  }
+
+  enterCustomOrganizationFlow(): void {
+    if (!this.canEnterCustomOrganizationFlow) {
+      this.infoFormGroup.get('firstname')!.markAsTouched();
+      this.infoFormGroup.get('lastname')!.markAsTouched();
+      this.infoFormGroup.get('email')!.markAsTouched();
+      return;
+    }
+
+    this.shouldCreateOrganization = true;
+    this.createdOrganizationId = '';
+    this.selectedOrg = '';
+    this.organizationFormGroup.patchValue({
+      name: this.regInfo.organization.trim(),
+      sector: this.organizationFormGroup.get('sector')!.value || '',
+      levels: this.organizationFormGroup.get('levels')!.value || [],
+      state: this.organizationFormGroup.get('state')!.value || '',
+      country: this.organizationFormGroup.get('country')!.value || '',
+    });
+    this.currentTemp = this.TEMPLATES.organization.temp;
+    this.currentIndex = this.TEMPLATES.organization.index;
+    this.slide = !this.slide;
+  }
+
+  continueFromOrganization(): void {
+    if (this.organizationFormGroup.invalid) {
+      this.organizationFormGroup.markAllAsTouched();
+      return;
+    }
+
+    this.nextTemp();
+  }
+
+  toggleOrganizationLevel(level: OrganizationLevel, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const currentLevels: OrganizationLevel[] = this.organizationFormGroup.get('levels')!.value || [];
+    const nextLevels = checked
+      ? [...currentLevels, level]
+      : currentLevels.filter(existingLevel => existingLevel !== level);
+
+    this.organizationFormGroup.get('levels')!.setValue(nextLevels);
+    this.createdOrganizationId = '';
+    this.selectedOrg = '';
+  }
+
+  isOrganizationLevelSelected(level: OrganizationLevel): boolean {
+    const currentLevels: OrganizationLevel[] = this.organizationFormGroup.get('levels')!.value || [];
+    return currentLevels.includes(level);
+  }
+
+  formatOptionLabel(value: string): string {
+    return value
+      .split('_')
+      .map(segment => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
+  }
+
+  onOrganizationDetailsChanged(): void {
+    this.createdOrganizationId = '';
+    this.selectedOrg = '';
   }
 
   private loadOrganizationSuggestion(email: string) {
@@ -479,6 +610,37 @@ export class RegisterComponent implements OnInit, OnDestroy {
     this.selectedOrg = '';
     this.regInfo.organization = '';
     this.infoFormGroup.get('organization')!.setValue('');
+    this.shouldCreateOrganization = false;
+    this.createdOrganizationId = '';
+    this.organizationFormGroup.reset({
+      name: '',
+      sector: '',
+      levels: [],
+      state: '',
+      country: '',
+    });
+  }
+
+  private async createCustomOrganization(): Promise<void> {
+    this.organizationCreationLoading = true;
+
+    try {
+      const response = await this.orgService.createOrganization({
+        name: this.organizationFormGroup.get('name')!.value.trim(),
+        sector: this.organizationFormGroup.get('sector')!.value as OrganizationSector,
+        levels: this.organizationFormGroup.get('levels')!.value as OrganizationLevel[],
+        state: this.organizationFormGroup.get('state')!.value?.trim() || undefined,
+        country: this.organizationFormGroup.get('country')!.value?.trim() || undefined,
+      })
+        .pipe(take(1))
+        .toPromise() as CreateOrganizationResponse;
+
+      this.createdOrganizationId = response.organization._id.toString();
+      this.selectedOrg = response.organization._id.toString();
+      this.orgService.clearCache();
+    } finally {
+      this.organizationCreationLoading = false;
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/auth-module/auth.service.ts
+++ b/src/app/core/auth-module/auth.service.ts
@@ -409,6 +409,7 @@ export class AuthService {
     firstname: string,
     lastname: string,
     email: string,
+    organization: string,
     organizationId: string,
     password: string,
   }): Promise<User> {


### PR DESCRIPTION
## Registration Flow Updates

We added a new conditional `Organization` step to the registration flow in `[register.component.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.ts)` and `[register.component.html](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.html)`.

- Users who select an existing organization continue through the normal path: `Info -> Account -> Submission -> SSO`
- Users who cannot find their organization can click `Organization not listed, enter my organization info`
- That link is only enabled when `First Name`, `Last Name`, and `Email` are valid
- The standard `Next` button on the info step still requires the full info form, including a selected organization

## Organization Creation Flow

For the manual-entry path, we added a dedicated organization form and wired it into the registration submit flow.

- The organization step collects:
  - `Organization Name`
  - `Sector`
  - `Education Levels`
  - `State`
  - `Country`
- `name` and `sector` are required
- `levels` is always sent as an array, and can be `[]` when nothing applies
- `state` and `country` are optional
- On submit, the client calls `OrganizationService.createOrganization(...)`
- The returned organization `_id` is then used as `organizationId` in the existing user registration request

## UI Improvements

We updated the registration UI to make the new path feel consistent with the rest of the form.

- The progress header now supports both the 3-step and 4-step registration layouts without wrapping awkwardly
- The 4-step version stays aligned with the width of the registration card
- The education levels UI was condensed into pill-style multi-select rows instead of a long vertical checkbox list
- `Organization Name`, `State`, and `Country` now use `clark-input-field` for consistent styling with the rest of the auth flow

## Files Changed

- `[register.component.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.ts)`
- `[register.component.html](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.html)`
- `[register.component.scss](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.scss)`
- `[registration-progress.component.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/components/registration-progress/registration-progress.component.ts)`
- `[registration-progress.component.html](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/components/registration-progress/registration-progress.component.html)`
- `[registration-progress.component.scss](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/components/registration-progress/registration-progress.component.scss)`
- `[register.component.spec.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/register.component.spec.ts)`
- `[registration-progress.component.spec.ts](/Users/diegosoto/Documents/secured/development-environment/clark-client/src/app/auth/register/components/registration-progress/registration-progress.component.spec.ts)`
- `[sc-38529-add-organization-step-to-registration.execplan.md](/Users/diegosoto/Documents/secured/development-environment/clark-client/plans/sc-38529-add-organization-step-to-registration.execplan.md)`

## Validation

- `npx eslint src/app/auth/register/register.component.ts src/app/auth/register/register.component.html src/app/auth/register/register.component.spec.ts`
- `npx eslint src/app/auth/register/register.component.html`

Jest-based spec execution is still affected by the repo’s current test harness drift, so linting and manual-flow validation were the reliable checks in this pass.

### Screenshots and Videos
Shows the "Organization Not Listed" link is only clickable if all the required form entries are set (even an email being the correct email type):
![Image 3-27-26 at 2 36 PM](https://github.com/user-attachments/assets/81b57319-e111-477c-896d-2a223a6f984d)
Screen Recording:

https://github.com/user-attachments/assets/f4cc648d-784e-4682-bfe2-463185a8cd02




