### PR TITLE
Bug/sc 39680/clark client bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clark",
-      "version": "7.1.2",
+      "version": "7.1.3",
       "license": "MIT",
       "dependencies": {
         "@angular/animations": "^18.2.14",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clark",
   "displayName": "CLARK: Cybersecurity Labs and Resource Knowledge-base",
-  "version": "7.1.2",
+  "version": "7.1.3",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/app/admin/pages/organizations/organization-migrate-modal/organization-migrate-modal.component.spec.ts
+++ b/src/app/admin/pages/organizations/organization-migrate-modal/organization-migrate-modal.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { OrganizationService } from 'app/core/organization-module/organization.service';
+import { Organization } from 'app/core/organization-module/organization.types';
+
+import { OrganizationMigrateModalComponent } from './organization-migrate-modal.component';
+
+describe('OrganizationMigrateModalComponent', () => {
+  let component: OrganizationMigrateModalComponent;
+  let fixture: ComponentFixture<OrganizationMigrateModalComponent>;
+  let organizationService: ReturnType<typeof jasmine.createSpyObj<OrganizationService>>;
+
+  const buildOrganization = (overrides: Partial<Organization> = {}): Organization => ({
+    _id: 'org-1',
+    name: 'Towson University',
+    normalizedName: 'towson university',
+    sector: 'academia',
+    levels: ['undergraduate'],
+    domains: ['towson.edu'],
+    isVerified: true,
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    organizationService = jasmine.createSpyObj<OrganizationService>('OrganizationService', ['searchOrganizations']);
+
+    await TestBed.configureTestingModule({
+      imports: [OrganizationMigrateModalComponent],
+      providers: [
+        { provide: OrganizationService, useValue: organizationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrganizationMigrateModalComponent);
+    component = fixture.componentInstance;
+    component.isVisible = true;
+    component.sourceOrganization = buildOrganization({ _id: 'source-org', name: 'Source University' });
+    component.getUserCount = () => 0;
+  });
+
+  it('selects a target organization when a search result is clicked', () => {
+    const targetOrganization = buildOrganization({ _id: 'target-org', name: 'Target University' });
+    component.searchTerm = 'Target';
+    component.searchResults = [targetOrganization];
+    component.showDropdown = true;
+
+    fixture.detectChanges();
+
+    const result = fixture.debugElement.query(By.css('.org-item'));
+    result.triggerEventHandler('click', new MouseEvent('click'));
+    fixture.detectChanges();
+
+    expect(component.selectedTargetOrganization).toEqual(targetOrganization);
+    expect(component.targetOrgId).toBe(targetOrganization._id);
+    expect(component.searchTerm).toBe(targetOrganization.name);
+    expect(component.showDropdown).toBe(false);
+  });
+});

--- a/src/app/admin/pages/organizations/organization-migrate-modal/organization-migrate-modal.component.ts
+++ b/src/app/admin/pages/organizations/organization-migrate-modal/organization-migrate-modal.component.ts
@@ -13,6 +13,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { MatButton } from '@angular/material/button';
 import { Subject, of } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs/operators';
+import { ActivateDirective } from '../../../../shared/directives/activate.directive';
 
 @Component({
     selector: 'clark-organization-migrate-modal',
@@ -36,6 +37,7 @@ import { catchError, debounceTime, distinctUntilChanged, map, switchMap, takeUnt
         MatCheckbox,
         MatButton,
         TitleCasePipe,
+        ActivateDirective,
     ],
 })
 export class OrganizationMigrateModalComponent implements OnInit, OnChanges, OnDestroy {

--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -606,6 +606,13 @@ export class RegisterComponent implements OnInit, OnDestroy {
         return maybeError.message;
       }
 
+      if (Array.isArray(maybeError.message) && maybeError.message.length > 0) {
+        const firstMessage = maybeError.message[0]?.message || maybeError.message[0];
+        if (firstMessage) {
+          return firstMessage;
+        }
+      }
+
       if (Array.isArray(maybeError.errors) && maybeError.errors.length > 0) {
         const firstMessage = maybeError.errors.find(item => item?.message)?.message;
         if (firstMessage) {


### PR DESCRIPTION
# Description
Edits bring fixes to two small bugs on our client, one related to the registration page and the other related to the admin dashboard organizations tab.

## Registration Bug
Not too much of a bug but we were really just not parsing the error message properly on the client after getting it from the backend. It is kind of a confusing thing to do since I know the errors returned from the DTO are formatted weirdly, plus if an error comes from the component layer of our api that also changes the formatting of the returned error body. So I added in the `getErrorMessage()` function of the register component an if block to check if the error body is of the type returned form the DTO, and if so, parse it accordingly. If the condition is not met, it proceeds with the other formatting checks that are already in place.

## Organizations Dashboard
The migrate users from one organization to another modal was not letting the user select an organization from the search results as the target organization. This component was just missing an import.