### PR TITLE
Bug/sc 38715/error adding learning object to library popup

### DIFF
--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -150,7 +150,7 @@ export class LibraryService {
             )
             .pipe(
                 catchError((error) => {
-                    if (error.status === 409) {
+                    if (this.isAlreadySavedError(error)) {
                         return of(new HttpResponse({ status: 409 }));
                     }
                     return throwError(error);
@@ -277,6 +277,32 @@ export class LibraryService {
 
     private getLearningObjectKey(cuid: string, version: number): string {
         return `${cuid}:${version}`;
+    }
+
+    private isAlreadySavedError(error: HttpErrorResponse): boolean {
+        if (error.status === 409) {
+            return true;
+        }
+
+        const errorBody = error.error;
+        const errorText = [
+            error.message,
+            typeof errorBody === "string" ? errorBody : undefined,
+            errorBody?.message,
+            errorBody?.error,
+        ]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase();
+
+        return (
+            (errorText.includes("already") &&
+                (errorText.includes("library") ||
+                    errorText.includes("saved"))) ||
+            (errorText.includes("duplicate") &&
+                (errorText.includes("library") ||
+                    errorText.includes("learning")))
+        );
     }
 
     private handleError(error: HttpErrorResponse) {

--- a/src/app/core/library-module/library.service.ts
+++ b/src/app/core/library-module/library.service.ts
@@ -20,6 +20,11 @@ export interface LibraryItem {
     learningObject: LearningObject;
 }
 
+export interface AddToLibraryResult {
+    status: number;
+    alreadySaved: boolean;
+}
+
 @Injectable({
     providedIn: "root",
 })
@@ -27,6 +32,7 @@ export class LibraryService {
     private user;
     private headers = new HttpHeaders();
     public libraryItems: Array<LibraryItem> = [];
+    private savedLearningObjectKeys = new Set<string>();
 
     // Observable boolean to toggle download spinner in components
     private _loading$ = new BehaviorSubject<boolean>(false);
@@ -92,14 +98,25 @@ export class LibraryService {
                     const learningObject = new LearningObject(
                         libraryItem.learningObject,
                     );
-                    learningObject.id = libraryItem.learningObject?._id;
+                    if (!learningObject.id && libraryItem.learningObject?._id) {
+                        learningObject.id = libraryItem.learningObject._id;
+                    }
 
-                    return {
+                    const item = {
                         _id: libraryItem._id,
                         savedBy: libraryItem.savedBy,
                         savedOn: libraryItem.savedOn,
                         learningObject,
                     };
+
+                    this.savedLearningObjectKeys.add(
+                        this.getLearningObjectKey(
+                            learningObject.cuid,
+                            learningObject.version,
+                        ),
+                    );
+
+                    return item;
                 });
                 return {
                     libraryItems: this.libraryItems,
@@ -108,7 +125,11 @@ export class LibraryService {
             });
     }
 
-    async addToLibrary(cuid: string, version: number): Promise<any> {
+    async addToLibrary(
+        cuid: string,
+        version: number,
+    ): Promise<AddToLibraryResult> {
+        this.updateUser();
         if (!this.user) {
             return;
         }
@@ -121,31 +142,44 @@ export class LibraryService {
                     cuid,
                     version,
                 },
-                { headers: this.headers, withCredentials: true },
+                {
+                    headers: this.headers,
+                    observe: "response",
+                    withCredentials: true,
+                },
             )
             .pipe(
                 catchError((error) => {
-                    // Check if the error is a 409 conflict error
                     if (error.status === 409) {
-                        // Log the error or handle it as needed
-                        console.log(
-                            "Conflict error (409) occurred, but proceeding without throwing.",
-                        );
-                        // Return an observable that completes without emitting, effectively "skipping" the error
-                        return of(null);
+                        return of(new HttpResponse({ status: 409 }));
                     }
-                    // For other errors, re-throw them or handle them as needed
                     return throwError(error);
                 }),
             )
-            .toPromise();
+            .toPromise()
+            .then((response: HttpResponse<unknown>) => {
+                this.savedLearningObjectKeys.add(
+                    this.getLearningObjectKey(cuid, version),
+                );
+
+                return {
+                    status: response.status,
+                    alreadySaved: response.status === 409,
+                };
+            });
     }
 
     removeFromLibrary(libraryItemId: string): Promise<void> {
         if (!this.user) {
             return;
         }
-        this.http
+        const removedItem = this.libraryItems.find(
+            (item) =>
+                item._id === libraryItemId ||
+                item.learningObject.id === libraryItemId,
+        );
+
+        return this.http
             .delete(
                 LIBRARY_ROUTES.REMOVE_LEARNING_OBJECT_FROM_LIBRARY(
                     this.user.username,
@@ -154,7 +188,17 @@ export class LibraryService {
                 { headers: this.headers, withCredentials: true },
             )
             .pipe(catchError((error) => this.handleError(error)))
-            .toPromise();
+            .toPromise()
+            .then(() => {
+                if (removedItem) {
+                    this.savedLearningObjectKeys.delete(
+                        this.getLearningObjectKey(
+                            removedItem.learningObject.cuid,
+                            removedItem.learningObject.version,
+                        ),
+                    );
+                }
+            });
     }
 
     /**
@@ -205,13 +249,34 @@ export class LibraryService {
      * @param learningObjectId the learning object to check for in the library
      * @returns whether the learning object exists in the library
      */
-    has(learningObjectId: string): boolean {
+    has(learningObjectId: string, cuid?: string, version?: number): boolean {
+        if (
+            cuid &&
+            version != null &&
+            this.savedLearningObjectKeys.has(
+                this.getLearningObjectKey(cuid, version),
+            )
+        ) {
+            return true;
+        }
+
         return (
-            this.libraryItems.filter(
-                (libraryItem: LibraryItem) =>
-                    libraryItem.learningObject.id === learningObjectId,
-            ).length > 0
+            this.libraryItems.filter((libraryItem: LibraryItem) => {
+                const learningObject = libraryItem.learningObject;
+
+                return (
+                    learningObject.id === learningObjectId ||
+                    (cuid &&
+                        version != null &&
+                        learningObject.cuid === cuid &&
+                        learningObject.version === version)
+                );
+            }).length > 0
         );
+    }
+
+    private getLearningObjectKey(cuid: string, version: number): string {
+        return `${cuid}:${version}`;
     }
 
     private handleError(error: HttpErrorResponse) {

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -88,6 +88,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     contributorsList = [];
     error = false;
     userIsAuthor = false;
+    private addToLibraryPending = false;
 
     public tips = TOOLTIP_TEXT;
 
@@ -122,19 +123,19 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
 
         this.url = this.buildLocation();
         // FIXME: Fault where 'libraryService.libraryItems' is returned null when it is supposed to be initialized in clark.component
-        await this.libraryService.getLibrary({
-            learningObjectCuid: this.learningObject.cuid,
-            version: this.learningObject.version,
-        });
-        this.saved = this.libraryService.has(this.learningObject.id);
+        await this.refreshLibraryStatus();
         this.getCollection();
-        this.libraryService.loaded.subscribe((val) => {
-            this.downloading = val;
-            this.changeDetectorRef.markForCheck();
-        });
-        this.dropdowns.userDropdown.subscribe((val) => {
-            this.userDropdown = val;
-        });
+        this.libraryService.loaded
+            .pipe(takeUntil(this.destroyed$))
+            .subscribe((val) => {
+                this.downloading = val;
+                this.changeDetectorRef.markForCheck();
+            });
+        this.dropdowns.userDropdown
+            .pipe(takeUntil(this.destroyed$))
+            .subscribe((val) => {
+                this.userDropdown = val;
+            });
     }
 
     get isReleased(): boolean {
@@ -148,50 +149,96 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
     async addToLibrary(download?: boolean) {
         this.error = false;
 
+        const canSaveToLibrary =
+            !!this.auth.user && !this.userIsAuthor && this.isReleased;
+        const alreadySaved = this.isSavedToLibrary();
+        const shouldAddToLibrary = canSaveToLibrary && !alreadySaved;
+
+        if (this.addToLibraryPending) {
+            return;
+        }
+
+        if (
+            download &&
+            (!this.auth.user || !this.hasDownloadAccess || this.downloading)
+        ) {
+            return;
+        }
+
+        if (canSaveToLibrary) {
+            this.saved = alreadySaved;
+        }
+
+        if (shouldAddToLibrary) {
+            this.addToLibraryPending = true;
+        }
+
         if (!download) {
             // we don't want the add to library button spinner on the 'download' action
-            this.addingToLibrary = true;
+            this.addingToLibrary = shouldAddToLibrary;
         }
-        if (download) {
-            this.download(this.learningObject.id);
-        }
-        if (!this.userIsAuthor && this.isReleased) {
-            this.saved = this.libraryService.has(this.learningObject.id);
 
-            if (!this.saved) {
-                try {
-                    await this.libraryService.addToLibrary(
-                        this.learningObject.cuid,
-                        this.learningObject.version,
-                    );
+        let savedByThisAction = false;
+        try {
+            if (shouldAddToLibrary) {
+                const result = await this.libraryService.addToLibrary(
+                    this.learningObject.cuid,
+                    this.learningObject.version,
+                );
 
+                this.saved = true;
+                savedByThisAction = true;
+                if (!result?.alreadySaved) {
                     this.toaster.success(
                         "Successfully Added!",
                         "Learning Object added to your library",
                     );
-                    this.saved = true;
                     this.animateSaves();
-                } catch (err: any) {
-                    if (err.status !== 201) {
-                        this.toaster.error(
-                            "Error!",
-                            "There was an error adding to your library",
-                        );
-                        this.addingToLibrary = false;
-                        this.changeDetectorRef.detectChanges();
-                        return;
-                    } else {
-                        // Do nothing if status is 201.
-                    }
                 }
             }
+
+            if (canSaveToLibrary) {
+                await this.refreshLibraryStatus();
+                this.saved = this.saved || savedByThisAction;
+            }
+        } catch (err: any) {
+            if (err.status === 409) {
+                this.saved = true;
+                await this.refreshLibraryStatus();
+            } else {
+                this.toaster.error(
+                    "Error!",
+                    "There was an error adding to your library",
+                );
+            }
+        } finally {
+            this.addToLibraryPending = false;
+            this.addingToLibrary = false;
+            this.changeDetectorRef.detectChanges();
         }
 
-        this.libraryService.getLibrary({
+        if (download) {
+            this.download(this.learningObject.id);
+        }
+    }
+
+    private async refreshLibraryStatus(): Promise<void> {
+        await this.libraryService.getLibrary({
             learningObjectCuid: this.learningObject.cuid,
+            version: this.learningObject.version,
         });
-        this.addingToLibrary = false;
-        this.changeDetectorRef.detectChanges();
+        this.saved = this.isSavedToLibrary();
+    }
+
+    private isSavedToLibrary(): boolean {
+        return (
+            this.saved ||
+            this.libraryService.has(
+                this.learningObject.id,
+                this.learningObject.cuid,
+                this.learningObject.version,
+            )
+        );
     }
 
     /**

--- a/src/app/cube/details/components/action-panel/action-panel.component.ts
+++ b/src/app/cube/details/components/action-panel/action-panel.component.ts
@@ -179,6 +179,7 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
         }
 
         let savedByThisAction = false;
+        let addError: any;
         try {
             if (shouldAddToLibrary) {
                 const result = await this.libraryService.addToLibrary(
@@ -198,27 +199,44 @@ export class ActionPanelComponent implements OnInit, OnDestroy {
             }
 
             if (canSaveToLibrary) {
-                await this.refreshLibraryStatus();
+                await this.tryRefreshLibraryStatus();
                 this.saved = this.saved || savedByThisAction;
             }
         } catch (err: any) {
-            if (err.status === 409) {
-                this.saved = true;
-                await this.refreshLibraryStatus();
-            } else {
-                this.toaster.error(
-                    "Error!",
-                    "There was an error adding to your library",
-                );
-            }
+            addError = err;
         } finally {
             this.addToLibraryPending = false;
             this.addingToLibrary = false;
             this.changeDetectorRef.detectChanges();
         }
 
+        if (addError) {
+            if (addError.status === 409) {
+                this.saved = true;
+            }
+
+            await this.tryRefreshLibraryStatus();
+
+            if (!this.saved) {
+                this.toaster.error(
+                    "Error!",
+                    "There was an error adding to your library",
+                );
+            }
+
+            this.changeDetectorRef.detectChanges();
+        }
+
         if (download) {
             this.download(this.learningObject.id);
+        }
+    }
+
+    private async tryRefreshLibraryStatus(): Promise<void> {
+        try {
+            await this.refreshLibraryStatus();
+        } catch {
+            // A failed refresh should not surface as an add-to-library failure.
         }
     }
 


### PR DESCRIPTION
## Description

This pull request addresses an issue where duplicate "Save to Library" errors or unexpected response statuses (such as a `409 Conflict`) would trigger error toast notifications or block users from seeing a correct saved state.

It introduces helper methods to properly parse duplicate error signatures, leverages a `savedLearningObjectKeys` `Set` to track saved items via their `cuid` and `version`, and updates the action panel UI to handle pending states gracefully and suppress redundant error popups.

## Key Changes

### Library Service (`library.service.ts`)

* **Added `AddToLibraryResult` Interface:** Return typed status and an `alreadySaved` boolean indicator rather than raw data.
* **Unique Tracking:** Introduced `savedLearningObjectKeys` (`Set<string>`) to cache unique composite keys (`cuid:version`) for objects in the library.
* **Error Catching & Parsing:**
* Intercepts errors and maps `409` conflict states to a successful mock response or handles text/body checks via a new `isAlreadySavedError()` helper.
* The `isAlreadySavedError()` method checks the error message and body strings for keywords like `"already"`, `"library"`, `"saved"`, and `"duplicate"`.


* **State Alignment:** Updates the unique keys set during standard retrieval (`getLibrary`) and deletion (`removeFromLibrary`).

### Action Panel Component (`action-panel.component.ts`)

* **Concurrency Guard:** Added a private `addToLibraryPending` flag to prevent duplicate simultaneous clicks/triggers.
* **Optimized Logic Flows:** Streamlined `addToLibrary()` to explicitly evaluate `shouldAddToLibrary` using new visibility and release criteria rules.
* **Toast Suppression:** Wrapped the success toaster so it only alerts the user if the item wasn't *already* flagged as saved (`!result?.alreadySaved`), eliminating redundant toast messages.
* **Safe Status Refreshing:** Added a private `tryRefreshLibraryStatus()` helper wrapped in a try/catch to ensure a failed status refresh doesn't falsely signal an add-to-library failure.

---

## Related Commits

* `6b26e77` - Fixed the error savetolibrary
* `56a9ab5` - Suppress duplicate library save error toast