### PR TITLE
Modernize visual design system and refresh marquee pages

### DIFF
--- a/src/_vars.scss
+++ b/src/_vars.scss
@@ -1,3 +1,115 @@
+// =====================================================================
+// Modern design tokens (2026 refresh)
+// New work should reference these tokens. Legacy variables below are
+// preserved so unmigrated components keep compiling unchanged.
+// =====================================================================
+
+// ----- Color: primary brand -----
+$brand-50:  #eef5ff;
+$brand-100: #d9e8ff;
+$brand-200: #b4d0ff;
+$brand-300: #84b1ff;
+$brand-500: #2f6ee0;
+$brand-600: #1f5bc7;
+$brand-700: #1949a3;
+$brand-900: #0e2c64;
+
+// ----- Color: neutrals (single-hue, cool grey) -----
+$neutral-0:   #ffffff;
+$neutral-50:  #f7f8fa;
+$neutral-100: #eef0f4;
+$neutral-200: #dde1e8;
+$neutral-300: #c2c8d2;
+$neutral-400: #98a0ad;
+$neutral-500: #6b7280;
+$neutral-600: #4b5360;
+$neutral-700: #343a45;
+$neutral-800: #1f242d;
+$neutral-900: #0f1218;
+
+// ----- Color: text -----
+$text-primary:   $neutral-800;
+$text-secondary: $neutral-600;
+$text-muted:     $neutral-500;
+$text-inverse:   $neutral-0;
+
+// ----- Color: surface -----
+$surface-page:    $neutral-0;
+$surface-raised:  $neutral-0;
+$surface-sunken:  $neutral-50;
+$surface-border:  $neutral-200;
+$surface-divider: $neutral-100;
+
+// ----- Color: status -----
+$success-500: #16a34a;
+$success-50:  #ecfdf5;
+$warning-500: #ea8a17;
+$warning-50:  #fff7ed;
+$danger-500:  #d92d20;
+$danger-50:   #fef2f2;
+$info-500:    #0ea5e9;
+$info-50:     #ecfeff;
+
+// ----- Spacing (4px scale) -----
+$space-1:  4px;
+$space-2:  8px;
+$space-3:  12px;
+$space-4:  16px;
+$space-5:  20px;
+$space-6:  24px;
+$space-7:  32px;
+$space-8:  40px;
+$space-9:  48px;
+$space-10: 64px;
+$space-11: 80px;
+$space-12: 96px;
+
+// ----- Radius -----
+$radius-sm:   6px;
+$radius-md:   10px;
+$radius-lg:   16px;
+$radius-xl:   24px;
+$radius-pill: 999px;
+
+// ----- Shadow (soft, layered) -----
+$shadow-sm: 0 1px 2px rgba(15, 18, 24, 0.05);
+$shadow-md: 0 4px 10px rgba(15, 18, 24, 0.06), 0 2px 4px rgba(15, 18, 24, 0.04);
+$shadow-lg: 0 12px 28px rgba(15, 18, 24, 0.10), 0 4px 8px rgba(15, 18, 24, 0.05);
+$shadow-ring: 0 0 0 3px rgba(47, 110, 224, 0.35);
+
+// ----- Type (rem-based, 16px root) -----
+$font-display:  clamp(2.25rem, 4vw + 1rem, 3.5rem); // 36 -> 56px
+$font-h1:       2rem;     // 32px
+$font-h2:       1.5rem;   // 24px
+$font-h3:       1.25rem;  // 20px
+$font-body-lg:  1.0625rem;// 17px
+$font-body:     1rem;     // 16px
+$font-caption:  0.875rem; // 14px
+$font-micro:    0.75rem;  // 12px
+
+$line-height-tight:   1.15;
+$line-height-normal:  1.5;
+$line-height-relaxed: 1.65;
+
+$letter-spacing-tight: -0.015em;
+$letter-spacing-wide:  0.04em;
+
+// ----- Motion -----
+$duration-fast: 120ms;
+$duration-base: 200ms;
+$duration-slow: 320ms;
+$ease-standard: cubic-bezier(0.2, 0, 0, 1);
+$ease-emphasis: cubic-bezier(0.2, 0, 0, 1.2);
+
+// ----- Breakpoints -----
+$bp-mobile: 640px;
+$bp-tablet: 960px;
+$bp-desktop: 1200px;
+
+// =====================================================================
+// Legacy variables (preserved for back-compat across the app)
+// =====================================================================
+
 // variables
 $max-width: 1600px;
 

--- a/src/app/components/primary-navbar/primary-navbar.component.scss
+++ b/src/app/components/primary-navbar/primary-navbar.component.scss
@@ -1,10 +1,12 @@
 @import '_vars.scss';
 .desktop-navbar {
-    max-height: 92px;
-    background: white;
-    color: $dark-grey;
+    max-height: 76px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: saturate(140%) blur(8px);
+    color: $text-secondary;
     position: relative;
     z-index: 4;
+    border-bottom: 1px solid $surface-divider;
 
     .nav-wrapper {
         margin: 0px;
@@ -12,34 +14,47 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        
+        align-items: center;
+        max-width: $max-width;
+        margin: 0 auto;
+        padding: 0 $space-6;
+
         a{
             text-decoration: none;
-        
+
             .logo {
                 cursor: pointer;
                 position: relative;
+                display: flex;
+                align-items: center;
                 left: 0;
-                padding: 20px;
-                padding-top: 30px;
-                
+                padding: $space-3 0;
+                border-radius: $radius-sm;
+
+                &:focus-visible {
+                    outline: 2px solid $brand-500;
+                    outline-offset: 4px;
+                }
+
                 &-image {
                     background-image: url('../../../assets/images/logo.png');
-                    width: 40px;
+                    width: 36px;
                     background-size: contain;
                     background-repeat: no-repeat;
+                    background-position: center;
                     flex-shrink: 0;
-                    height: 100%;
-                    padding: 20px;
+                    height: 36px;
+                    padding: 0;
                 }
-                
+
                 &-link {
-                    font-size: $larger;
+                    font-size: $font-h3;
                     font-weight: 700;
-                    padding-right: 15px;
+                    padding-right: $space-3;
                     position: relative;
-                    margin-left: 10px;
-                    color: $homepage-gray;
+                    margin-left: $space-3;
+                    color: $text-primary;
+                    letter-spacing: $letter-spacing-tight;
                 }
             }
         }
@@ -72,11 +87,18 @@
                 button {
                     cursor: pointer;
                     color: white;
-                    border-radius: 0px 6px 6px 0px;
+                    border-radius: 0px $radius-sm $radius-sm 0px;
                     border: none;
-                    width: 50px;
-                    height: 44px;
-                    background: $homepage-light-blue;
+                    width: 44px;
+                    height: 40px;
+                    background: $brand-600;
+                    transition: background-color $duration-fast $ease-standard;
+
+                    &:hover { background: $brand-700; }
+                    &:focus-visible {
+                        outline: 2px solid $brand-500;
+                        outline-offset: 2px;
+                    }
                 }
             }
         }
