### PR TITLE
feature/sc-38956/edit-review-button-in-details-adds-another

### DIFF
--- a/src/app/cube/details/details.component.html
+++ b/src/app/cube/details/details.component.html
@@ -50,9 +50,8 @@
                   tip="You must verify your email in order to review Learning Objects."
                   [tipDisabled]="auth.user.emailVerified"
                   class="button good content-container__ratings-container__button-container"
-                  (activate)="showAddRating = auth.user.emailVerified"
-                  attr.aria-label="Clickable button {{ userRating.date ? 'Edit your' : 'Write a'}} review">{{ !canAddNewRating ? 'Edit' :
-                  'Write a'}} review
+                  (activate)="openAddRatingModal()"
+                  attr.aria-label="Clickable button Write a review">Write a review
                   <i class="far fa-pencil"></i>
                 </button>
             </div>
@@ -109,12 +108,12 @@
   </ng-container>
 </main>
 
-<clark-popup [floating]="true" *ngIf="showAddRating" (closed)="showAddRating = false">
+<clark-popup [floating]="true" *ngIf="showAddRating" (closed)="closeAddRatingModal()">
   <div #popupInner style="min-width: 300px; max-width:100vw" class="popup-inner">
     <div class="new-rating">
       <div class="title">Rate this Learning Object</div>
       <clark-new-rating [rating]="userRating" [editing]="editRating" (setRating)="handleRatingSubmission($event)"
-        (cancelRating)="showAddRating = false;"></clark-new-rating>
+        (cancelRating)="closeAddRatingModal()"></clark-new-rating>
     </div>
   </div>
 </clark-popup>

--- a/src/app/cube/details/details.component.ts
+++ b/src/app/cube/details/details.component.ts
@@ -416,6 +416,25 @@ export class DetailsComponent implements OnInit, OnDestroy {
     }
   }
 
+  openAddRatingModal() {
+    if (!this.auth.user.emailVerified) {
+      return;
+    }
+
+    this.editRating = false;
+    this.userRating = {
+      value: undefined,
+      comment: undefined,
+    };
+    this.showAddRating = true;
+  }
+
+  closeAddRatingModal() {
+    this.showAddRating = false;
+    this.editRating = false;
+    this.userRating = {};
+  }
+
   /**
    * Creates a new rating
    *
@@ -431,11 +450,11 @@ export class DetailsComponent implements OnInit, OnDestroy {
       .then(
         () => {
           this.getLearningObjectRatings();
-          this.showAddRating = false;
+          this.closeAddRatingModal();
           this.toastService.success('Success!', 'Review submitted successfully!');
         },
         error => {
-          this.showAddRating = false;
+          this.closeAddRatingModal();
           this.toastService.error('Error!', 'An error occurred and your rating could not be submitted');
         }
       );
@@ -484,11 +503,11 @@ export class DetailsComponent implements OnInit, OnDestroy {
       .then(
         () => {
           this.getLearningObjectRatings();
-          this.showAddRating = false;
+          this.closeAddRatingModal();
           this.toastService.success('Success!', 'Rating updated successfully!');
         },
         (error) => {
-          this.showAddRating = false;
+          this.closeAddRatingModal();
           this.toastService.error('Error!', 'An error occurred and your rating could not be updated');
         }
       );


### PR DESCRIPTION
Write a review always starts a brand-new review instead of inheriting any prior edit state. The big blue button now opens a clean review form, while review editing is still available only through the Edit rating action on an existing review.

Also cleans up the modal flow by centralizing open/close behavior for the review popup. Makes sure that the form resets correctly when opened and closes consistently after submit or cancel. 