### PR TITLE
chore/sc-39281/bring-back-sort-by-oldest-on-clark-for-admins

### DIFF
--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -108,6 +108,13 @@
           >
             <ul>
               <li
+                *ngIf="isAdminOrEditor()"
+                [ngClass]="{ selected: sortText === 'Oldest' }"
+                (click)="toggleSort('ad')"
+              >
+                Oldest
+              </li>
+              <li
                 [ngClass]="{ selected: sortText === 'Newest' }"
                 (click)="toggleSort('dd')"
               >

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -18,6 +18,7 @@ import { OrderBy, Query, SortType } from '../../interfaces/query';
 import { COPY } from './browse.copy';
 import { FilterSectionInfo } from './components/filter-section/filter-section.component';
 import { FilterComponent } from './components/filter/filter.component';
+import { AuthService } from 'app/core/auth-module/auth.service';
 
 @Component({
   selector: 'cube-browse',
@@ -99,6 +100,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
     private cd: ChangeDetectorRef,
     private navService: NavbarService,
     private renderer: Renderer2,
+    private authService: AuthService
   ) {
     this.windowWidth = window.innerWidth;
     this.cd.detach();
@@ -450,6 +452,10 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
         this.sortText = 'Newest';
         this.query.orderBy = OrderBy.Date;
         this.query.sortType = SortType.Descending;
+      } else if (val === 'ad') {
+        this.sortText = 'Oldest';
+        this.query.orderBy = OrderBy.Date;
+        this.query.sortType = SortType.Ascending
       } else if (val === 'w') {
         this.sortText = 'Most Downloaded';
         this.query.orderBy = OrderBy.Downloads;
@@ -670,5 +676,9 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
     this.performSearch(true);
     this.cd.detectChanges();
+  }
+
+  isAdminOrEditor(): boolean {
+    return this.authService.isAdminOrEditor();
   }
 }


### PR DESCRIPTION
# Summary
Asked by Leah in the dev-ops channel, but adding back sort by Oldest first in the browse page as an admin only feature. Before this was removed along with sort by alphabetical since those are rarely if ever used by end users. The use case for bringing back Oldest First is it would make it easier for Leah to look at what objects are going to need relevancy checks the most, and she asked to keep this admin only.

**Note:** only requires client side changes to pass the query through on the request, service already is setup to handle sort by oldest. It doesn't have admin only verification on it though, but I don't think it's a big deal really. So just these changes are needed


https://github.com/user-attachments/assets/c644bfa9-6f49-40a4-951d-3051a7e8e47d

