### PR TITLE
OIDC role now parameters.role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
               --target-version="${TARGET_VERSION}"       
       - aws-cli/setup:
           region: us-east-1
-          role_arn: S3_OIDC_ROLE
+          role_arn: $<<parameters.role_arn>>
       - aws-s3/sync:
           from: ./dist/browser
           to: s3://<< parameters.bucket >>


### PR DESCRIPTION
OIDC role for S3 jobs now using parameters.role.