### PR TITLE
feature/sc-38995/update-lo-component-to-use-author-field-not

### DIFF
--- a/src/app/cube/shared/learning-object/learning-object.component.html
+++ b/src/app/cube/shared/learning-object/learning-object.component.html
@@ -59,12 +59,12 @@
 
       <div class="details">
         <div class="author">
-          {{ learningObject.contributors[0]?.name | titlecase }}
+          {{ learningObject.author?.name | titlecase }}
           {{ learningObject.contributors?.length > 1 ? ' et al.' : '' }}
         </div>
         <div class="organization">
           {{
-            orgStore.organizationNameFromUser$(learningObject.contributors[0])
+            orgStore.organizationNameFromUser$(learningObject.author)
               | async
           }}
         </div>


### PR DESCRIPTION
# Description

Story explains it well, but this updates the Learning-Object Card components that display objects on the Browse page. Currently, all the author info (their name and organization) that is displayed is being retrieved from the learning object's `contributors[]` attribute, and getting the first element of that array (which is always the original author). 

This can potentially lead to bad or stale data if, especially if we ever have a change of authorship. This is rare but can happen through the admin dashboard, and this usually updates the author field on a LO in Mongo, but moves the original author to the contributors array. This would lead to the old author being shown on the LO's card in browse instead of the new one. 