### PR TITLE
bug/sc-39005/fix-affiliated-organizations-count-on-clark

### DIFF
--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -131,10 +131,7 @@ export class UsageStatsComponent implements OnInit {
     });
 
     this.utilityService.getOrganizations().then((organizations) => {
-      console.log("Getting organizaiton data");
-      console.log("Organizations: " + organizations);
       this.usageStats.users.organizations = organizations.total;
-      console.log("Number of organizations: " + this.usageStats.users.organizations);
       this.buildCounterStats();
     });
   }

--- a/src/app/cube/usage-stats/usage-stats.component.ts
+++ b/src/app/cube/usage-stats/usage-stats.component.ts
@@ -131,7 +131,10 @@ export class UsageStatsComponent implements OnInit {
     });
 
     this.utilityService.getOrganizations().then((organizations) => {
-      this.usageStats.users.organizations = organizations.length;
+      console.log("Getting organizaiton data");
+      console.log("Organizations: " + organizations);
+      this.usageStats.users.organizations = organizations.total;
+      console.log("Number of organizations: " + this.usageStats.users.organizations);
       this.buildCounterStats();
     });
   }


### PR DESCRIPTION
# Description
Fixes the Usage Statistics page, which currently on prod, doesn't display a value for the number of Affiliated Organizations.

This has to do with the recent changes to the GET - /organizations route we had in the Organizations Epic. Before we were able to call the organizations GET route, which returns an array [ ], and just display the length, and that would be displayed as the value under 'Affiliated Organizations.' 

This route on Clark Service now returns an object with the organizations array nested inside:
```
{
   organizations: [ ... ],
   total: 1095
}
```
But you can see the updated response also returns the total, which is the number we want. This matches the total number of verified organizations by the way, so the correct value is displayed.