### PR TITLE
feature/sc-38831/remove-legacy-organization-field-from-clark

### DIFF
--- a/src/app/cube/user-profile/components/edit-profile/edit-profile.component.ts
+++ b/src/app/cube/user-profile/components/edit-profile/edit-profile.component.ts
@@ -135,7 +135,6 @@ export class EditProfileComponent implements OnChanges, OnInit, OnDestroy {
       username: this.user.username,
       name: this.userService.combineName(this.editInfo.firstname, this.editInfo.lastname, true),
       email: this.editInfo.email.trim(),
-      organization: this.editInfo.organization.trim(),
       organizationId: this.selectedOrg,
       bio: this.editInfo.bio.trim(),
     };
@@ -159,11 +158,6 @@ export class EditProfileComponent implements OnChanges, OnInit, OnDestroy {
       changedFields.email = edits.email;
     }
     if (edits.organizationId !== this.user.organizationId) {
-      // Current backend validator still expects legacy `organization` field
-      // in update payload checks, so send both during transition.
-      // TODO(clark-api): Remove legacy `organization` from user update payload once backend
-      // accepts `organizationId` as a valid update field for profile edits.
-      changedFields.organization = edits.organization;
       changedFields.organizationId = edits.organizationId;
     }
     if (edits.bio !== this.user.bio) {

--- a/src/entity/user/user.ts
+++ b/src/entity/user/user.ts
@@ -101,19 +101,6 @@ private _id: string;
     }
   }
 
-  /**
-   * TODO(SC-38733): Remove legacy organization string fallback once
-   * LearningObject author/contributors consistently provide organizationId.
-   */
-  _organization: string;
-  /**
-   * Legacy read-only fallback for older payloads that still send `organization`
-   * instead of `organizationId`.
-   */
-  get organization(): string {
-    return this._organization;
-  }
-
   _bio: string;
   /**
    * @property {string} bio a user's bio
@@ -151,7 +138,6 @@ private _id: string;
     this._email = user?.email || '';
     this._emailVerified = user?.emailVerified || false;
     this._organizationId = user?.organizationId || '';
-    this._organization = user?.organization || '';
     this._bio = user?.bio || '';
     this._createdAt = user?.createdAt || Date.now().toString();
   }


### PR DESCRIPTION
# Summary
This is the client PR for the organizations epic cleanup, getting rid of the now legacy implementation of holding the 'organization' string value directly on a user document. 

The only location where it still remained in the client code base was in the user profile's edit modal, organization was still being sent along with organizationId to keep things backwards compatible. It's now safe to remove and the code has been tested with the required clark-service changes, all works as it should. Those service changes are located at https://github.com/Cyber4All/clark-service/pull/507 and remove all the old logic from the api which is a lot more than here. The service changes handles the logic with changing authors on learning objects, searching learning objects, and a few other things. Client changes were a lot more simple.

The legacy organization field also used to be used in the client's registration flow but it was already removed in #2204 