### PR TITLE
Add pending learning object search results after applying filters

### DIFF
--- a/src/app/cube/browse/browse.component.html
+++ b/src/app/cube/browse/browse.component.html
@@ -170,7 +170,7 @@
           class="filter-footer-btn primary-btn"
         >
           <span class="button-text">Show Results</span>
-          <span class="result-count">({{ totalLearningObjects }})</span>
+          <span class="result-count">({{ totalLearningObjectsPreview }})</span>
         </button>
       </div>
     </div>

--- a/src/app/cube/browse/browse.component.ts
+++ b/src/app/cube/browse/browse.component.ts
@@ -29,6 +29,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
   copy = COPY;
   learningObjects: LearningObject[] = [];
   totalLearningObjects = 0;
+  totalLearningObjectsPreview = 0;
   outcomeSources: any[];
 
   query: Query = {
@@ -74,6 +75,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
   windowWidth: number;
 
   unsubscribe: Subject<void> = new Subject();
+  private totalLearningObjectsPreviewRequestId = 0;
 
   shouldResetPage = false;
 
@@ -329,9 +331,11 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
   /**
    * Handle backdrop click to close modal
+   * Applies pending modal filters first so clicking outside behaves like the Show Results button.
    */
   onBackdropClick(event: MouseEvent) {
     if (event.target === event.currentTarget) {
+      this.applyFilters();
       this.closeFilters();
     }
   }
@@ -382,6 +386,8 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
 
     if (!this.filtersDownMobile) {
       this.performSearch(true);
+    } else {
+      this.fetchTotalLearningObjectsPreview();
     }
   }
 
@@ -519,6 +525,7 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
   }
 
   async fetchLearningObjects(query: Query) {
+    this.totalLearningObjectsPreviewRequestId++;
     this.loading = true;
     this.learningObjects = [];
     // Trim leading and trailing whitespace
@@ -529,12 +536,65 @@ export class BrowseComponent implements AfterViewInit, OnDestroy {
         await this.searchLearningObjectService.getLearningObjects(this.removeObjFalsy(query));
       this.learningObjects = learningObjects;
       this.totalLearningObjects = total;
+      this.totalLearningObjectsPreview = total;
       this.pageCount = Math.ceil(total / +this.query.limit);
       this.loading = false;
       this.cd.detectChanges();
     } catch (e) {
       console.log(`Error: ${e}`);
     }
+  }
+
+  /**
+   * Fetches only the result count for the filters currently selected in the modal.
+   * This lets the modal preview the number of matching learning objects without
+   * navigating or replacing the result cards shown on the page.
+   */
+  private async fetchTotalLearningObjectsPreview() {
+    const requestId = ++this.totalLearningObjectsPreviewRequestId;
+    const previewQuery = {
+      ...this.getQueryWithPendingFilters(),
+      currPage: 1,
+      limit: 1,
+    };
+
+    previewQuery.text = previewQuery.text ? previewQuery.text.trim() : '';
+
+    try {
+      const { total } =
+        await this.searchLearningObjectService.getLearningObjects(this.removeObjFalsy(previewQuery));
+
+      if (requestId !== this.totalLearningObjectsPreviewRequestId) {
+        return;
+      }
+
+      this.totalLearningObjectsPreview = total;
+      this.cd.detectChanges();
+    } catch (e) {
+      console.log(`Error: ${e}`);
+    }
+  }
+
+  /**
+   * Builds a query from the applied route state plus any pending modal filter changes.
+   * Removed filter categories are deleted from the applied query so the preview count
+   * matches what would be sent if the user applied the current modal state.
+   */
+  private getQueryWithPendingFilters(): Query {
+    const pendingQuery = { ...this.query };
+
+    if (this.filters && Object.keys(this.filters).length > 0) {
+      (this.filters.removed as string[] || []).forEach(
+        (category) => delete pendingQuery[category],
+      );
+
+      const filters = { ...this.filters };
+      delete filters.removed;
+
+      return { ...pendingQuery, ...filters };
+    }
+
+    return pendingQuery;
   }
 
   /**


### PR DESCRIPTION
This pull request enhances the filter modal in the `BrowseComponent` by adding a live preview of the number of matching learning objects as users adjust filters, without affecting the main results until filters are applied. It introduces logic to fetch and display a preview count, ensures the preview is accurate even with rapid filter changes, and improves the user experience on mobile devices.

**Filter modal preview improvements:**

* Added a new property `totalLearningObjectsPreview` to track and display the preview count in the filter modal, updating the UI to use this value instead of the main `totalLearningObjects`. (`src/app/cube/browse/browse.component.html`, `src/app/cube/browse/browse.component.ts`) [[1]](diffhunk://#diff-5e1ee49375d2a00ac5ceb40b0e64ea1218f16ade2b95054dc0ecc560ac5f2b50L173-R173) [[2]](diffhunk://#diff-ba404bcd1e8d60d2636a9c2acec5401c9d2cd51abd37e89254b15e9fdaebcf81R32)
* Implemented the `fetchTotalLearningObjectsPreview` method to asynchronously fetch the count of matching objects based on pending filter changes, using a request ID to prevent race conditions. (`src/app/cube/browse/browse.component.ts`) [[1]](diffhunk://#diff-ba404bcd1e8d60d2636a9c2acec5401c9d2cd51abd37e89254b15e9fdaebcf81R548-R599) [[2]](diffhunk://#diff-ba404bcd1e8d60d2636a9c2acec5401c9d2cd51abd37e89254b15e9fdaebcf81R78)
* Added `getQueryWithPendingFilters` to build a query reflecting both applied and pending modal filter changes for accurate preview counts. (`src/app/cube/browse/browse.component.ts`)

**User experience improvements:**

* On mobile, the preview count is fetched when filters change, so users see updated results before applying filters. (`src/app/cube/browse/browse.component.ts`)
* Modified the backdrop click handler to apply pending filters before closing the modal, making its behavior consistent with the "Show Results" button. (`src/app/cube/browse/browse.component.ts`)

**Data consistency:**

* Updated the logic in `fetchLearningObjects` to keep `totalLearningObjectsPreview` in sync with the main result count when a new search is performed. (`src/app/cube/browse/browse.component.ts`) [[1]](diffhunk://#diff-ba404bcd1e8d60d2636a9c2acec5401c9d2cd51abd37e89254b15e9fdaebcf81R528) [[2]](diffhunk://#diff-ba404bcd1e8d60d2636a9c2acec5401c9d2cd51abd37e89254b15e9fdaebcf81R539)



https://github.com/user-attachments/assets/aa4bd48e-aabe-47c1-8164-4f183e832e91