@@ -84,19 +106,36 @@
         .right {
             display: flex;
             flex-direction: row;
+            align-items: center;
             justify-content: flex-end;
-            padding: 20px 18px;
-            gap: 10px;
-            
+            padding: $space-3 0;
+            gap: $space-3;
+
             .contribute-button {
                 cursor: pointer;
-                color: $dark-grey;
-                background-color: $primary-white;
-                border: solid $secondary-white 1px;
-                height: 45px;
-                border-radius: 4px;
-                padding: 0 18px;
-                margin-right: 2vw;
+                color: $text-primary;
+                background-color: $neutral-0;
+                border: 1px solid $surface-border;
+                height: 40px;
+                border-radius: $radius-md;
+                padding: 0 $space-4;
+                font-weight: 600;
+                margin-right: $space-4;
+                transition:
+                    background-color $duration-fast $ease-standard,
+                    border-color $duration-fast $ease-standard,
+                    box-shadow $duration-base $ease-standard;
+
+                &:hover {
+                    background: $neutral-50;
+                    border-color: $neutral-300;
+                    box-shadow: $shadow-sm;
+                }
+
+                &:focus-visible {
+                    outline: 2px solid $brand-500;
+                    outline-offset: 2px;
+                }
             }
             
             .logged-in{
@@ -106,37 +145,52 @@
                 
                 
                 .profile-picture {
-                    width: 50px;
-                    height: 50px;
+                    width: 38px;
+                    height: 38px;
                     background-size: cover;
                     background-position: center;
                     background-repeat: no-repeat;
                     border-radius: 50%;
-                    box-shadow: 0  1px 6px 2px rgba(0, 0, 0, 0.05);
+                    box-shadow: $shadow-sm, 0 0 0 2px $neutral-0, 0 0 0 3px $surface-border;
                 }
-                
+
                 .username {
                     cursor: pointer;
                     display: flex;
                     flex-direction: row;
-                    padding: 15px 5px;
+                    align-items: center;
+                    padding: $space-2 $space-2;
+                    color: $text-secondary;
+                    border-radius: $radius-md;
                     overflow:visible;
+                    transition: background-color $duration-fast $ease-standard;
+
+                    &:hover { background: $neutral-50; color: $text-primary; }
+
                     .arrow {
-                        margin-left: 10px;
+                        margin-left: $space-2;
+                        font-size: 0.75em;
                     }
                 }
             }
-            
+
             .logged-out {
                 display: flex;
                 flex-direction: row;
+                align-items: center;
                 justify-content: space-evenly;
-                padding: 15px;
-                
+                gap: $space-2;
+                padding: 0;
+
                 .login-button {
-                    margin-right: 23px;
-                    color: $homepage-light-blue;
-                    font-weight: 400;
+                    margin-right: $space-3;
+                    color: $brand-600;
+                    font-weight: 600;
+                    padding: 8px 14px;
+                    border-radius: $radius-md;
+                    transition: background-color $duration-fast $ease-standard;
+
+                    &:hover { background: $brand-50; }
                 }
             }
         }
@@ -333,15 +387,15 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background: $slideout-underlay;
-    opacity: 80%;
-    backdrop-filter: blur(10px);
+    background: rgba(15, 23, 42, 0.5);
+    opacity: 0;
+    backdrop-filter: blur(8px);
     z-index: 4;
-    transition: all 0.5s ease;
+    transition: opacity $duration-base $ease-standard, visibility $duration-base $ease-standard;
     visibility: hidden;
-    
+
     &.active {
-        opacity: 0.8;
+        opacity: 1;
         visibility: visible;
     }
 

--- a/src/app/components/secondary-navbar/secondary-navbar.component.scss
+++ b/src/app/components/secondary-navbar/secondary-navbar.component.scss
@@ -3,37 +3,47 @@
 .secondary-navbar {
     display: flex;
     flex-direction: row;
+    align-items: center;
     position: relative;
-    background-color: $primary-white;
-    padding: 12px 0 12px 40px;
-    border: solid 1px $secondary-white;
+    background-color: $neutral-0;
+    padding: $space-2 $space-6;
+    border-bottom: 1px solid $surface-divider;
     z-index: 4;
 
     .item {
         cursor: pointer;
-        font-weight: 400;
-        color: $dark-grey;
-        padding: 0 45px;
+        font-weight: 600;
+        font-size: $font-caption;
+        color: $text-secondary;
+        padding: $space-2 $space-4;
+        border-radius: $radius-md;
+        transition:
+            background-color $duration-fast $ease-standard,
+            color $duration-fast $ease-standard;
 
-        span {
-            margin-left: 5px;
+        span { margin-left: $space-2; }
+
+        &:hover {
+            background: $neutral-50;
+            color: $text-primary;
+        }
+
+        &:focus-visible {
+            outline: 2px solid $brand-500;
+            outline-offset: 2px;
         }
     }
+
     a:hover {
-        color: $dark-grey;
         text-decoration: none;
     }
 
     .item:first-child {
-        padding-left: 0;
+        margin-left: 0;
     }
-
 }
 
 a {
     text-decoration: none;
-    color: $dark-grey;
-    &:hover {
-        color: white;
-    }
+    color: inherit;
 }

--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -178,9 +178,20 @@
 
   <!-- Results grid -->
   <div class="results-container" id="pageContent" tabindex="0">
-    <h3 *ngIf="learningObjects.length === 0 && !loading" class="no-results">
-      {{ copy.NORESULTS }}
-    </h3>
+    <div *ngIf="learningObjects.length === 0 && !loading" class="no-results">
+      <div class="no-results__icon" aria-hidden="true">
+        <i class="far fa-search"></i>
+      </div>
+      <h3 class="no-results__title">{{ copy.NORESULTS }}</h3>
+      <p class="no-results__hint">Try removing a filter, broadening your search, or browsing all topics.</p>
+      <button
+        *ngIf="anyFiltersSelected() || query?.text"
+        class="button neutral"
+        type="button"
+        (click)="clearAllFilters(true); clearSearch()">
+        Clear filters &amp; search
+      </button>
+    </div>
     <div class="results-grid" *ngIf="learningObjects.length > 0 || loading">
       <clark-learning-object-component
         *ngFor="let l of learningObjects; trackBy: trackByLearningObject"

--- a/src/app/cube/browse/browse.component.scss
+++ b/src/app/cube/browse/browse.component.scss
@@ -19,24 +19,27 @@
 
 // Page header section
 .page-header {
-  padding: 20px 0;
+  padding: $space-6 0 $space-4;
   margin-bottom: 0;
   display: flex;
   justify-content: space-between;
   align-items: center;
 
   .results-title {
-    font-size: $normal;
-    text-transform: uppercase;
-    color: $darker-grey;
+    font-size: $font-h3;
+    font-weight: 700;
+    text-transform: none;
+    letter-spacing: $letter-spacing-tight;
+    color: $text-primary;
     display: flex;
     align-items: center;
-    gap: 10px;
+    gap: $space-3;
     flex-wrap: wrap;
 
     .loading {
       display: inline-block;
-      margin-left: 10px;
+      margin-left: $space-2;
+      color: $brand-500;
     }
   }
 }
@@ -74,35 +77,44 @@
 
   .filter-btn,
   .sort-btn {
-    border: 1px solid $light-grey;
-    background: white;
-    border-radius: 6px;
-    height: 42px;
-    padding: 0 12px;
+    border: 1px solid $surface-border;
+    background: $neutral-0;
+    border-radius: $radius-md;
+    height: 40px;
+    padding: 0 $space-3;
     box-sizing: border-box;
-    font-size: $normal;
+    font-size: $font-caption;
+    font-weight: 600;
     cursor: pointer;
-    color: $darker-grey;
+    color: $text-primary;
     display: flex;
     align-items: center;
-    gap: 6px;
-    transition: all 0.15s ease;
+    gap: $space-2;
+    transition:
+      border-color $duration-fast $ease-standard,
+      background-color $duration-fast $ease-standard,
+      box-shadow $duration-base $ease-standard,
+      color $duration-fast $ease-standard;
     white-space: nowrap;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+    box-shadow: $shadow-sm;
 
-    i {
-      font-size: $smaller;
-    }
+    i { font-size: $font-micro; }
 
     &:hover {
-      border-color: $dark-grey;
-      background: $primary-white;
+      border-color: $neutral-300;
+      background: $neutral-50;
+      box-shadow: $shadow-md;
     }
 
     &.active {
-      border-color: $blue-accent;
-      color: $blue-accent;
-      background: rgba(70, 144, 255, 0.05);
+      border-color: $brand-500;
+      color: $brand-700;
+      background: $brand-50;
+    }
+
+    &:focus-visible {
+      outline: 2px solid $brand-500;
+      outline-offset: 2px;
     }
   }
 
@@ -526,13 +538,43 @@
 
 // Results container
 .results-container {
-  padding: 30px 0;
+  padding: $space-7 0;
   min-height: 300px;
 
   .no-results {
     text-align: center;
-    color: $dark-grey;
-    padding: 40px 20px;
+    color: $text-secondary;
+    padding: $space-10 $space-5;
+    max-width: 480px;
+    margin: 0 auto;
+
+    &__icon {
+      width: 72px;
+      height: 72px;
+      margin: 0 auto $space-5;
+      border-radius: $radius-pill;
+      background: $brand-50;
+      color: $brand-600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.75rem;
+    }
+
+    &__title {
+      font-size: $font-h3;
+      color: $text-primary;
+      font-weight: 700;
+      letter-spacing: $letter-spacing-tight;
+      margin: 0 0 $space-3;
+    }
+
+    &__hint {
+      font-size: $font-body;
+      color: $text-secondary;
+      line-height: $line-height-relaxed;
+      margin: 0 0 $space-6;
+    }
   }
 }
 
@@ -551,7 +593,7 @@
 
 // Pagination
 .paginationCtrl {
-  margin: 40px 0 30px;
+  margin: $space-8 0 $space-7;
 
   ul {
     margin: 0;
@@ -560,38 +602,47 @@
     justify-content: center;
     align-items: center;
     flex-wrap: wrap;
-    gap: 5px;
+    gap: $space-1;
 
     li {
-      color: $homepage-light-blue;
-      border: none;
-      font-size: 15px;
+      color: $text-secondary;
+      border: 1px solid transparent;
+      font-size: $font-caption;
+      font-weight: 600;
       background: transparent;
-      padding: 5px 10px;
+      min-width: 36px;
+      height: 36px;
+      padding: 0 $space-3;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: $space-2;
       list-style-type: none;
       text-align: center;
-      border-radius: 4px;
+      border-radius: $radius-md;
       cursor: pointer;
-      transition: all 0.15s ease;
+      transition:
+        background-color $duration-fast $ease-standard,
+        color $duration-fast $ease-standard,
+        border-color $duration-fast $ease-standard;
 
-      svg {
-        padding: 0px 10px;
-      }
+      svg { padding: 0; }
 
       &.gone {
-        color: $homepage-pagination;
+        color: $neutral-300;
         cursor: default !important;
       }
 
-      &:not(.active):not(:disabled):hover {
-        opacity: 80%;
+      &:not(.active):not(.gone):hover {
+        background: $neutral-50;
+        color: $text-primary;
         cursor: pointer;
       }
 
       &.active {
-        background: $box-background;
-        color: $homepage-light-blue;
-        font-weight: 600;
+        background: $brand-600;
+        color: $text-inverse;
+        border-color: $brand-600;
       }
     }
   }

--- a/src/app/cube/details/_global-details.scss
+++ b/src/app/cube/details/_global-details.scss
@@ -11,16 +11,20 @@
 }
 
 h1 {
-  color: $darker-grey;
-  font-size: $largest;
-  font-weight: 600;
-  margin: 0;
+  color: $text-primary;
+  font-size: $font-h1;
+  font-weight: 700;
+  line-height: $line-height-tight;
+  letter-spacing: $letter-spacing-tight;
+  margin: 0 0 $space-3;
 }
 
 h2 {
-  font-size: $larger;
-  font-weight: 600;
-  color: $darker-grey;
+  font-size: $font-h2;
+  font-weight: 700;
+  color: $text-primary;
+  letter-spacing: $letter-spacing-tight;
+  line-height: $line-height-tight;
   margin: 0;
 }
 

--- a/src/app/cube/details/details.component.scss
+++ b/src/app/cube/details/details.component.scss
@@ -2,24 +2,28 @@
 @import './global-details';
 
 .details-background {
-  background-color: white;
+  background: linear-gradient(180deg, $brand-50 0%, $surface-page 280px);
   min-height: 100vh;
 }
 
 .details {
-  background: white;
+  background: transparent;
   max-width: $max-width;
   margin: auto;
-  padding-left: 20px;
+  padding-left: $space-5;
   position: relative;
 }
 
 .section-title {
-  margin-bottom: 20px;
+  margin-bottom: $space-5;
+  font-size: $font-h2;
+  font-weight: 700;
+  color: $text-primary;
+  letter-spacing: $letter-spacing-tight;
 }
 
 .section {
-  padding-top: 30px;
+  padding-top: $space-8;
 }
 .details__content-container {
   display: flex;
@@ -79,13 +83,17 @@
 
 .details__content-relevancy__banner {
   z-index: 5;
-  background-color: $light-blue;
-  color: white;
-  padding: 10px;
+  background: linear-gradient(90deg, $brand-700, $brand-500);
+  color: $text-inverse;
+  padding: $space-3 $space-4;
   text-align: center;
+  font-weight: 600;
+  border-radius: $radius-md;
+  box-shadow: $shadow-md;
+  margin-bottom: $space-5;
 
   a {
-    color: white;
+    color: $text-inverse;
     text-decoration: underline;
   }
 }
@@ -133,32 +141,40 @@
 }
 
 .inner {
-  background: white;
-  border-radius: 2px;
-  box-shadow: 0 0 12px 1px rgba(0, 0, 0, 0.03);
-  padding: 20px;
-  margin-bottom: 15px;
+  background: $surface-raised;
+  border-radius: $radius-lg;
+  border: 1px solid $surface-border;
+  box-shadow: $shadow-sm;
+  padding: $space-6;
+  margin-bottom: $space-4;
 
   .no-revisions {
-    font-size: $normal;
-    color: $dark-grey;
-    padding-right: 10px;
+    font-size: $font-body;
+    color: $text-secondary;
+    padding-right: $space-2;
     text-align: center;
     display: inline-block;
   }
 }
+
 .text {
-  font-size: $normal;
-  color: $dark-grey;
-  padding-right: 10px;
-  padding-left: 50px;
+  font-size: $font-body;
+  color: $text-secondary;
+  padding-right: $space-2;
+  padding-left: $space-9;
   display: inline-block;
+  line-height: $line-height-relaxed;
 }
 
 .relevancy__notice {
-  color: $dark-grey;
-  padding: 10px;
+  color: $text-secondary;
+  padding: $space-3;
   text-align: center;
+  font-size: $font-caption;
+}
+
+.details-loading {
+  .svg-inline--fa { color: $brand-600; }
 }
 
 @media only screen and (max-width: 1400px) {

--- a/src/app/cube/home/help/components/help-card/help-card.component.html
+++ b/src/app/cube/home/help/components/help-card/help-card.component.html
@@ -1,4 +1,4 @@
-<div class="helpCard" [routerLink]="option.link">
+<div class="helpCard" [routerLink]="option.link" tabindex="0" role="link" [attr.aria-label]="option.title">
     <div class="content">
         <span [ngClass]="option.iconColor">
             <i [ngClass]="option.icon"></i>

--- a/src/app/cube/home/help/components/help-card/help-card.component.scss
+++ b/src/app/cube/home/help/components/help-card/help-card.component.scss
@@ -1,32 +1,52 @@
 @import '_vars.scss';
 
 .helpCard {
-    background-color: $primary-white;
-    border: 1px solid $secondary-white;
-    border-radius: 6px;
+    background-color: $neutral-0;
+    border: 1px solid $surface-border;
+    border-radius: $radius-lg;
     text-align: center;
-    padding: 35px 35px;
+    padding: $space-7 $space-6;
     height: 100%;
     box-sizing: border-box;
-    transition: all 0.25s ease;
+    cursor: pointer;
+    transition:
+        transform $duration-base $ease-standard,
+        box-shadow $duration-base $ease-standard,
+        border-color $duration-base $ease-standard;
 
     &:hover {
-        transform: scale(1.02);
-        box-shadow: 0 4px 22px 0 rgba(0, 0, 0, 0.1);
+        transform: translateY(-4px);
+        box-shadow: $shadow-lg;
+        border-color: $brand-200;
+    }
+
+    &:focus-visible {
+        outline: none;
+        border-color: $brand-500;
+        box-shadow: $shadow-md, $shadow-ring;
+        transform: translateY(-2px);
     }
 
     &:active {
-        transition-duration: 0.1s;
+        transform: translateY(-1px);
+        transition-duration: $duration-fast;
     }
 
     .content {
         h2 {
             padding: 0;
-            margin: 0;
+            margin: 0 0 $space-3;
+            font-size: $font-h3;
+            font-weight: 600;
+            color: $text-primary;
+            letter-spacing: $letter-spacing-tight;
         }
 
         p {
-            color: $homepage-text;
+            color: $text-secondary;
+            font-size: $font-body;
+            line-height: $line-height-relaxed;
+            margin: 0 0 $space-5;
         }
 
         span {
@@ -34,11 +54,11 @@
             flex-direction: row;
             justify-content: center;
             align-items: center;
-            margin: 0 auto 20px auto;
-            width: 70px;
-            height: 70px;
-            border-radius: 100px;
-            font-size: $larger;
+            margin: 0 auto $space-5;
+            width: 64px;
+            height: 64px;
+            border-radius: $radius-lg;
+            font-size: 1.5rem;
 
             &.orange {
                 color: $homepage-orange;
@@ -51,14 +71,27 @@
             }
 
             &.green {
-                color: $homepage-green;
-                background: $homepage-green-background;
+                color: $success-500;
+                background: $success-50;
             }
         }
 
         .link {
-            color: $homepage-light-blue;
+            display: inline-flex;
+            align-items: center;
+            gap: $space-2;
+            color: $brand-600;
+            font-weight: 600;
+            font-size: $font-caption;
+            text-transform: uppercase;
+            letter-spacing: $letter-spacing-wide;
+            transition: gap $duration-fast $ease-standard, color $duration-fast $ease-standard;
+
+            &:hover {
+                color: $brand-700;
+                gap: $space-3;
+                text-decoration: none;
+            }
         }
     }
-
 }

--- a/src/app/cube/home/learning-object-info/learning-objects/learning-objects.component.scss
+++ b/src/app/cube/home/learning-object-info/learning-objects/learning-objects.component.scss
@@ -1,58 +1,78 @@
 @import '_vars.scss';
 
 p {
-    color: $homepage-text;
+    color: $text-secondary;
+    line-height: $line-height-relaxed;
 }
 
 .wrapper {
     display: flex;
     flex-direction: column;
-    margin-right: 50px;
-    margin-bottom: 400px;
+    margin-right: $space-7;
+    margin-bottom: $space-12;
 
     .learning-object-info {
-        padding-bottom: 60px;
-        border-bottom: 1px solid $secondary-white;
+        padding-bottom: $space-8;
+        border-bottom: 1px solid $surface-divider;
 
         h1 {
             margin-top: 0;
+            font-size: $font-h1;
+            font-weight: 700;
+            color: $text-primary;
+            letter-spacing: $letter-spacing-tight;
+            line-height: $line-height-tight;
         }
     }
 
     .featured-object {
-        margin-top: 50px;
-        border: 1px solid $secondary-white;
-        box-shadow: 0px 10px 20px -10px rgba(0, 0, 0, 0.1);
-        border-radius: 4px;
+        margin-top: $space-7;
+        border: 1px solid $surface-border;
+        box-shadow: $shadow-md;
+        border-radius: $radius-lg;
+        overflow: hidden;
+        background: $surface-raised;
+        transition: transform $duration-base $ease-standard, box-shadow $duration-base $ease-standard;
+
+        &:hover {
+            transform: translateY(-2px);
+            box-shadow: $shadow-lg;
+        }
 
         .featured-text {
-            margin-left: 17px;
-            margin-right: 13px;
-            line-height: 2;
+            margin: $space-3 $space-4;
+            line-height: $line-height-relaxed;
 
             .levels {
-                color: $homepage-light-blue;
+                color: $brand-600;
+                font-size: $font-caption;
+                font-weight: 600;
+                text-transform: uppercase;
+                letter-spacing: $letter-spacing-wide;
                 margin-bottom: 0;
             }
 
             h3 {
-                margin-top: 12px;
-                font-size: 1.5em;
+                margin-top: $space-2;
+                font-size: $font-h3;
+                font-weight: 700;
+                letter-spacing: $letter-spacing-tight;
+                color: $text-primary;
 
                 a:not(:hover) {
-                    color: black;
+                    color: $text-primary;
                 }
             }
 
             p.outcomeText {
-                margin: 24px 0 0;
-                color: black;
+                margin: $space-5 0 0;
+                color: $text-primary;
             }
 
             ul {
-                margin-top: 12px;
-                padding-inline-start: 20px;
-
+                margin-top: $space-2;
+                padding-inline-start: $space-5;
+                color: $text-secondary;
             }
         }
 
@@ -60,37 +80,38 @@ p {
             display: flex;
             flex-direction: row;
             justify-content: space-evenly;
-            background-color: $primary-white;
-            padding: 30px 22px;
-            border-top: 1px solid $secondary-white;
+            background-color: $surface-sunken;
+            padding: $space-5 $space-4;
+            border-top: 1px solid $surface-divider;
 
             .contributor-card {
                 display: flex;
                 flex-direction: row;
             }
-
         }
-
     }
 
     .learning-object-button {
-        padding: 16px 27px;
-        margin-top: 70px;
-        background-color: $homepage-light-blue;
-        color: white;
+        padding: 14px 24px;
+        margin-top: $space-8;
+        background: $brand-600;
+        color: $text-inverse;
+        font-weight: 600;
+        font-size: $font-body;
         border: none;
-        border-radius: 4px;
+        border-radius: $radius-pill;
         cursor: pointer;
-        box-shadow: 0px 6px 12px -6px $homepage-light-blue;
+        box-shadow: $shadow-md, 0 8px 20px -8px rgba(47, 110, 224, 0.5);
         width: fit-content;
+        transition: background-color $duration-fast $ease-standard, transform $duration-fast $ease-standard, box-shadow $duration-base $ease-standard;
 
         &:hover {
-            opacity: 80%;
+            background: $brand-700;
+            transform: translateY(-1px);
+            box-shadow: $shadow-lg, 0 12px 28px -10px rgba(47, 110, 224, 0.55);
         }
 
-        &:active {
-            opacity: 100%;
-        }
+        &:active { transform: translateY(0); }
     }
 }
 

--- a/src/app/cube/home/mission/mission.component.scss
+++ b/src/app/cube/home/mission/mission.component.scss
@@ -3,78 +3,93 @@
 .wrapper {
     display: flex;
     flex-direction: column;
-    padding: 10px 60px;
+    padding: $space-10 $space-6;
+    max-width: $max-width;
+    margin: 0 auto;
 
     .first {
         display: flex;
         flex-direction: column;
         align-items: center;
         text-align: center;
-        padding: 0px 240px 100px;
+        padding: 0 0 $space-10;
+        max-width: 720px;
+        margin: 0 auto;
 
-        h1{
-            padding-bottom: 35px;
+        h1 {
+            padding-bottom: $space-5;
+            font-size: $font-h1;
+            font-weight: 700;
+            letter-spacing: $letter-spacing-tight;
+            color: $text-primary;
+            margin: 0;
         }
     }
 
     .second {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-around;
-        margin-left: 50px;
-        padding-bottom: 250px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: $space-7;
+        margin: 0;
+        padding-bottom: $space-12;
 
         .clark-quality {
-            margin-right: 50px;
-            width: 30%;
+            margin: 0;
+            width: 100%;
+            text-align: center;
+            padding: $space-6;
+            background: $surface-raised;
+            border: 1px solid $surface-border;
+            border-radius: $radius-lg;
+            box-shadow: $shadow-sm;
+            transition: transform $duration-base $ease-standard, box-shadow $duration-base $ease-standard;
+
+            &:hover {
+                transform: translateY(-2px);
+                box-shadow: $shadow-md;
+            }
 
             h2 {
-                margin: 10px 0 auto;
+                margin: $space-3 0 $space-2;
+                font-size: $font-h3;
+                font-weight: 700;
+                color: $text-primary;
+                letter-spacing: $letter-spacing-tight;
             }
+
             span {
                 position: relative;
-                left: -10px;
-                .fa-stack-2x {
-                    color: $box-background;
-                }
-    
-                .fa-stack-1x {
-                    color: $homepage-light-blue;
-                }
+                left: 0;
+
+                .fa-stack-2x { color: $brand-50; }
+                .fa-stack-1x { color: $brand-600; }
             }
-            
         }
     }
 }
 
 p {
     font-weight: 400;
-    font-size: 18px;
-    color: #454545; 
+    font-size: $font-body-lg;
+    line-height: $line-height-relaxed;
+    color: $text-secondary;
 }
 
-@media screen and (max-width: 950px) {
-    .wrapper{
-        padding: 10px 30px;
-        .first {
-            padding: 0px 0px 60px;
-        }
+@media screen and (max-width: $bp-tablet) {
+    .wrapper {
+        padding: $space-8 $space-4;
+
+        .first { padding: 0 0 $space-7; }
+
         .second {
-            flex-direction: column;
-            align-items: center;
-            margin-left: 0;
+            grid-template-columns: 1fr;
+            gap: $space-5;
+            padding-bottom: $space-10;
 
             .clark-quality {
-                margin: 0px 0px 60px;
-                text-align: center;
-                width: 75%;
-                max-width: 360px;
-
-                span {
-                    left: 0px;
-                }
+                max-width: 480px;
+                margin: 0 auto;
             }
         }
     }
-    
 }

--- a/src/app/cube/home/splash/splash.component.html
+++ b/src/app/cube/home/splash/splash.component.html
@@ -1,25 +1,54 @@
-<div class="wrapper">
-    <div class="first">
-        <h1>
-            Teach Cyber Today... <br />
-            Secure Tomorrow
-        </h1>
-        <p>
-            CLARK is the largest platform that provides <strong>FREE</strong> cybersecurity curriculum. It is home to high-value, high-impact 
-            cyber curriculum created by top educators and reviewed for relevance and quality. Whether you’re looking to teach something new tomorrow, 
-            align with curriculum guidelines and standards, or refine your current course, CLARK has free resources ready for you to use!
-        </p>
-        <button id="pageContent" (click)="this.googleTagService.triggerGoogleTagEvent('browse_learning_objects', 'homepageRedirect', 'splashBrowse')" [routerLink]="'/browse'">BROWSE {{ numReleasedObjects | number }}+ LEARNING OBJECTS</button>
-        <button id="pageContent" class="card" [tip]="'You will be redirected to the CAE Resource Directory'" (click)="utilityService.openCard()">BROWSE {{ resourceCount | number }}+ RESOURCES</button>
+<section class="hero">
+    <div class="hero__inner">
+        <div class="hero__copy">
+            <span class="hero__kicker">Free cybersecurity curriculum</span>
+            <h1 class="hero__title">
+                Teach Cyber Today.<br />
+                <span class="hero__title-accent">Secure Tomorrow.</span>
+            </h1>
+            <p class="hero__lede">
+                CLARK is the largest platform of <strong>free</strong> cybersecurity curriculum &mdash;
+                high-value content created by top educators and reviewed for relevance and quality.
+                Find resources to teach tomorrow, align with standards, or refine your current course.
+            </p>
+
+            <div class="hero__ctas">
+                <button
+                    id="pageContent"
+                    class="hero__cta hero__cta--primary"
+                    (click)="this.googleTagService.triggerGoogleTagEvent('browse_learning_objects', 'homepageRedirect', 'splashBrowse')"
+                    [routerLink]="'/browse'">
+                    Browse {{ numReleasedObjects | number }}+ learning objects
+                    <i class="fas fa-arrow-right" aria-hidden="true"></i>
+                </button>
+
+                <button
+                    id="pageContentResources"
+                    class="hero__cta hero__cta--ghost"
+                    [tip]="'You will be redirected to the CAE Resource Directory'"
+                    (click)="utilityService.openCard()">
+                    Browse {{ resourceCount | number }}+ resources
+                    <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                </button>
+            </div>
+
+            <ul class="hero__signals" aria-label="Platform highlights">
+                <li><i class="fas fa-check-circle" aria-hidden="true"></i> Peer-reviewed content</li>
+                <li><i class="fas fa-check-circle" aria-hidden="true"></i> Aligned to standards</li>
+                <li><i class="fas fa-check-circle" aria-hidden="true"></i> Always free</li>
+            </ul>
+        </div>
+
+        <div class="hero__media">
+            <div class="hero__video">
+                <iframe
+                    src="https://www.youtube.com/embed/wXlZZjq0lDo"
+                    title="What is CLARK?"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen>
+                </iframe>
+            </div>
+        </div>
     </div>
-    <div class="second">
-        <iframe 
-        src="https://www.youtube.com/embed/wXlZZjq0lDo" 
-        title="What is CLARK?" 
-        frameborder="0" 
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
-        allowfullscreen
-        >
-        </iframe>
-    </div>
-</div>
+</section>

--- a/src/app/cube/home/splash/splash.component.scss
+++ b/src/app/cube/home/splash/splash.component.scss
@@ -1,118 +1,203 @@
 @import '_vars.scss';
 
-.wrapper {
-    display: flex;
-    flex-direction: row;
-    padding: 85px;
-    background: linear-gradient(0deg, $primary-white 0%, rgba(255, 255, 255, 0) 100%);
-    border: 1px solid $secondary-white;
-    border-top: none;
+.hero {
+    position: relative;
+    background:
+        radial-gradient(1200px 600px at 85% -10%, rgba(47, 110, 224, 0.12), transparent 60%),
+        radial-gradient(900px 500px at 10% 110%, rgba(189, 0, 255, 0.06), transparent 60%),
+        linear-gradient(180deg, $brand-50 0%, $neutral-0 70%);
+    overflow: hidden;
+    border-bottom: 1px solid $surface-divider;
 
-    //remove after 5th birthday
-    padding-top: 135px;
-    //remove after 5th birthday
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background-image: $cube-pattern;
+        background-size: 56px 100px;
+        opacity: 0.04;
+        pointer-events: none;
+        mix-blend-mode: multiply;
+    }
 
-    .first {
-        h1 {
-            font-size: 40px;
-            margin-top: 0;
-        }
+    &__inner {
+        position: relative;
+        max-width: $max-width;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: 1.05fr 1fr;
+        gap: $space-10;
+        align-items: center;
+        padding: $space-12 $space-10;
+    }
 
-        p {
-            width: 80%;
-            font-size: 16px;
-            color: $homepage-text;
-        }
+    &__copy {
+        max-width: 60ch;
+    }
 
-        button {
-            padding: 16px 27px;
-            margin-top: 40px;
-            background-color: $homepage-light-blue;
-            color: white;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-            box-shadow: 0px 6px 12px -6px $homepage-light-blue;
-        }
+    &__kicker {
+        display: inline-block;
+        font-size: $font-caption;
+        font-weight: 600;
+        letter-spacing: $letter-spacing-wide;
+        text-transform: uppercase;
+        color: $brand-700;
+        background: $brand-100;
+        padding: 6px 12px;
+        border-radius: $radius-pill;
+        margin-bottom: $space-5;
+    }
 
-        .card {
-            margin: 20px 0 0 15px;
-            background-color: $card-primary;
-        }
+    &__title {
+        font-size: $font-display;
+        line-height: $line-height-tight;
+        letter-spacing: $letter-spacing-tight;
+        font-weight: 700;
+        color: $text-primary;
+        margin: 0 0 $space-5;
 
-        button:hover {
-            opacity: 80%;
-        }
-
-        button:active {
-            opacity: 100%;
+        &-accent {
+            background: linear-gradient(90deg, $brand-600 0%, #6f3ce0 100%);
+            -webkit-background-clip: text;
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
         }
     }
 
-    .second {
+    &__lede {
+        font-size: $font-body-lg;
+        line-height: $line-height-relaxed;
+        color: $text-secondary;
+        margin: 0 0 $space-7;
+    }
+
+    &__ctas {
         display: flex;
+        flex-wrap: wrap;
+        gap: $space-3;
+        margin-bottom: $space-6;
+    }
+
+    &__cta {
+        display: inline-flex;
         align-items: center;
-        iframe {
-            width: 560px;
-            height: 315px; 
-            box-shadow: 0px 10px 20px -10px rgba(0, 0, 0, 0.5);
-            border-radius: 6px;
+        gap: $space-2;
+        padding: 14px 24px;
+        font-size: $font-body;
+        font-weight: 600;
+        border-radius: $radius-pill;
+        border: 0;
+        cursor: pointer;
+        transition:
+            transform $duration-fast $ease-standard,
+            box-shadow $duration-base $ease-standard,
+            background-color $duration-fast $ease-standard;
+
+        i { font-size: 0.85em; }
+
+        &--primary {
+            background: $brand-600;
+            color: $text-inverse;
+            box-shadow: $shadow-md, 0 8px 20px -8px rgba(47, 110, 224, 0.55);
+
+            &:hover {
+                background: $brand-700;
+                transform: translateY(-1px);
+                box-shadow: $shadow-lg, 0 12px 28px -10px rgba(47, 110, 224, 0.6);
+            }
+        }
+
+        &--ghost {
+            background: $neutral-0;
+            color: $brand-700;
+            box-shadow: inset 0 0 0 1px $surface-border, $shadow-sm;
+
+            &:hover {
+                background: $brand-50;
+                box-shadow: inset 0 0 0 1px $brand-200, $shadow-md;
+                transform: translateY(-1px);
+            }
         }
     }
-}
 
-
-@media screen and (max-width: 1150px) {
-    .wrapper {
+    &__signals {
+        list-style: none;
+        padding: 0;
+        margin: 0;
         display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        text-align: center;
+        flex-wrap: wrap;
+        gap: $space-5;
+        font-size: $font-caption;
+        color: $text-muted;
 
-        .first {
-            display: flex;
-            flex-direction: column;
+        li {
+            display: inline-flex;
             align-items: center;
-            margin-bottom: 30px;
+            gap: $space-2;
         }
 
-        .second {
-            iframe {
-                width: 500px;
-                height: 280px;
-                margin-top: 80px;
-            }
+        i { color: $success-500; }
+    }
+
+    &__media {
+        display: flex;
+        justify-content: center;
+    }
+
+    &__video {
+        position: relative;
+        width: 100%;
+        max-width: 600px;
+        aspect-ratio: 16 / 9;
+        border-radius: $radius-lg;
+        overflow: hidden;
+        box-shadow: $shadow-lg;
+        background: $neutral-100;
+
+        iframe {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
         }
     }
 }
 
-@media (max-width: 600px) {
-    .wrapper {
-        .second {
-            iframe {
-                width: 325px;
-                height: 180px;
-            }
+@media (max-width: $bp-tablet) {
+    .hero {
+        &__inner {
+            grid-template-columns: 1fr;
+            gap: $space-8;
+            padding: $space-10 $space-6;
         }
+
+        &__copy { max-width: none; }
     }
 }
 
-@media (max-width: 320px) {
-    .wrapper {
-        .first {
-            h1 {
-                font-size: 30px;
-            }
-            button {
-                padding: 10px;
-            }
+@media (max-width: $bp-mobile) {
+    .hero {
+        &__inner {
+            padding: $space-8 $space-4;
         }
-        .second {
-            iframe {
-                width: 250px;
-                height: 140px;
-            }
+
+        &__title {
+            font-size: 2.25rem;
+        }
+
+        &__lede {
+            font-size: $font-body;
+        }
+
+        &__cta {
+            width: 100%;
+            justify-content: center;
+        }
+
+        &__signals {
+            gap: $space-3;
+            font-size: $font-micro;
         }
     }
 }

--- a/src/globals.scss
+++ b/src/globals.scss
@@ -13,12 +13,22 @@
 body {
   font-family: 'Source Sans Pro', sans-serif;
   background: $wrapper-background !important;
-  // height: 100vh;
+  color: $text-primary;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   margin: 0;
   padding: 0;
 
-  &.hide-outlines * {
-    outline: 0 !important;
+  // Hide focus rings for mouse interactions only; keyboard users still see them.
+  // Replaces the legacy `body.hide-outlines * { outline: 0 !important }` hack.
+  :focus:not(:focus-visible) {
+    outline: 0;
+  }
+
+  :focus-visible {
+    outline: 2px solid $brand-500;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   &.no-scroll {
@@ -28,11 +38,25 @@ body {
 
 a,
 a:visited {
-  color: $light-blue;
+  color: $brand-600;
   text-decoration: none;
+  text-underline-offset: 3px;
+  transition: color $duration-fast $ease-standard;
 
   &:hover {
+    color: $brand-700;
     text-decoration: underline;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }
 
@@ -42,77 +66,129 @@ a:visited {
 }
 
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $space-2;
   border: 0;
-  padding: 11px 20px 11px 25px;
-  border-radius: 4px;
-  background: white;
-  color: $light-blue;
+  padding: 10px 18px;
+  border-radius: $radius-md;
+  background: $neutral-0;
+  color: $brand-600;
   text-transform: uppercase;
-  font-size: $small;
+  letter-spacing: $letter-spacing-wide;
+  font-size: $font-caption;
+  font-weight: 600;
+  line-height: 1.2;
   cursor: pointer;
-  transition: opacity 0.2s ease;
   position: relative;
-  font-weight: normal;
+  box-shadow: $shadow-sm;
+  transition:
+    transform $duration-fast $ease-standard,
+    box-shadow $duration-base $ease-standard,
+    background-color $duration-fast $ease-standard,
+    color $duration-fast $ease-standard;
 
   &.shadow {
-    box-shadow: inset 0 1px 2px 1px rgba(0, 0, 0, 0.1);
+    box-shadow: $shadow-md;
   }
 
   .svg-inline--fa,
   .icon {
-    margin-left: 10px;
+    margin-left: 0;
   }
 
   &.icon-only {
-    padding: 4px 9px;
-
-    .svg-inline--fa,
-    .icon {
-      margin-left: 0;
-    }
-    margin: 0px 5px 10px;
+    padding: 8px 10px;
+    gap: 0;
+    margin: 0;
   }
 
+  // Primary action
   &.good {
-    color: white;
-    background: $light-blue-gradient;
-  }
+    color: $text-inverse;
+    background: $brand-600;
+    box-shadow: $shadow-sm;
 
-  &.neutral {
-    color: $dark-grey;
-    background: transparent;
-
-    &:after {
-      content: '';
-      background: transparent;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      border: 1px solid $dark-grey;
-      border-radius: inherit;
-      position: absolute;
+    &:hover:not([disabled]):not(.disabled) {
+      background: $brand-700;
+      box-shadow: $shadow-md;
+      transform: translateY(-1px);
     }
   }
 
+  // Neutral / secondary
+  &.neutral {
+    color: $text-secondary;
+    background: $neutral-0;
+    box-shadow: inset 0 0 0 1px $surface-border;
+
+    &:hover:not([disabled]):not(.disabled) {
+      background: $neutral-50;
+      color: $text-primary;
+      box-shadow: inset 0 0 0 1px $neutral-300;
+    }
+
+    // Legacy positioning hook some templates rely on
+    &:after {
+      content: none;
+    }
+  }
+
+  // Destructive
   &.bad {
-    color: white;
-    background: $error-red;
+    color: $text-inverse;
+    background: $danger-500;
+
+    &:hover:not([disabled]):not(.disabled) {
+      background: darken($danger-500, 6%);
+      box-shadow: $shadow-md;
+      transform: translateY(-1px);
+    }
 
     &.inverted {
-      color: $error-red;
+      color: $danger-500;
       background: transparent;
+      box-shadow: inset 0 0 0 1px $danger-500;
     }
 
     &.white {
-      background: white;
-      color: $error-red;
+      background: $neutral-0;
+      color: $danger-500;
     }
   }
 
+  // Success
   &.green {
-    color: white;
-    background: $success-green;
+    color: $text-inverse;
+    background: $success-500;
+
+    &:hover:not([disabled]):not(.disabled) {
+      background: darken($success-500, 5%);
+      box-shadow: $shadow-md;
+      transform: translateY(-1px);
+    }
+  }
+
+  // Modern variants (opt-in)
+  &.button--ghost {
+    background: transparent;
+    color: $brand-600;
+    box-shadow: none;
+
+    &:hover:not([disabled]):not(.disabled) {
+      background: $brand-50;
+    }
+  }
+
+  &.button--pill {
+    border-radius: $radius-pill;
+    padding: 12px 24px;
+  }
+
+  &.button--lg {
+    padding: 14px 24px;
+    font-size: $font-body;
   }
 
   &.disabled,
@@ -121,10 +197,16 @@ a:visited {
     box-shadow: none;
     cursor: default;
     pointer-events: none;
+    transform: none;
   }
 
   &:hover {
-    opacity: 0.8;
+    // Default fallback hover for the bare white variant
+    background: $neutral-50;
+  }
+
+  &:active:not([disabled]):not(.disabled) {
+    transform: translateY(0);
   }
 }
 
@@ -175,9 +257,9 @@ a:visited {
 .popup {
   position: fixed;
   z-index: $popup-z;
-  background: white;
-  border-radius: 1px;
-  box-shadow: 0 0 12px 2px rgba(0, 0, 0, 0.05);
+  background: $neutral-0;
+  border-radius: $radius-md;
+  box-shadow: $shadow-lg;
 
   ul {
     margin: 0;
@@ -265,8 +347,8 @@ a:visited {
   &.dialog {
     max-width: 500px;
     min-width: 300px;
-    padding: 20px 40px;
-    border-radius: 4px;
+    padding: $space-6 $space-8;
+    border-radius: $radius-lg;
     margin: auto;
     left: 0;
     right: 0;


### PR DESCRIPTION
Adds a token layer (color ramps, spacing, radii, shadows, rem type scale, motion, breakpoints) to _vars.scss while preserving legacy variables for back-compat, then migrates the highest-visibility pages onto it.

Highlights:
- globals: replace `outline: 0 !important` a11y bug with :focus-visible rings + prefers-reduced-motion; rewrite .button with flat fills, hover lift, ghost/pill variants; polish .popup/.dialog
- primary + secondary navbar: lower visual weight, focus-visible on every interactive, softer slideout underlay
- home splash: rewrite hero with kicker, gradient display heading, pill CTAs, trust signals, aspect-ratio video, brand-textured background; drop the "remove after 5th birthday" hack and fix the duplicated id="pageContent"
- home mission / learning-objects / help-card: token migration so the rest of the homepage matches; help cards are now keyboard-focusable
- browse: modernized filter bar, real empty state with icon and clear-filters action, pill pagination with active state
- details: brand-tinted page wash, card refresh, gradient banner, typographic hierarchy

No behavior, routing, or dependency changes. Production build is clean with no new SCSS or bundle-budget warnings.